### PR TITLE
Migrate two getReportTransactions callers off the deprecated default

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1293,9 +1293,9 @@ function getReportOrDraftReport(
 }
 
 /**
- * This function is being migrated to remove `deprecatedReportsTransactions`.
- * If you need to use this function, you must explicitly pass the `allReportsTransactions` parameter
- * instead of relying on the default value. In React components, prefer using the `useReportTransactions` hook.
+ * @deprecated This function is being migrated and will be removed later.
+ * Always explicitly pass the `allReportsTransactions` parameter instead of relying on the default value.
+ * In React components, prefer using the `useReportTransactions` hook.
  */
 function getReportTransactions(reportID: string | undefined, allReportsTransactions: Record<string, Transaction[]> = deprecatedReportsTransactions): Transaction[] {
     if (!reportID) {

--- a/src/pages/TransactionMerge/DynamicConfirmationPage.tsx
+++ b/src/pages/TransactionMerge/DynamicConfirmationPage.tsx
@@ -29,7 +29,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {MergeTransactionNavigatorParamList} from '@libs/Navigation/types';
 import {getFilteredReportActionsForReportView, getIOUActionForTransactionID} from '@libs/ReportActionsUtils';
-import {findSelfDMReportID, getReportTransactions} from '@libs/ReportUtils';
+import {findSelfDMReportID} from '@libs/ReportUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -106,7 +106,7 @@ function DynamicConfirmationPage({route}: DynamicConfirmationPageProps) {
         // mergeTransactionRequest optimistically deletes the report. Capture that here (before the optimistic update runs)
         // so we can replace the now-deleted report screen instead of pushing on top of it — otherwise the stale screen
         // lingers in the stack and briefly flashes the "not found" page when the user taps back. Must be read pre-merge.
-        const willDeleteTargetTransactionReport = getReportTransactions(targetTransaction.reportID).length === 1;
+        const willDeleteTargetTransactionReport = Object.keys(targetReportTransactionsCollection ?? {}).length === 1;
 
         setIsMergingExpenses(true);
 

--- a/tests/unit/OptionsListUtilsTest.tsx
+++ b/tests/unit/OptionsListUtilsTest.tsx
@@ -75,7 +75,6 @@ import {
     getMovedActionMessage,
     getMovedTransactionMessage,
     getReportPreviewReportActionMessage,
-    getReportTransactions,
     isCanceledTaskReport,
     isExpensifyOnlyParticipantInReport,
 } from '@libs/ReportUtils';
@@ -7722,7 +7721,7 @@ describe('OptionsListUtils', () => {
 
                 currentUserLogin: CURRENT_USER_EMAIL,
             });
-            const transactions = getReportTransactions(report.reportID);
+            const transactions = [scannedTransaction];
             const scanningTransactions = transactions.filter((transaction) => isScanning(transaction));
             expect(result).toBe(
                 translateLocal('iou.receiptScanning', {


### PR DESCRIPTION
## Summary
- `getReportTransactions()` in `ReportUtils.ts` falls back to a deprecated internal global (`deprecatedReportsTransactions`) when the `allReportsTransactions` param is omitted. This is the first PR in an incremental migration of external callers off that implicit default.
- `DynamicConfirmationPage.tsx` now reuses the `useReportTransactionsCollection` result it already fetches for the same reportID, instead of a bare call.
- `OptionsListUtilsTest.tsx` now builds the expected transaction list directly from the transaction it already created, instead of relying on the deprecated global being populated via Onyx.
- Marked `getReportTransactions` as `@deprecated` with a note on why, so other in-flight PRs don't add new bare calls while the rest of the migration is in progress.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint-changed` passes
- [ ] Run `OptionsListUtilsTest` and confirm the "Receipt scanning..." test still passes
- [ ] In the app: start a transaction merge flow (TransactionMerge) where the target report has only the one expense being merged away, confirm the report is correctly detected as being deleted and navigation behaves the same as before