### PR TITLE
Home-Unable to paste image in home search box

### DIFF
--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -131,6 +131,9 @@ jest.mock('react-native-share', () => ({
 jest.mock('react-native-reanimated', () => ({
     ...jest.requireActual<typeof Animated>('react-native-reanimated/mock'),
     createAnimatedPropAdapter: jest.fn,
+    // react-native-reanimated/mock leaves dispatchCommand out (see its own "ADD ME IF NEEDED" comment). forceClearInput
+    // (src/libs/ComponentUtils) dispatches it from a UI-thread worklet, so any test exercising that path needs it mocked.
+    dispatchCommand: jest.fn(),
     useReducedMotion: jest.fn,
     useScrollViewOffset: jest.fn(() => 0),
     useAnimatedRef: jest.fn(() => jest.fn()),

--- a/src/pages/home/ForYouSection/ConciergePromptBox.tsx
+++ b/src/pages/home/ForYouSection/ConciergePromptBox.tsx
@@ -82,8 +82,12 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
     const actionButtonRef = useRef<View | HTMLDivElement | null>(null);
     const animatedRef = useAnimatedRef<NativeMethods>();
 
+    // The native Composer only forwards its underlying input to a callback ref, so an object ref would never be populated.
+    const composerRef = useRef<ComposerRef | null>(null);
+
     const setComposerRef = (element: ComposerRef) => {
         animatedRef(element);
+        composerRef.current = element;
     };
 
     const clearInput = () => {
@@ -93,8 +97,10 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
     };
 
     const sendAttachment = (attachments: FileObject | FileObject[]) => {
-        askConciergeWithAttachment(attachments, value);
-        clearInput();
+        interceptAnonymousUser(() => {
+            askConciergeWithAttachment(attachments, value);
+            clearInput();
+        });
     };
     const {pickAttachments, PDFValidationComponent} = useConciergeAttachmentPicker(conciergeTargetReportID, sendAttachment);
 
@@ -239,6 +245,18 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
                         onKeyPress={handleKeyPress}
+                        onPasteFile={(files) => {
+                            // Concierge isn't reachable yet, so there is nowhere to send the paste. Mirrors the disabled "+" button.
+                            if (!shouldShowAskConcierge) {
+                                return;
+                            }
+
+                            interceptAnonymousUser(() => {
+                                // Blur before the attachment preview modal takes over, so the keyboard doesn't stay up over it.
+                                composerRef.current?.blur();
+                                pickAttachments(files);
+                            });
+                        }}
                         maxLines={MAX_INPUT_LINES}
                         multiline
                         textAlignVertical="top"

--- a/src/pages/home/ForYouSection/useConciergeAttachmentPicker.ts
+++ b/src/pages/home/ForYouSection/useConciergeAttachmentPicker.ts
@@ -39,8 +39,9 @@ function useConciergeAttachmentPicker(reportID: string | undefined, onConfirm: (
 
     const {validateFiles, PDFValidationComponent} = useFilesValidation(onFilesValidated);
 
-    const pickAttachments = (files: FileObject[]) => {
-        const fileObjects = files.map((item) => cleanFileObjectName(cleanFileObject(item)));
+    // A pasted file arrives as a single FileObject on native and for base64/Google Workspace images on web, so both shapes are accepted.
+    const pickAttachments = (files: FileObject | FileObject[]) => {
+        const fileObjects = (Array.isArray(files) ? files : [files]).map((item) => cleanFileObjectName(cleanFileObject(item)));
         if (!fileObjects.length) {
             return;
         }

--- a/tests/ui/ConciergePromptBoxTest.tsx
+++ b/tests/ui/ConciergePromptBoxTest.tsx
@@ -1,4 +1,4 @@
-import {act, fireEvent, render, screen} from '@testing-library/react-native';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react-native';
 
 import useAskConcierge from '@components/Search/SearchRouter/useAskConcierge';
 
@@ -17,6 +17,8 @@ import CONST from '@src/CONST';
 import type {FileObject} from '@src/types/utils/Attachment';
 
 import React, {useState} from 'react';
+
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 
 const CONCIERGE_REPORT_ID = '100';
 const LONG_PLACEHOLDER = 'homePage.conciergePrompt.inputPlaceholder';
@@ -84,6 +86,8 @@ jest.mock('@libs/Browser', () => ({
     ...jest.requireActual<typeof BrowserModule>('@libs/Browser'),
     isSafari: jest.fn(() => false),
 }));
+
+jest.mock('@pages/Share/getFileSize', () => jest.fn(() => Promise.resolve(100)));
 
 jest.mock('@userActions/Modal', () => ({
     close: jest.fn(),
@@ -156,6 +160,10 @@ function pressEnter(options?: {shiftKey?: boolean}) {
         preventDefault: jest.fn(),
         nativeEvent: {key: CONST.KEYBOARD_SHORTCUTS.ENTER.shortcutKey, shiftKey: options?.shiftKey ?? false},
     });
+}
+
+function pasteImage() {
+    fireEvent(getInput(), 'paste', {nativeEvent: {items: [{type: 'image/png', data: 'file:///image.png'}]}});
 }
 
 function measureLongPlaceholder(height: number) {
@@ -317,6 +325,32 @@ describe('ConciergePromptBox', () => {
             expect(mockAskConciergeWithAttachment).toHaveBeenCalledWith(files, 'Here it is');
             expect(getInput()).toHaveDisplayValue('');
         });
+
+        it('starts the attachment flow for a pasted image', async () => {
+            // Given the prompt box
+            render(<ConciergePromptBoxWrapper />);
+
+            // When an image is pasted into the input
+            pasteImage();
+
+            // Then the pasted file goes through the same validation and preview flow as the picker
+            await waitFor(() => {
+                expect(mockPickAttachments).toHaveBeenCalled();
+            });
+        });
+
+        it('ignores a pasted image until the Concierge report is ready', async () => {
+            // Given a prompt box that has nowhere to send the attachment yet
+            setAskConcierge(false);
+            render(<ConciergePromptBoxWrapper />);
+
+            // When an image is pasted into the input
+            pasteImage();
+            await waitForBatchedUpdatesWithAct();
+
+            // Then the attachment flow is not started
+            expect(mockPickAttachments).not.toHaveBeenCalled();
+        });
     });
 
     describe('anonymous user', () => {
@@ -359,6 +393,32 @@ describe('ConciergePromptBox', () => {
 
             // Then the menu stays closed and the sign in flow opens
             expect(screen.queryByLabelText(ADD_ATTACHMENT)).toBeNull();
+            expect(mockSignOutAndRedirectToSignIn).toHaveBeenCalled();
+        });
+
+        it('asks to sign in instead of starting the attachment flow for a pasted image', async () => {
+            // Given an anonymous user
+            render(<ConciergePromptBoxWrapper />);
+
+            // When an image is pasted into the input
+            pasteImage();
+            await waitForBatchedUpdatesWithAct();
+
+            // Then the attachment flow is not started and the sign in flow opens
+            expect(mockPickAttachments).not.toHaveBeenCalled();
+            expect(mockSignOutAndRedirectToSignIn).toHaveBeenCalled();
+        });
+
+        it('asks to sign in instead of sending a confirmed attachment', () => {
+            // Given an anonymous user with attachments confirmed in the preview modal
+            const files: FileObject[] = [{name: 'receipt.jpg', type: 'image/jpeg', uri: 'file://receipt.jpg'}];
+            render(<ConciergePromptBoxWrapper />);
+
+            // When the modal confirms
+            act(() => pickerHandler.onConfirm?.(files));
+
+            // Then nothing is sent and the sign in flow opens
+            expect(mockAskConciergeWithAttachment).not.toHaveBeenCalled();
             expect(mockSignOutAndRedirectToSignIn).toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The Home Concierge prompt box reuses the shared `Composer` but never passed `onPasteFile`, so a pasted image was silently dropped (on web the paste was even `preventDefault`ed first). `ConciergePromptBox` now passes `onPasteFile`, routing pasted files into the existing validation + preview + send flow used by the "+" button, and `useConciergeAttachmentPicker` accepts the single-file shape that paste emits.

This also fixes a rebase-only gap in `jest/setup.ts`: `main` recently added `clearInput` -> `forceClearInput` (`src/libs/ComponentUtils`), which dispatches a UI-thread worklet via `dispatchCommand`. `react-native-reanimated/mock` doesn't export `dispatchCommand` (it has its own `// dispatchCommand: ADD ME IF NEEDED` comment), and that worklet runs on a real `setTimeout(0)` that isn't tied to the test that queued it - it can fire during a *later* test's `await`/`waitFor`, wherever that lands. Our new async paste test happened to be the first thing in this suite to await anything after a message send, so it's what surfaced the crash, but the gap belongs to `main`'s change, not to this test. Added `dispatchCommand: jest.fn()` to the global reanimated mock so any test in the app touching a cleared composer is covered, not just this file.

The app behaviour after being fixed:

https://github.com/user-attachments/assets/ec2b7318-6ef8-4a7e-a199-953d2e2d4578


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99554
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Copy an image to the clipboard (e.g. take a screenshot).
2. Sign in and stay on the Home page.
3. Click the Concierge prompt box under the greeting to focus it.
4. Paste with Ctrl/Cmd+V (on Android: long-press the input and choose Paste).
5. Verify that the attachment preview modal opens with the pasted image, and that on Android the keyboard is dismissed.
6. Press Send in the modal.
7. Verify that the image is posted to the Concierge chat.

8. Back on Home, type `Here is my receipt` into the prompt box.
9. Paste the image again and press Send in the preview modal.
10. Verify that the image is posted to Concierge together with the typed message, and that the prompt box is left empty.

11. Copy plain text to the clipboard, focus the Home prompt box and paste.
12. Verify that the text is inserted into the input and no attachment preview modal opens.

13. Copy an image to the clipboard, focus the search input at the top of Home and paste there.
14. Verify that no attachment preview modal opens - the Concierge prompt box must not capture pastes aimed at another input.

15. Copy an image out of Google Docs/Sheets (this uses a different clipboard path), paste it into the Home prompt box.
16. Verify that the attachment preview modal opens with that image.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Turn off the network connection.
2. Paste an image into the Home Concierge prompt box.
3. Verify that the attachment preview modal still opens and Send is available.
4. Press Send.
5. Verify that the attachment appears in the Concierge chat in a pending (greyed out) state.
6. Restore the network connection.
7. Verify that the attachment finishes uploading and loses the pending state, with no duplicate message.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
