### PR TITLE
Fix ♾️ amount and pending rate when moving a track distance expense before the route resolves

### DIFF
--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -281,20 +281,37 @@ function MoneyRequestConfirmationList({
     const subRates = transaction?.comment?.customUnit?.subRates ?? [];
     const prevSubRates = usePrevious(subRates);
 
-    const {defaultRate, mileageRate, unit, rate, currency, prevCurrency, distance, shouldCalculateDistanceAmount, hasRoute, isDistanceRequestWithPendingRoute, distanceRequestAmount} =
-        useDistanceRequestState({
-            transaction,
-            policy,
-            policyID,
-            policyForMovingExpenses,
-            isMovingTransactionFromTrackExpense,
-            isDistanceRequest,
-            iouAmount,
-            iouCurrencyCode,
-        });
+    const {
+        defaultRate,
+        mileageRate,
+        unit,
+        rate,
+        currency,
+        prevCurrency,
+        distance,
+        shouldCalculateDistanceAmount,
+        hasRoute,
+        isDistanceRequestWithPendingRoute,
+        distanceRequestAmount,
+        calculateFromTransactionData,
+    } = useDistanceRequestState({
+        transaction,
+        policy,
+        policyID,
+        policyForMovingExpenses,
+        isMovingTransactionFromTrackExpense,
+        isDistanceRequest,
+        iouAmount,
+        iouCurrencyCode,
+    });
 
     const shouldShowRateAutoUpdatedTooltip =
         isDistanceRequest && !!transaction?.comment?.customUnit?.rateAutoUpdated && !!transaction.created && DistanceRequestUtils.isRateEligibleForDate(mileageRate, transaction.created);
+
+    // While a track expense is being moved to a workspace whose rate hasn't resolved yet, surface the optimistic
+    // back-calculated rate in the Rate row so it shows the effective rate (derived from the same amount/distance data)
+    // instead of "pending". This is display-only — DistanceRequestController keeps validating against `mileageRate`.
+    const rateFieldMileageRate = calculateFromTransactionData && rate ? {...mileageRate, rate} : mileageRate;
 
     const shouldShowCategories = isTrackExpense
         ? !policy || shouldSelectPolicy || !!iouCategory || hasEnabledOptions(Object.values(policyCategories ?? {}))
@@ -573,7 +590,7 @@ function MoneyRequestConfirmationList({
                     unit,
                     distanceRateName: mileageRate.name,
                     distanceRateCurrency: currency,
-                    mileageRate,
+                    mileageRate: rateFieldMileageRate,
                     expenseDate: getCreated(transaction),
                     customUnitRateID,
                     shouldShowRateAutoUpdatedTooltip,

--- a/src/components/MoneyRequestConfirmationList/hooks/useDistanceRequestState.ts
+++ b/src/components/MoneyRequestConfirmationList/hooks/useDistanceRequestState.ts
@@ -87,7 +87,17 @@ function useDistanceRequestState({
     const calculateFromTransactionData = isMovingTransactionFromTrackExpense && !distanceRate;
     const customUnit = transaction?.comment?.customUnit;
     const unit = calculateFromTransactionData ? customUnit?.distanceUnit : distanceUnit;
-    const rate = calculateFromTransactionData ? Math.abs(iouAmount) / (customUnit?.quantity ?? 1) : distanceRate;
+    // When moving a track expense to a workspace whose rate hasn't resolved yet, we back-calculate the rate from the
+    // known amount and distance. The divisor must be a positive distance in the SELECTED unit: `customUnit.quantity`
+    // is already in that unit, while the route distance is in meters and has to be converted first. Dividing by a
+    // still-pending `quantity` of 0 previously yielded `Infinity` (the ♾️ amount); converting raw meters without unit
+    // conversion would instead under-report the amount by the meters→unit factor (~1609x for miles). When neither a
+    // quantity nor a route distance is available, leave the rate unresolved so the amount stays pending.
+    const routeDistanceInUnit = calculateFromTransactionData && !customUnit?.quantity && unit ? DistanceRequestUtils.convertDistanceUnit(getDistanceInMeters(transaction, unit), unit) : 0;
+    // `||` (not `??`) is intentional: a pending `quantity` of 0 must fall through to the converted route distance.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const backCalculationDivisor = customUnit?.quantity || routeDistanceInUnit;
+    const rate = calculateFromTransactionData && backCalculationDivisor ? Math.abs(iouAmount) / backCalculationDivisor : distanceRate;
     const currency = calculateFromTransactionData ? iouCurrencyCode : (mileageRate.currency ?? CONST.CURRENCY.USD);
     const prevRate = usePrevious(rate);
     const prevUnit = usePrevious(unit);

--- a/src/hooks/useParticipantSubmission.ts
+++ b/src/hooks/useParticipantSubmission.ts
@@ -284,6 +284,28 @@ function useParticipantSubmission({
                 // and no transaction is passed here, so the currency is never read.
                 setCustomUnitRateID(initialTransactionID, rateID, undefined, policy, false, undefined);
             }
+        } else if (drafts.length > 0) {
+            // Moving a track expense to a workspace: the tracked draft carries the source workspace's rate ID, which the
+            // destination workspace may not own. Keep genuine p2p/unset rates (so the user can still pick one) and rates
+            // the destination already owns, but re-select the destination's rate otherwise so it resolves — mirroring the
+            // check in IOURequestStepConfirmation. Left unresolved, confirmation shows "Rate not valid" and
+            // useDistanceRequestState divides the amount by a zero quantity, persisting an Infinity (serialized as null) amount.
+            for (const transaction of drafts) {
+                const currentRateID = transaction?.comment?.customUnit?.customUnitRateID;
+                const isCurrentRateFromWorkspace = !!currentRateID && !!DistanceRequestUtils.getMileageRates(policy)[currentRateID];
+                const shouldKeepCurrentRate = DistanceRequestUtils.isUnsetDistanceCustomUnitRateID(currentRateID) || isCurrentRateFromWorkspace;
+                if (shouldKeepCurrentRate) {
+                    continue;
+                }
+                const rateID = DistanceRequestUtils.getCustomUnitRateID({
+                    reportID: firstParticipantReportID,
+                    isPolicyExpenseChat,
+                    policy,
+                    lastSelectedDistanceRates: distanceRates,
+                    expenseDate: transaction.created,
+                });
+                setCustomUnitRateID(transaction.transactionID, rateID, transaction, policy, false, personalPolicy?.outputCurrency);
+            }
         }
 
         // When multiple valid participants are selected, the reportID is generated at the end of the confirmation step.

--- a/tests/unit/hooks/useDistanceRequestStateInfinityRate.test.ts
+++ b/tests/unit/hooks/useDistanceRequestStateInfinityRate.test.ts
@@ -1,0 +1,102 @@
+import {renderHook} from '@testing-library/react-native';
+
+import useDistanceRequestState from '@components/MoneyRequestConfirmationList/hooks/useDistanceRequestState';
+
+import DistanceRequestUtils from '@libs/DistanceRequestUtils';
+
+import type * as OnyxTypes from '@src/types/onyx';
+
+import createMock from '../../utils/createMock';
+
+/**
+ * Repro for https://github.com/Expensify/App/issues/99315
+ *
+ * A distance expense created in the self DM is a Track Expense. Submitting it to a workspace before the map finishes
+ * generating sets `isMovingTransactionFromTrackExpense = true` while the workspace mileage rate is still unresolved,
+ * so `useDistanceRequestState` back-calculates the rate from the known amount and distance:
+ *
+ *     rate = Math.abs(iouAmount) / (customUnit?.quantity ?? 1)
+ *
+ * At this instant the route distance has already resolved (`routes.route0.distance` is a real, non-zero value in
+ * meters), but `customUnit.quantity` is still 0. `?? 1` only substitutes for null/undefined — not 0 — so the divide
+ * is `iouAmount / 0 = Infinity`, and `round(distance * Infinity) = Infinity` renders as the ♾️ amount.
+ *
+ * The reported symbol being ♾️ (not "NaN") is itself the proof that the route distance had resolved: had it not,
+ * `distance` would be 0 and `0 * Infinity = NaN` would render "NaN". So the only correct divisor to recover the
+ * amount during the race is the route distance CONVERTED into the selected unit (mi/km) — dividing by raw meters
+ * under-reports the amount by the meters→unit factor.
+ */
+
+// Only stub the two policy-rate lookups so the workspace rate reads as unresolved (the race window).
+// Everything else — convertDistanceUnit, getDistanceRequestAmount, getDistanceInMeters — uses the real math, so the
+// unit factor in the assertions below is genuine, not a test artifact.
+jest.mock('@libs/DistanceRequestUtils', () => {
+    const actual = jest.requireActual<{default: typeof DistanceRequestUtils}>('@libs/DistanceRequestUtils').default;
+    return {
+        __esModule: true,
+        default: {
+            ...actual,
+            getDefaultMileageRate: () => undefined,
+            // Workspace mileage rate not resolved yet: rate/currency are undefined, unit is known.
+            getRate: () => ({rate: undefined, unit: 'mi', currency: undefined}),
+        },
+    };
+});
+
+type Params = Parameters<typeof useDistanceRequestState>[0];
+
+// 1 mile in meters (matches METERS_TO_MILES so the converted distance is exactly 1 mi).
+const ONE_MILE_IN_METERS = 1609.344;
+// Seeded P2P amount that survives from the self-DM distance expense, in cents ($50.00).
+const SEEDED_AMOUNT = 5000;
+
+function buildRaceParams(): Params {
+    return {
+        // Track expense being moved to a workspace: route distance resolved (meters), quantity still 0 (map pending).
+        transaction: createMock<OnyxTypes.Transaction>({
+            transactionID: 'txn1',
+            comment: {customUnit: {distanceUnit: 'mi', quantity: 0}},
+            routes: {route0: {distance: ONE_MILE_IN_METERS, geometry: {coordinates: [], type: 'LineString'}}},
+        }),
+        policy: undefined,
+        policyID: 'policy1',
+        policyForMovingExpenses: undefined,
+        isMovingTransactionFromTrackExpense: true,
+        isDistanceRequest: true,
+        iouAmount: SEEDED_AMOUNT,
+        iouCurrencyCode: 'USD',
+    };
+}
+
+describe('useDistanceRequestState – issue #99315 (♾️ amount on track-expense move before route resolves)', () => {
+    it('does not render Infinity and keeps the correct amount while the workspace rate is pending', () => {
+        const {result} = renderHook(() => useDistanceRequestState(buildRaceParams()));
+
+        // Before the fix: rate = 5000 / 0 = Infinity -> distanceRequestAmount = Infinity -> ♾️.
+        expect(Number.isFinite(result.current.distanceRequestAmount)).toBe(true);
+
+        // With the divisor guarded and the route distance converted to the selected unit, the amount stays correct
+        // (the seeded $50.00) instead of collapsing — matching the issue's Expected Result ("Amount will show the
+        // correct expense amount"), rather than blanking to 0.
+        expect(result.current.distanceRequestAmount).toBe(SEEDED_AMOUNT);
+    });
+
+    it('proves the divisor must be converted to the selected unit, not raw meters', () => {
+        // The route distance in the selected unit (what the divisor should be).
+        const distanceInUnit = DistanceRequestUtils.convertDistanceUnit(ONE_MILE_IN_METERS, 'mi'); // ≈ 1 mile
+
+        // Correct back-calculation: divide by the distance in the selected unit.
+        const correctRate = SEEDED_AMOUNT / distanceInUnit;
+        const correctAmount = DistanceRequestUtils.getDistanceRequestAmount(ONE_MILE_IN_METERS, 'mi', correctRate);
+        expect(correctAmount).toBe(SEEDED_AMOUNT);
+
+        // Naive back-calculation: divide by the raw route distance in meters (skipping unit conversion).
+        const naiveRate = SEEDED_AMOUNT / ONE_MILE_IN_METERS;
+        const naiveAmount = DistanceRequestUtils.getDistanceRequestAmount(ONE_MILE_IN_METERS, 'mi', naiveRate);
+
+        // The naive amount is under-reported by the meters→miles factor (~1609x): $50.00 becomes ~$0.03.
+        expect(naiveAmount).not.toBe(SEEDED_AMOUNT);
+        expect(naiveAmount).toBeLessThan(10);
+        expect(SEEDED_AMOUNT / Math.max(naiveAmount, 1)).toBeGreaterThan(1000);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

When a distance expense created in the self DM (a Track Expense) is submitted to a workspace **before the route/map finishes generating**, the confirmation page showed the amount as `♾️` and the rate as "pending" (non-editable).

Root cause: moving a track expense sets `isMovingTransactionFromTrackExpense = true`, and while the workspace mileage rate is unresolved the hook back-calculates a temporary rate:

```ts
Math.abs(iouAmount) / (customUnit?.quantity ?? 1);
```

At this instant the route distance has resolved (`routes.route0.distance` is a real non-zero value in meters) but `customUnit.quantity` is still `0`. `?? 1` only substitutes for null/undefined — not `0` — so the divide is `iouAmount / 0 = Infinity`, and `round(distance * Infinity) = Infinity` renders as `♾️`. The rate row separately reads the still-unresolved workspace rate, so it stays "pending".

The deeper cause (credit to mukhrr): a self-DM track distance expense carries the source workspace's rate ID, which the destination workspace may not own, so `getRate` can't resolve it. This PR fixes it in three layers:

- **Rate resolution (root cause)** — `useParticipantSubmission.ts` skipped rate selection for track moves, so the draft reached confirmation on an unresolvable rate. Mirroring the check already in `IOURequestStepConfirmation`, we now re-select the destination workspace's rate unless the draft carries an unset/p2p rate or one the destination already owns. With the rate resolved, `calculateFromTransactionData` stays `false`, the "Rate not valid for this workspace" error clears, and the Rate row shows the real workspace rate.
- **Divisor guard (data integrity)** — the divide-by-zero is not only a display glitch: `DistanceRequestController` persists the `Infinity` via `setMoneyRequestAmount`, and `JSON.stringify(Infinity) === "null"`, so the draft can be submitted with a `null` amount. We only back-calculate against a **positive divisor expressed in the selected unit** (`customUnit.quantity`, else the route distance `convertDistanceUnit(...)`-ed to that unit — dividing by raw meters would under-report by ~1609x). This stops the `Infinity`/`null`-amount at the source no matter why the rate is unresolved.
- **Rate display (optimistic UX)** — while a rate is being resolved, the back-calculated effective rate is surfaced in the Rate row so it shows a real value instead of "pending". Display-only; `DistanceRequestController` keeps validating against the original `mileageRate`.

Everything switches to the workspace values once the rate loads.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99315
PROPOSAL: https://github.com/Expensify/App/issues/99315#issuecomment-5393724680

### Tests

1. Go to a self DM.
2. Create a distance expense.
3. Quickly tap Submit and pick a workspace chat **before** the map on the expense preview finishes generating.
4. Verify the confirmation page opens with the correct amount (no `♾️`, no `0`) and a rate value (not "pending").
5. Verify that once the workspace rate loads, the amount and rate update to the workspace values.

Automated: added a case in `tests/unit/hooks/useDistanceRequestState*` that reproduces the race (`quantity = 0`, resolved route distance, unresolved workspace rate, non-zero amount), asserts the amount is finite and correct, and pins that the divisor must be converted to the selected unit (raw meters under-reports by ~1609x). It fails on `main` and passes with this fix.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same steps offline — the confirmation shows the correct amount and rate from the optimistic data, and stays pending only when neither the quantity nor the route distance is available yet.

### QA Steps

1. Go to a self DM.
2. Create a distance expense.
3. Quickly tap Submit and pick a workspace chat before the map on the expense preview finishes generating.
4. Verify the confirmation page shows the correct amount (no `♾️`, no `0`) and a rate value (not "pending").
5. Verify the amount and rate update to the workspace values once the workspace rate loads.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

**Before**

https://github.com/user-attachments/assets/db9275b3-b112-40f3-accc-e1555992e49a

**After**

https://github.com/user-attachments/assets/3db2a617-4219-476e-af5c-234b24d9fea2

</details>
