### PR TITLE
Replace getPersonalDetailByEmail with usePersonalDetailByLogin for share BA and HR

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -46,8 +46,6 @@ import type {TupleToUnion, ValueOf} from 'type-fest';
 
 import {Str} from 'expensify-common';
 
-import type {MemberForList} from './OptionsListUtils';
-
 import {getBankAccountFromID} from './actions/BankAccounts';
 import {hasSynchronizationErrorMessage, isConnectionUnverified} from './actions/connections';
 import {shouldShowQBOReimbursableExportDestinationAccountError} from './actions/connections/QuickbooksOnline';
@@ -58,7 +56,6 @@ import {convertToBackendAmount} from './CurrencyUtils';
 import {getHRAdvancedModeFinalApprover, isAnyHRConnected, isMergeHRCompleteSetupNeeded, shouldShowHRConnectionError} from './HRUtils';
 import Navigation from './Navigation/Navigation';
 import {getIsOffline} from './NetworkState';
-import {formatMemberForList} from './OptionsListUtils';
 import {getAccountIDsByLogins, getKnownAccountIDByLogin, getPersonalDetailByEmail} from './PersonalDetailsUtils';
 import {getAllSortedTransactions, getCategory, getTag, getTagArrayFromName} from './TransactionUtils';
 import {generateAccountID} from './UserUtils';
@@ -437,28 +434,6 @@ function getEligibleBankAccountShareRecipientEmails(policies: OnyxCollection<Pol
     }
 
     return Array.from(recipientEmails);
-}
-
-/** Return members who can receive a shared bank account from the current user. */
-function getEligibleBankAccountShareRecipients(policies: OnyxCollection<Policy> | null, currentUserLogin: string | undefined, bankAccountID: string | undefined): MemberForList[] {
-    return getEligibleBankAccountShareRecipientEmails(policies, currentUserLogin, bankAccountID).flatMap((email) => {
-        const personalDetails = getPersonalDetailByEmail(email);
-        if (!personalDetails) {
-            return [];
-        }
-
-        return [
-            formatMemberForList({
-                text: personalDetails.displayName,
-                alternateText: personalDetails.login,
-                keyForList: personalDetails.login ?? String(personalDetails.accountID),
-                accountID: personalDetails.accountID,
-                login: personalDetails.login,
-                pendingAction: personalDetails.pendingAction,
-                reportID: '',
-            }),
-        ];
-    });
 }
 
 /** Return whether the current user has someone they can share a bank account with. */
