### PR TITLE
fix: open the sign in RHP for anonymous users in the Home Concierge prompt box

### DIFF
--- a/src/pages/home/ForYouSection/ConciergePromptBox.tsx
+++ b/src/pages/home/ForYouSection/ConciergePromptBox.tsx
@@ -21,6 +21,7 @@ import {isSafari} from '@libs/Browser';
 import {canSkipTriggerHotkeys} from '@libs/ComposerUtils';
 import DateUtils from '@libs/DateUtils';
 import getButtonState from '@libs/getButtonState';
+import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 
 import SubmitDraftButton from '@pages/inbox/report/ReportActionCompose/SubmitDraftButton';
 
@@ -117,8 +118,10 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
         if (!canSubmit) {
             return;
         }
-        askConcierge(value);
-        clearInput();
+        interceptAnonymousUser(() => {
+            askConcierge(value);
+            clearInput();
+        });
     };
 
     const handleKeyPress = (event: TextInputKeyPressEvent) => {
@@ -163,7 +166,7 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
                                                     onPress={(e) => {
                                                         e?.preventDefault();
                                                         actionButtonRef.current?.blur();
-                                                        setIsMenuVisible((prev) => !prev);
+                                                        interceptAnonymousUser(() => setIsMenuVisible((prev) => !prev));
                                                     }}
                                                     style={({hovered, pressed}) => [
                                                         styles.composerSizeButton,

--- a/tests/ui/ConciergePromptBoxTest.tsx
+++ b/tests/ui/ConciergePromptBoxTest.tsx
@@ -11,6 +11,7 @@ import {isSafari} from '@libs/Browser';
 import ConciergePromptBox from '@pages/home/ForYouSection/ConciergePromptBox';
 
 import {close} from '@userActions/Modal';
+import {isAnonymousUser, signOutAndRedirectToSignIn} from '@userActions/Session';
 
 import CONST from '@src/CONST';
 import type {FileObject} from '@src/types/utils/Attachment';
@@ -88,11 +89,18 @@ jest.mock('@userActions/Modal', () => ({
     close: jest.fn(),
 }));
 
+jest.mock('@userActions/Session', () => ({
+    isAnonymousUser: jest.fn(() => false),
+    signOutAndRedirectToSignIn: jest.fn(),
+}));
+
 const mockUseAskConcierge = jest.mocked(useAskConcierge);
 const mockUseResponsiveLayout = jest.mocked(useResponsiveLayout);
 const mockUseKeyboardState = jest.mocked(useKeyboardState);
 const mockIsSafari = jest.mocked(isSafari);
 const mockClose = jest.mocked(close);
+const mockIsAnonymousUser = jest.mocked(isAnonymousUser);
+const mockSignOutAndRedirectToSignIn = jest.mocked(signOutAndRedirectToSignIn);
 
 function ConciergePromptBoxWrapper() {
     const [isMenuVisible, setIsMenuVisible] = useState(false);
@@ -162,6 +170,7 @@ describe('ConciergePromptBox', () => {
         setResponsiveLayout(false);
         setKeyboardShown(false);
         mockIsSafari.mockReturnValue(false);
+        mockIsAnonymousUser.mockReturnValue(false);
     });
 
     describe('sending a message', () => {
@@ -307,6 +316,50 @@ describe('ConciergePromptBox', () => {
             // Then the attachments are sent with the message and the input is emptied
             expect(mockAskConciergeWithAttachment).toHaveBeenCalledWith(files, 'Here it is');
             expect(getInput()).toHaveDisplayValue('');
+        });
+    });
+
+    describe('anonymous user', () => {
+        beforeEach(() => {
+            mockIsAnonymousUser.mockReturnValue(true);
+        });
+
+        it('asks to sign in instead of sending on the send button', () => {
+            // Given an anonymous user with a typed message
+            render(<ConciergePromptBoxWrapper />);
+            fireEvent.changeText(getInput(), 'Where is my expense?');
+
+            // When the send button is pressed
+            fireEvent.press(screen.getByLabelText(SEND_BUTTON));
+
+            // Then nothing is sent and the sign in flow opens
+            expect(mockAskConcierge).not.toHaveBeenCalled();
+            expect(mockSignOutAndRedirectToSignIn).toHaveBeenCalled();
+        });
+
+        it('asks to sign in instead of sending on Enter', () => {
+            // Given an anonymous user with a typed message
+            render(<ConciergePromptBoxWrapper />);
+            fireEvent.changeText(getInput(), 'Where is my expense?');
+
+            // When Enter is pressed
+            pressEnter();
+
+            // Then nothing is sent and the sign in flow opens
+            expect(mockAskConcierge).not.toHaveBeenCalled();
+            expect(mockSignOutAndRedirectToSignIn).toHaveBeenCalled();
+        });
+
+        it('asks to sign in instead of opening the actions menu', () => {
+            // Given an anonymous user
+            render(<ConciergePromptBoxWrapper />);
+
+            // When the "+" button is pressed
+            fireEvent.press(screen.getByLabelText(PLUS_BUTTON));
+
+            // Then the menu stays closed and the sign in flow opens
+            expect(screen.queryByLabelText(ADD_ATTACHMENT)).toBeNull();
+            expect(mockSignOutAndRedirectToSignIn).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The Concierge prompt box on the Home page was fully usable while signed out, so an anonymous user could send a message straight to the Concierge report and open the attachment flow. Both entry points now go through `interceptAnonymousUser`, which is what the rest of the app uses to send an anonymous user to sign in.

**In the app**

- Sending a message from the Home Concierge prompt box (Enter or the send button) as an anonymous user opens the sign in RHP instead of posting the message and failing with "Unexpected error posting the comment".
- The typed message stays in the box while the sign in RHP is open, so nothing is lost.
- Pressing "+" as an anonymous user opens the sign in RHP instead of the "Add attachment" menu, which also blocks the attachment picker and the preview behind it.
- Nothing changes for a signed in user.

**In the code**

- `ConciergePromptBox` wraps the submit handler and the "+" press handler in `interceptAnonymousUser` (`src/libs/interceptAnonymousUser.ts`), the helper already used by the FAB, the floating camera button and the search suggestions.
- The guard sits in the component rather than in `useAskConcierge`, so the attachment path is cut off at the button instead of at the API call.
- `tests/ui/ConciergePromptBoxTest.tsx` covers all three anonymous paths (send button, Enter, "+") with the real `interceptAnonymousUser` over a mocked `@userActions/Session`.

**Out of scope**

- `SearchRouter` calls `askConcierge` without the same guard. It is left alone here to keep the fix scoped to the box reported in the issue. An anonymous user cannot reach that item anyway: `TopBar` hides the search button for them, the search tab button already runs `interceptAnonymousUser`, the Ctrl+K shortcut goes through `callFunctionIfActionIsAllowed`, and the search route is not in `canAnonymousUserAccessRoute`.
- `askConciergeWithAttachment` is guarded through the "+" button rather than at the call itself. That covers every path that exists today: the Composer in this box does not pass `onPasteFile`, and the page wide drop zone on Home is receipt scan only and already anonymous gated.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99492
PROPOSAL: N/A - internal regression fix, follows the maintainer guidance in the issue.


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Sign out of New Expensify.
2. Open the public room https://staging.new.expensify.com/r/4009163200148429 so an anonymous session is created, then go to Home with the tab bar (do not reload the URL, a full load of /home opens the sign in RHP on its own).
3. Type a message in the Concierge prompt box and press Enter, then repeat with the send button. Verify that the sign in RHP opens each time, the message is not sent, the typed text stays in the box and no "Unexpected error posting the comment" appears.
4. Close the sign in RHP and press "+". Verify that the sign in RHP opens and the "Add attachment" menu does not.
5. Sign in with a real account and go to Home. Verify that the prompt box still sends messages to Concierge, and that "+" > "Add attachment" opens the picker and the attachment preview as before.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - the guard is a local check on the session and runs before any request, so there is no new network or Onyx behavior to test offline.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/ae996335-719f-4609-a41d-69e77bbe96e3


</details>


<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/bfbdf58a-99d1-42a3-8c3b-0c59aeff1cf9


</details>



<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/5d7c1444-37af-4b95-9d30-7828c520c3da


</details>

