### PR TITLE
Fix Spend tab pagination stalling when a page is requested mid-refresh

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -395,6 +395,10 @@ function Search({
 
     const shouldRetrySearchWithTotalsOrGroupedRef = useRef(false);
 
+    // `isLoading` has to stay out of the effect deps below, or every completed search would start another,
+    // so a page requested while one was in flight is remembered here and fired once it resolves.
+    const pendingSearchOffsetRef = useRef<number | undefined>(undefined);
+
     useEffect(() => {
         const focusedRoute = findFocusedRoute(navigationRef.getRootState());
         const isMigratedModalDisplayed = focusedRoute?.name === NAVIGATORS.MIGRATED_USER_MODAL_NAVIGATOR || focusedRoute?.name === SCREENS.MIGRATED_USER_WELCOME_MODAL.DYNAMIC_ROOT;
@@ -419,6 +423,9 @@ function Search({
         if (searchResults?.search?.isLoading) {
             if (validGroupBy || (shouldCalculateTotals && searchResults?.search?.count === undefined)) {
                 shouldRetrySearchWithTotalsOrGroupedRef.current = true;
+            }
+            if (offset > 0) {
+                pendingSearchOffsetRef.current = offset;
             }
             return;
         }
@@ -445,6 +452,7 @@ function Search({
             return;
         }
 
+        pendingSearchOffsetRef.current = undefined;
         handleSearch({
             queryJSON,
             searchKey: currentSearchKey,
@@ -471,6 +479,7 @@ function Search({
         }
 
         shouldRetrySearchWithTotalsOrGroupedRef.current = false;
+        pendingSearchOffsetRef.current = undefined;
         handleSearch({
             queryJSON,
             searchKey: currentSearchKey,
@@ -488,6 +497,35 @@ function Search({
         searchResults?.search?.isLoading,
         shouldCalculateTotals,
         validGroupBy,
+        searchRequestOffset,
+    ]);
+
+    useEffect(() => {
+        if (pendingSearchOffsetRef.current !== offset || searchResults?.search?.isLoading || !searchResults?.search?.hasMoreResults || !isFocused || isOffline || hasErrors) {
+            return;
+        }
+
+        pendingSearchOffsetRef.current = undefined;
+        handleSearch({
+            queryJSON,
+            searchKey: currentSearchKey,
+            offset: searchRequestOffset,
+            shouldCalculateTotals,
+            prevReportsLength: filteredDataLength,
+            isLoading: false,
+        });
+    }, [
+        filteredDataLength,
+        handleSearch,
+        hasErrors,
+        isFocused,
+        isOffline,
+        offset,
+        queryJSON,
+        currentSearchKey,
+        searchResults?.search?.isLoading,
+        searchResults?.search?.hasMoreResults,
+        shouldCalculateTotals,
         searchRequestOffset,
     ]);
 

--- a/tests/ui/SearchPageTest.tsx
+++ b/tests/ui/SearchPageTest.tsx
@@ -27,6 +27,7 @@ import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
+import type SearchResults from '@src/types/onyx/SearchResults';
 
 import type * as CoreNavigation from '@react-navigation/core';
 import type * as reactNavigationNativeImport from '@react-navigation/native';
@@ -71,9 +72,21 @@ jest.mock('@react-navigation/core', () => ({
     useNavigation: jest.fn(() => ({getState: jest.fn(() => undefined), isFocused: jest.fn(() => true)})),
 }));
 
+// FlashList never lays out here, so stand in for it to get at onEndReached.
+const listProps: {onEndReached?: () => void} = {};
+jest.mock('@components/Search/SearchList/BaseSearchList', () => ({
+    __esModule: true,
+    default: (props: {onEndReached?: () => void}) => {
+        listProps.onEndReached = props.onEndReached;
+        return null;
+    },
+}));
+
+const mockIsFocused = jest.fn(() => true);
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual<typeof reactNavigationNativeImport>('@react-navigation/native'),
     useNavigationState: () => {},
+    useIsFocused: () => mockIsFocused(),
 }));
 
 type TestNavigationContainerProps = {initialState: reactNavigationNativeImport.InitialState};
@@ -90,6 +103,70 @@ const mockSearch = jest.mocked(search);
 
 const FAILED_QUERY = 'type:chat category:abcd';
 const failedQueryJSON = SearchQueryUtils.buildSearchQueryJSON(FAILED_QUERY);
+
+const EXPENSE_QUERY = 'type:expense';
+const expenseQueryJSON = SearchQueryUtils.buildSearchQueryJSON(EXPENSE_QUERY);
+
+const SUBMITTER_ACCOUNT_ID = 1;
+
+// A full first page: pagination only starts once the loaded results fill one page.
+function buildExpenseSnapshotData(): SearchResults['data'] {
+    const data: Record<string, unknown> = {
+        personalDetailsList: {[SUBMITTER_ACCOUNT_ID]: {accountID: SUBMITTER_ACCOUNT_ID, avatar: '', displayName: 'Submitter', login: 'submitter@expensify.com'}},
+    };
+
+    for (let index = 1; index <= CONST.SEARCH.RESULTS_PAGE_SIZE; index++) {
+        const id = String(index);
+        data[`report_${id}`] = {
+            accountID: SUBMITTER_ACCOUNT_ID,
+            chatReportID: '9999',
+            currency: 'USD',
+            ownerAccountID: SUBMITTER_ACCOUNT_ID,
+            policyID: 'A1B2C3',
+            reportID: id,
+            reportName: 'Expense Report',
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            total: -5000,
+            type: CONST.REPORT.TYPE.EXPENSE,
+        };
+        data[`transactions_${id}`] = {
+            amount: -5000,
+            category: '',
+            comment: {comment: ''},
+            created: '2024-12-21',
+            currency: 'USD',
+            merchant: 'Coffee',
+            modifiedCreated: '',
+            modifiedCurrency: '',
+            modifiedMerchant: '',
+            reportID: id,
+            tag: '',
+            transactionID: id,
+        };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test-only: the rows only carry the fields the list reads, not the full Transaction/Report shapes
+    return data as SearchResults['data'];
+}
+
+const expenseSnapshotData = buildExpenseSnapshotData();
+
+function getExpenseSnapshot(isLoading: boolean) {
+    return {
+        data: expenseSnapshotData,
+        search: {
+            type: CONST.SEARCH.DATA_TYPES.EXPENSE,
+            offset: 0,
+            hash: expenseQueryJSON?.hash,
+            sortBy: expenseQueryJSON?.sortBy,
+            sortOrder: expenseQueryJSON?.sortOrder,
+            state: CONST.SEARCH.SNAPSHOT_STATE.LOADED,
+            isLoading,
+            hasMoreResults: true,
+        },
+    };
+}
 
 function TestSearchFullscreenNavigator() {
     return (
@@ -177,6 +254,9 @@ describe('SearchPageNarrow', () => {
 
     beforeEach(() => {
         mockUseNetwork.mockReturnValue({isOffline: false} as ReturnType<typeof useNetwork>);
+        mockSearchQueryParam.mockReturnValue(FAILED_QUERY);
+        mockIsFocused.mockReturnValue(true);
+        listProps.onEndReached = undefined;
     });
 
     it('SearchPageNarrow renders correctly', async () => {
@@ -315,5 +395,104 @@ describe('SearchPageNarrow', () => {
         });
 
         expect(renderedPage.UNSAFE_getByType(SearchLoadingSkeleton)).toBeTruthy();
+    });
+    it('loads the next page after a request that was in flight when the list hit its end resolves', async () => {
+        mockSearchQueryParam.mockReturnValue(EXPENSE_QUERY);
+        await act(async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, getExpenseSnapshot(false));
+        });
+
+        renderPage(EXPENSE_QUERY);
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        expect(listProps.onEndReached).toBeDefined();
+
+        // Mount refresh still in flight when the end of the list is reached.
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, {search: {isLoading: true}});
+        });
+        await act(async () => {
+            listProps.onEndReached?.();
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        const wasSearchedAtNextPage = () => mockSearch.mock.calls.some(([params]) => params?.offset === CONST.SEARCH.RESULTS_PAGE_SIZE);
+        expect(wasSearchedAtNextPage()).toBe(false);
+
+        // Refresh lands.
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, {search: {isLoading: false}});
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        expect(wasSearchedAtNextPage()).toBe(true);
+    });
+    it('does not fire a pending page once the screen is no longer focused', async () => {
+        mockSearchQueryParam.mockReturnValue(EXPENSE_QUERY);
+        await act(async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, getExpenseSnapshot(false));
+        });
+
+        renderPage(EXPENSE_QUERY);
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, {search: {isLoading: true}});
+        });
+        await act(async () => {
+            listProps.onEndReached?.();
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        // User navigates away while the refresh is still on the wire.
+        mockIsFocused.mockReturnValue(false);
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, {search: {isLoading: false}});
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        expect(mockSearch.mock.calls.some(([params]) => params?.offset === CONST.SEARCH.RESULTS_PAGE_SIZE)).toBe(false);
+    });
+    it('does not request a queued page the refreshed snapshot no longer has', async () => {
+        mockSearchQueryParam.mockReturnValue(EXPENSE_QUERY);
+        await act(async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, getExpenseSnapshot(false));
+        });
+        renderPage(EXPENSE_QUERY);
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, {search: {isLoading: true}});
+        });
+        await act(async () => {
+            listProps.onEndReached?.();
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        // Refresh lands and the result set no longer has a further page.
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.SNAPSHOT}${expenseQueryJSON?.hash}`, {search: {isLoading: false, hasMoreResults: false}});
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(0);
+        });
+
+        expect(mockSearch.mock.calls.some(([params]) => params?.offset === CONST.SEARCH.RESULTS_PAGE_SIZE)).toBe(false);
     });
 });


### PR DESCRIPTION
### Explanation of Change

Reaching the end of the Spend list while a search was already in flight silently dropped the requested page.

`fetchMoreResults` bumps the local `offset` on scroll, but the effect that issues the request early-returns while `searchResults.search.isLoading` is true, and never re-runs when that clears, because `isLoading` is deliberately not one of its dependencies (adding it would make every completed search start another one). The local `offset` had already advanced past the loaded data, so `fetchMoreResults` then refused to bump again and the list could not paginate at all until it remounted. The existing retry effect only covers grouped/totals queries, so the plain Expenses and Reports views got no recovery.

This remembers the dropped offset and re-issues that page once the in-flight request resolves, guarded so it cannot fire on a screen that is no longer focused.

### Fixed Issues

https://github.com/Expensify/App/issues/97485
PROPOSAL: https://github.com/Expensify/App/issues/97485#issuecomment-5280814352

### Tests

**Precondition (this is the part that makes or breaks the test)**

An account with **more than 50 expenses** visible in Spend → Expenses, ideally 100+ spanning several months. Below 51 there is no second page and pagination never engages at all, so the test will silently pass on a broken build. Confirm before starting: scroll the list and check it doesn't simply end after the first screenful.

**Test 1 — the fix (Chrome, macOS or Windows)**

1. Sign in and open **Spend → Expenses**. Let the list finish loading, then note the date on the **last row** — scroll to the very bottom to see it.
2. Open DevTools → **Network** tab. Set **throttling to "Slow 4G"**. Leave DevTools open. In the filter box type `Search`.
3. Reload the page (Cmd/Ctrl+R). The rows appear from cache almost immediately, while a `Search` request is still pending in the Network tab.
4. **While that request is still pending**, scroll straight to the bottom of the list.
5. Wait for the pending `Search` request to complete.
6. **Verify:** within a second or two more rows appear below, without you scrolling again. The last-row date is now further back in time than in step 1 (an older month).
7. **Verify** in the Network tab: a second `Search` request went out. Its payload `jsonQuery` contains `"offset":50`.
8. Scroll to the bottom again and verify pages keep loading (`offset:100`, and so on).

**On a broken build, step 6 fails:** nothing loads after the request completes, and scrolling to the bottom repeatedly does nothing. The list stays stuck on the first 50 rows until you navigate away and back.

**Test 2 — no regression to normal pagination**

1. Turn throttling back to **No throttling**.
2. Open Spend → Expenses and scroll to the bottom several times.
3. Verify each page loads as before, with no duplicated or skipped rows.

**Test 3 — offline**

1. Open Spend → Expenses, then go offline.
2. Scroll to the bottom.
3. Verify no `Search` request is attempted and the cached rows stay put, with no error or crash.
4. Go back online and scroll to the bottom.
5. Verify pagination resumes normally.

**Test 4 — Reports tab**

Repeat Test 1 on **Spend → Reports** (same defect, same code path) with an account that has more than 50 reports.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open **Spend > Expenses** and scroll to the end of the list.
3. Verify no Search request is attempted and the list keeps showing the cached rows.
4. Come back online.
5. Verify pagination resumes normally on the next scroll to the end.

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/748bbedb-e1d9-422d-94f8-ccc68dabde9c


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/c008d4f0-4325-4467-a225-b072a19e9990


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/808d4b2d-f6ea-4c02-bd88-3ca4c1620a25


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/b68c3bef-8a21-4009-9f66-2c8f28a307a4


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/6d6e425c-20a4-4405-b60e-72ff84b65454


<!-- add screenshots or videos here -->

</details> 