@@ -3216,7 +3191,7 @@ export {
     getNetSuiteVendorOptions,
     canUseTaxNetSuite,
     canUseProvincialTaxNetSuite,
-    getEligibleBankAccountShareRecipients,
+    getEligibleBankAccountShareRecipientEmails,
     getFilteredReimbursableAccountOptions,
     getNetSuiteReimbursableAccountOptions,
     getFilteredCollectionAccountOptions,

--- a/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
+++ b/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
@@ -15,11 +15,12 @@ import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import {usePersonalDetailsByLogins} from '@hooks/usePersonalDetailByLogin';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {getHeaderMessage, getSearchValueForPhoneOrEmail} from '@libs/OptionsListUtils';
+import {formatMemberForList, getHeaderMessage, getSearchValueForPhoneOrEmail} from '@libs/OptionsListUtils';
 import type {MemberForList} from '@libs/OptionsListUtils';
-import {getEligibleBankAccountShareRecipients} from '@libs/PolicyUtils';
+import {getEligibleBankAccountShareRecipientEmails} from '@libs/PolicyUtils';
 import tokenizedSearch from '@libs/tokenizedSearch';
 
 import Navigation from '@navigation/Navigation';
@@ -58,7 +59,27 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
 
     const [searchTerm, debouncedSearchTerm, setSearchTerm] = useDebouncedState('');
     const {translate} = useLocalize();
-    const admins = getEligibleBankAccountShareRecipients(allPolicies, currentUserLogin, bankAccountID);
+    const adminEmails = getEligibleBankAccountShareRecipientEmails(allPolicies, currentUserLogin, bankAccountID);
+    const admins = usePersonalDetailsByLogins(adminEmails, (personalDetailsByLogin) =>
+        adminEmails.flatMap((email) => {
+            const personalDetails = personalDetailsByLogin[email];
+            if (!personalDetails) {
+                return [];
+            }
+
+            return [
+                formatMemberForList({
+                    text: personalDetails.displayName,
+                    alternateText: personalDetails.login,
+                    keyForList: personalDetails.login ?? String(personalDetails.accountID),
+                    accountID: personalDetails.accountID,
+                    login: personalDetails.login,
+                    pendingAction: personalDetails.pendingAction,
+                    reportID: '',
+                }),
+            ];
+        }),
+    );
     const shouldShowTextInput = admins && admins?.length >= CONST.STANDARD_LIST_ITEM_LIMIT;
     const textInputLabel = shouldShowTextInput ? translate('common.search') : undefined;
     const debouncedSearchValue = debouncedSearchTerm.trim().toLowerCase();

--- a/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
+++ b/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
@@ -60,26 +60,24 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
     const [searchTerm, debouncedSearchTerm, setSearchTerm] = useDebouncedState('');
     const {translate} = useLocalize();
     const adminEmails = getEligibleBankAccountShareRecipientEmails(allPolicies, currentUserLogin, bankAccountID);
-    const admins = usePersonalDetailsByLogins(adminEmails, (personalDetailsByLogin) =>
-        adminEmails.flatMap((email) => {
-            const personalDetails = personalDetailsByLogin[email];
-            if (!personalDetails) {
-                return [];
-            }
-
-            return [
-                formatMemberForList({
-                    text: personalDetails.displayName,
-                    alternateText: personalDetails.login,
-                    keyForList: personalDetails.login ?? String(personalDetails.accountID),
-                    accountID: personalDetails.accountID,
-                    login: personalDetails.login,
-                    pendingAction: personalDetails.pendingAction,
-                    reportID: '',
-                }),
-            ];
-        }),
-    );
+    const adminPersonalDetails = usePersonalDetailsByLogins(adminEmails);
+    const admins = adminEmails.flatMap((email) => {
+        const personalDetails = adminPersonalDetails[email];
+        if (!personalDetails) {
+            return [];
+        }
+        return [
+            formatMemberForList({
+                text: personalDetails.displayName,
+                alternateText: personalDetails.login,
+                keyForList: personalDetails.login ?? String(personalDetails.accountID),
+                accountID: personalDetails.accountID,
+                login: personalDetails.login,
+                pendingAction: personalDetails.pendingAction,
+                reportID: '',
+            }),
+        ];
+    });
     const shouldShowTextInput = admins && admins?.length >= CONST.STANDARD_LIST_ITEM_LIMIT;
     const textInputLabel = shouldShowTextInput ? translate('common.search') : undefined;
     const debouncedSearchValue = debouncedSearchTerm.trim().toLowerCase();

--- a/src/pages/settings/Wallet/UnshareBankAccount/UnshareBankAccount.tsx
+++ b/src/pages/settings/Wallet/UnshareBankAccount/UnshareBankAccount.tsx
@@ -50,28 +50,27 @@ function UnshareBankAccount({route}: ShareBankAccountProps) {
     const admins = bankAccountList?.[bankAccountID]?.accountData?.sharees;
     const totalAdmins = bankAccountList?.[bankAccountID]?.accountData?.sharees?.length;
     const adminEmails = admins?.filter((admin) => admin !== currentUserPersonalDetails?.email) ?? [];
-    const adminsList = usePersonalDetailsByLogins(adminEmails, (personalDetailsByLogin) => {
-        const adminsWithInfo = adminEmails.map((admin) => {
-            const personalDetails = personalDetailsByLogin[admin];
-            const formattedAdmin = formatMemberForList({
-                text: personalDetails?.displayName,
-                alternateText: personalDetails?.login,
-                keyForList: personalDetails?.login ?? '',
-                accountID: personalDetails?.accountID,
-                login: personalDetails?.login,
-                pendingAction: personalDetails?.pendingAction,
-                reportID: '',
-            });
-            return {...formattedAdmin, isInteractive: false};
+    const adminPersonalDetails = usePersonalDetailsByLogins(adminEmails);
+    const adminsWithInfo = adminEmails.map((admin) => {
+        const personalDetails = adminPersonalDetails[admin];
+        const formattedAdmin = formatMemberForList({
+            text: personalDetails?.displayName,
+            alternateText: personalDetails?.login,
+            keyForList: personalDetails?.login ?? '',
+            accountID: personalDetails?.accountID,
+            login: personalDetails?.login,
+            pendingAction: personalDetails?.pendingAction,
+            reportID: '',
         });
-
-        let adminsToDisplay = [...adminsWithInfo];
-        if (debouncedSearchTerm) {
-            const searchValue = getSearchValueForPhoneOrEmail(debouncedSearchTerm, countryCode).toLowerCase();
-            adminsToDisplay = tokenizedSearch(adminsWithInfo, searchValue, (option) => [option.text ?? '', option.alternateText ?? '']);
-        }
-        return adminsToDisplay;
+        return {...formattedAdmin, isInteractive: false};
     });
+
+    let adminsList = adminsWithInfo;
+    if (debouncedSearchTerm) {
+        const searchValue = getSearchValueForPhoneOrEmail(debouncedSearchTerm, countryCode).toLowerCase();
+        adminsList = tokenizedSearch(adminsWithInfo, searchValue, (option) => [option.text ?? '', option.alternateText ?? '']);
+    }
+
     const error = getLatestErrorMessage(bankAccountList?.[bankAccountID] ?? {});
     const isExpensifyCardError = error?.includes(CONST.EXPENSIFY_CARD.BANK);
     const isExpensifyCardSettlementAccount = bankAccountList?.[bankAccountID]?.isExpensifyCardSettlementAccount ?? false;

--- a/src/pages/settings/Wallet/UnshareBankAccount/UnshareBankAccount.tsx
+++ b/src/pages/settings/Wallet/UnshareBankAccount/UnshareBankAccount.tsx
@@ -13,11 +13,11 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useDebouncedState from '@hooks/useDebouncedState';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
+import {usePersonalDetailsByLogins} from '@hooks/usePersonalDetailByLogin';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {getLatestErrorMessage} from '@libs/ErrorUtils';
 import {formatMemberForList, getHeaderMessage, getSearchValueForPhoneOrEmail} from '@libs/OptionsListUtils';
-import {getPersonalDetailByEmail} from '@libs/PersonalDetailsUtils';
 import tokenizedSearch from '@libs/tokenizedSearch';
 
 import Navigation from '@navigation/Navigation';
@@ -49,6 +49,29 @@ function UnshareBankAccount({route}: ShareBankAccountProps) {
     const {translate} = useLocalize();
     const admins = bankAccountList?.[bankAccountID]?.accountData?.sharees;
     const totalAdmins = bankAccountList?.[bankAccountID]?.accountData?.sharees?.length;
+    const adminEmails = admins?.filter((admin) => admin !== currentUserPersonalDetails?.email) ?? [];
+    const adminsList = usePersonalDetailsByLogins(adminEmails, (personalDetailsByLogin) => {
+        const adminsWithInfo = adminEmails.map((admin) => {
+            const personalDetails = personalDetailsByLogin[admin];
+            const formattedAdmin = formatMemberForList({
+                text: personalDetails?.displayName,
+                alternateText: personalDetails?.login,
+                keyForList: personalDetails?.login ?? '',
+                accountID: personalDetails?.accountID,
+                login: personalDetails?.login,
+                pendingAction: personalDetails?.pendingAction,
+                reportID: '',
+            });
+            return {...formattedAdmin, isInteractive: false};
+        });
+
+        let adminsToDisplay = [...adminsWithInfo];
+        if (debouncedSearchTerm) {
+            const searchValue = getSearchValueForPhoneOrEmail(debouncedSearchTerm, countryCode).toLowerCase();
+            adminsToDisplay = tokenizedSearch(adminsWithInfo, searchValue, (option) => [option.text ?? '', option.alternateText ?? '']);
+        }
+        return adminsToDisplay;
+    });
     const error = getLatestErrorMessage(bankAccountList?.[bankAccountID] ?? {});
     const isExpensifyCardError = error?.includes(CONST.EXPENSIFY_CARD.BANK);
     const isExpensifyCardSettlementAccount = bankAccountList?.[bankAccountID]?.isExpensifyCardSettlementAccount ?? false;
@@ -89,35 +112,6 @@ function UnshareBankAccount({route}: ShareBankAccountProps) {
         setUnshareUser(undefined);
     };
 
-    const getAdminsList = () => {
-        if (admins?.length === 0) {
-            return [];
-        }
-        const adminsWithInfo =
-            admins
-                ?.filter((admin) => admin !== currentUserPersonalDetails?.email)
-                .map((admin) => {
-                    const personalDetails = getPersonalDetailByEmail(admin);
-                    const formattedAdmin = formatMemberForList({
-                        text: personalDetails?.displayName,
-                        alternateText: personalDetails?.login,
-                        keyForList: personalDetails?.login ?? '',
-                        accountID: personalDetails?.accountID,
-                        login: personalDetails?.login,
-                        pendingAction: personalDetails?.pendingAction,
-                        reportID: '',
-                    });
-                    return {...formattedAdmin, isInteractive: false};
-                }) ?? [];
-
-        let adminsToDisplay = [...adminsWithInfo];
-        if (debouncedSearchTerm) {
-            const searchValue = getSearchValueForPhoneOrEmail(debouncedSearchTerm, countryCode).toLowerCase();
-            adminsToDisplay = tokenizedSearch(adminsWithInfo, searchValue, (option) => [option.text ?? '', option.alternateText ?? '']);
-        }
-        return adminsToDisplay;
-    };
-
     const hideUnshareErrorModal = () => {
         clearUnshareBankAccountErrors(Number(bankAccountID));
         setShowExpensifyCardErrorModal(false);
@@ -142,8 +136,6 @@ function UnshareBankAccount({route}: ShareBankAccountProps) {
     };
 
     const onButtonPress = () => Navigation.goBack(ROUTES.SETTINGS_WALLET);
-
-    const adminsList = getAdminsList();
 
     const getHeaderSearchMessage = () => {
         const searchValue = debouncedSearchTerm.trim().toLowerCase();

--- a/src/pages/workspace/hr/WorkspaceHRPage.tsx
+++ b/src/pages/workspace/hr/WorkspaceHRPage.tsx
@@ -13,6 +13,7 @@ import useLocalize from '@hooks/useLocalize';
 import useMergeHRInitialSyncingModal from '@hooks/useMergeHRInitialSyncingModal';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import {usePersonalDetailsByLogins} from '@hooks/usePersonalDetailByLogin';
 import usePolicy from '@hooks/usePolicy';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -57,6 +58,7 @@ function WorkspaceHRPage({
     const StyleUtils = useStyleUtils();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const policy = usePolicy(policyID);
+    const policyEmployeePersonalDetails = usePersonalDetailsByLogins([...Object.keys(policy?.employeeList ?? {})]);
     const [connectionSyncProgress] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policyID}`);
     const icons = useMemoizedLazyExpensifyIcons(['GustoSquare', 'TriNetSquare']);
     const [activeHRFlow, setActiveHRFlow] = useState<{setupLink: string; key: number} | undefined>();
@@ -75,6 +77,7 @@ function WorkspaceHRPage({
 
     const cards = getHRCards({
         policy,
+        policyEmployeePersonalDetails,
         connectionSyncProgress,
         getLocalDateFromDatetime,
         translate,

--- a/src/pages/workspace/hr/utils.ts
+++ b/src/pages/workspace/hr/utils.ts
@@ -1,4 +1,5 @@
 import type {LocaleContextProps} from '@components/LocaleContextProvider';
+import type {PersonalDetailsByLogin} from '@components/PersonalDetailsByLoginProvider';
 
 import {hasSynchronizationErrorMessage, isConnectionInProgress} from '@libs/actions/connections';
 import getGustoSetupLink from '@libs/actions/connections/Gusto';
@@ -8,7 +9,7 @@ import getZenefitsSetupLink from '@libs/actions/connections/Zenefits';
 import {getConnectedHRProvider, getHRApprovalMode, isMergeHRCompleteSetupNeeded} from '@libs/HRUtils';
 import type {HRConnectionName} from '@libs/HRUtils';
 import {formatList} from '@libs/Localize';
-import {getPersonalDetailByEmail, temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
+import {temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
 import {getIntegrationLastSuccessfulDate} from '@libs/PolicyUtils';
 
 import CONST from '@src/CONST';
@@ -203,6 +204,7 @@ function getMergeHRGroupsLabel(policy: OnyxEntry<Policy>): string | undefined {
 /** Resolves the final approver email to a display name via personal details. Returns "Not set" when no approver is configured. */
 function getFinalApproverDisplayName(
     finalApprover: string | undefined | null,
+    policyEmployeePersonalDetails: PersonalDetailsByLogin,
     translate: LocaleContextProps['translate'],
     formatPhoneNumber: LocaleContextProps['formatPhoneNumber'],
 ): string {
@@ -210,7 +212,7 @@ function getFinalApproverDisplayName(
         return translate('workspace.hr.notSet');
     }
     return temporaryGetDisplayNameOrDefault({
-        passedPersonalDetails: getPersonalDetailByEmail(finalApprover),
+        passedPersonalDetails: policyEmployeePersonalDetails[finalApprover],
         defaultValue: finalApprover,
         shouldFallbackToHidden: false,
         translate,
@@ -257,6 +259,9 @@ type GetHRCardsParams = {
     /** The workspace policy used to derive connection state for each HR provider. */
     policy: OnyxEntry<Policy>;
 
+    /** The policy employee's personal details keyed by login */
+    policyEmployeePersonalDetails: PersonalDetailsByLogin;
+
     /** Current sync progress entry from Onyx, shared across all providers. */
     connectionSyncProgress: OnyxEntry<PolicyConnectionSyncProgress>;
 
@@ -280,7 +285,16 @@ type GetHRCardsParams = {
 };
 
 /** Builds the full list of HR provider card descriptors for the workspace HR page, including static providers (Gusto, Zenefits) and dynamic Merge HR sub-providers. */
-function getHRCards({policy, connectionSyncProgress, getLocalDateFromDatetime, translate, formatPhoneNumber, policyID, ...iconParams}: GetHRCardsParams): HRCardDescriptor[] {
+function getHRCards({
+    policy,
+    policyEmployeePersonalDetails,
+    connectionSyncProgress,
+    getLocalDateFromDatetime,
+    translate,
+    formatPhoneNumber,
+    policyID,
+    ...iconParams
+}: GetHRCardsParams): HRCardDescriptor[] {
     const cards: HRCardDescriptor[] = [];
 
     for (const provider of STATIC_HR_PROVIDERS) {
@@ -308,7 +322,7 @@ function getHRCards({policy, connectionSyncProgress, getLocalDateFromDatetime, t
                           {
                               field: 'finalApprover',
                               description: translate('workspace.hr.finalApprover'),
-                              title: getFinalApproverDisplayName(config?.finalApprover, translate, formatPhoneNumber),
+                              title: getFinalApproverDisplayName(config?.finalApprover, policyEmployeePersonalDetails, translate, formatPhoneNumber),
                               route: provider.finalApproverRoute.getRoute(policyID),
                               pendingAction: config?.pendingFields?.finalApprover,
                               errors: config?.errorFields?.finalApprover,
@@ -350,7 +364,7 @@ function getHRCards({policy, connectionSyncProgress, getLocalDateFromDatetime, t
                       {
                           field: 'finalApprover',
                           description: translate('workspace.hr.finalApprover'),
-                          title: getFinalApproverDisplayName(mergeConfig?.finalApprover, translate, formatPhoneNumber),
+                          title: getFinalApproverDisplayName(mergeConfig?.finalApprover, policyEmployeePersonalDetails, translate, formatPhoneNumber),
                           route: ROUTES.WORKSPACE_HR_MERGE_FINAL_APPROVER.getRoute(policyID),
                           pendingAction: mergeConfig?.pendingFields?.finalApprover,
                           errors: mergeConfig?.errorFields?.finalApprover,

--- a/tests/unit/HrUtilsTest.ts
+++ b/tests/unit/HrUtilsTest.ts
@@ -139,6 +139,7 @@ function makeGetHRCardsParams(overrides: Partial<GetHRCardsParams> = {}): GetHRC
         policyID: POLICY_ID,
         gustoIcon: STUB_ICON,
         trinetIcon: STUB_ICON,
+        policyEmployeePersonalDetails: {},
         ...overrides,
     };
 }

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -25,7 +25,7 @@ import {
     getDefaultChatEnabledPolicySelection,
     getDefaultTimeTrackingRate,
     getDefaultWorkspacePlanType,
-    getEligibleBankAccountShareRecipients,
+    getEligibleBankAccountShareRecipientEmails,
     getExcludedUsers,
     getExpensifyTeamExclusions,
     getManagerAccountID,
@@ -2047,7 +2047,7 @@ describe('PolicyUtils', () => {
         });
     });
 
-    describe('getEligibleBankAccountShareRecipients', () => {
+    describe('getEligibleBankAccountShareRecipientEmails', () => {
         beforeEach(() => {
             wrapOnyxWithWaitForBatchedUpdates(Onyx);
             Onyx.set(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
@@ -2070,7 +2070,7 @@ describe('PolicyUtils', () => {
                 '1': {...createRandomPolicy(1, CONST.POLICY.TYPE.TEAM), pendingAction: undefined},
                 '2': {...createRandomPolicy(2, CONST.POLICY.TYPE.TEAM), pendingAction: undefined},
             };
-            const result = getEligibleBankAccountShareRecipients(policies, approverEmail, bankAccountID);
+            const result = getEligibleBankAccountShareRecipientEmails(policies, approverEmail, bankAccountID);
             expect(result).toHaveLength(0);
         });
         it('should return array with admins from the bank account workspace', async () => {
@@ -2096,7 +2096,7 @@ describe('PolicyUtils', () => {
                 },
                 '2': {...createRandomPolicy(2, CONST.POLICY.TYPE.TEAM), pendingAction: undefined},
             };
-            const result = getEligibleBankAccountShareRecipients(policies, approverEmail, bankAccountID);
+            const result = getEligibleBankAccountShareRecipientEmails(policies, approverEmail, bankAccountID);
             expect(result).toHaveLength(1);
         });
         it('should not return user with already shared bank account', async () => {
@@ -2123,7 +2123,7 @@ describe('PolicyUtils', () => {
                 },
                 '2': {...createRandomPolicy(2, CONST.POLICY.TYPE.TEAM), pendingAction: undefined},
             };
-            const result = getEligibleBankAccountShareRecipients(policies, approverEmail, bankAccountID);
+            const result = getEligibleBankAccountShareRecipientEmails(policies, approverEmail, bankAccountID);
             expect(result).toHaveLength(0);
         });
         it('should not return current user for sharing account', async () => {
@@ -2148,7 +2148,7 @@ describe('PolicyUtils', () => {
                     },
                 },
             };
-            const result = getEligibleBankAccountShareRecipients(policies, adminEmail, bankAccountID);
+            const result = getEligibleBankAccountShareRecipientEmails(policies, adminEmail, bankAccountID);
             expect(result).toHaveLength(1);
         });
         it('should allow Payments Admins to share with and receive from members who can manage payments', () => {
@@ -2164,10 +2164,10 @@ describe('PolicyUtils', () => {
                 },
             };
 
-            const result = getEligibleBankAccountShareRecipients(policies, adminEmail, '1');
+            const result = getEligibleBankAccountShareRecipientEmails(policies, adminEmail, '1');
 
             expect(result).toHaveLength(1);
-            expect(result.at(0)?.login).toBe(approverEmail);
+            expect(result.at(0)).toBe(approverEmail);
         });
         it('should not return members who cannot manage payments', () => {
             const policies = {
@@ -2182,7 +2182,7 @@ describe('PolicyUtils', () => {
                 },
             };
 
-            const result = getEligibleBankAccountShareRecipients(policies, adminEmail, '1');
+            const result = getEligibleBankAccountShareRecipientEmails(policies, adminEmail, '1');
 
             expect(result).toHaveLength(0);
         });
@@ -2199,7 +2199,7 @@ describe('PolicyUtils', () => {
                 },
             };
 
-            const recipients = getEligibleBankAccountShareRecipients(policies, adminEmail, '1');
+            const recipients = getEligibleBankAccountShareRecipientEmails(policies, adminEmail, '1');
             const hasEligibleRecipient = hasEligibleBankAccountShareRecipient(policies, adminEmail, '1');
 
             expect(recipients).toHaveLength(0);
@@ -2217,7 +2217,7 @@ describe('PolicyUtils', () => {
                     },
                 },
             };
-            const result = getEligibleBankAccountShareRecipients(policies, adminEmail, '1');
+            const result = getEligibleBankAccountShareRecipientEmails(policies, adminEmail, '1');
             expect(result).toHaveLength(0);
         });
         it('should return Expensify guide when policy owner is Expensify team', () => {
@@ -2232,7 +2232,7 @@ describe('PolicyUtils', () => {
                     },
                 },
             };
-            const result = getEligibleBankAccountShareRecipients(policies, adminEmail, '1');
+            const result = getEligibleBankAccountShareRecipientEmails(policies, adminEmail, '1');
             expect(result).toHaveLength(1);
         });
         it('should return Expensify guide when current user is Expensify team', () => {
@@ -2247,7 +2247,7 @@ describe('PolicyUtils', () => {
                     },
                 },
             };
-            const result = getEligibleBankAccountShareRecipients(policies, 'someone@expensify.com', '1');
+            const result = getEligibleBankAccountShareRecipientEmails(policies, 'someone@expensify.com', '1');
             expect(result).toHaveLength(1);
         });
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/66391
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA Steps
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as QA Steps
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Prerequisite: workspace with HR feature enabled
1. Connect to an HR provider and set a final approver
2. Verify the final approver field shows the selected user display name correctly

we can mock the data by running this command in the console:
```
Onyx.merge('policy_[put_your_policyID_here]', { isHREnabled: true, connections: { merge_hris: { config: { approvalMode: 'custom', finalApprover: '[put_any_ws_member_email_here]', integration: 'bamboohr' }, }, }, }); 
```

Prerequisite: workspace with BA connected and other ws admins other than yourself
1. Go to Account > Wallet
2. On the business bank accounts, press the three-dot button on the BBA
3. Select Share
4. Verify it shows the admins list details correctly

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1195" height="959" alt="Screenshot 2026-08-26 at 14 59 10" src="https://github.com/user-attachments/assets/7405f87c-5363-456a-9187-60708ccf0850" />
<img width="1192" height="969" alt="Screenshot 2026-08-26 at 15 12 43" src="https://github.com/user-attachments/assets/3e07cac2-ee48-4234-89be-c59a17e43306" />

</details>
