### PR TITLE
Fix expense rule selection being cancelled when opened via the Concierge link

### DIFF
--- a/src/components/MoneyReportHeader.tsx
+++ b/src/components/MoneyReportHeader.tsx
@@ -17,7 +17,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 
-import {useRoute} from '@react-navigation/native';
+import {useIsFocused, useRoute} from '@react-navigation/native';
 import React, {useEffect} from 'react';
 import {View} from 'react-native';
 
@@ -95,6 +95,7 @@ function MoneyReportHeaderContent({reportID: reportIDProp, shouldDisplayBackButt
     const shouldShowBackButton = shouldDisplayBackButton || shouldUseNarrowLayout;
 
     const isMobileSelectionModeEnabled = useMobileSelectionMode();
+    const isFocused = useIsFocused();
 
     useEffect(() => {
         return () => {
@@ -105,7 +106,7 @@ function MoneyReportHeaderContent({reportID: reportIDProp, shouldDisplayBackButt
     if (isMobileSelectionModeEnabled && shouldUseNarrowLayout) {
         // If mobile selection mode is enabled but only one or no transactions remain, turn it off
         const visibleTransactions = transactions.filter((t) => t.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || isOffline);
-        if (visibleTransactions.length <= 1) {
+        if (visibleTransactions.length <= 1 && isFocused) {
             turnOffMobileSelectionMode();
         }
 

--- a/src/hooks/useMobileSelectionMode.ts
+++ b/src/hooks/useMobileSelectionMode.ts
@@ -2,6 +2,7 @@ import {turnOffMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 
 import ONYXKEYS from '@src/ONYXKEYS';
 
+import {useIsFocused} from '@react-navigation/native';
 import {useEffect, useRef} from 'react';
 
 import useOnyx from './useOnyx';
@@ -11,14 +12,20 @@ export default function useMobileSelectionMode(onTurnOffSelectionMode = () => {}
     const [isSelectionModeEnabled = false] = useOnyx(ONYXKEYS.RAM_ONLY_MOBILE_SELECTION_MODE);
     const initialSelectionModeValueRef = useRef(isSelectionModeEnabled);
     const prevIsSelectionModeEnabled = usePrevious(isSelectionModeEnabled);
+    const isFocused = useIsFocused();
 
     useEffect(() => {
         // in case the selection mode is already off at the start, we don't need to turn it off again
         if (!initialSelectionModeValueRef.current) {
             return;
         }
+        // An unfocused subscriber would wipe the selection a focused screen just enabled.
+        if (!isFocused) {
+            return;
+        }
+        initialSelectionModeValueRef.current = false;
         turnOffMobileSelectionMode();
-    }, []);
+    }, [isFocused]);
 
     useEffect(() => {
         if (!prevIsSelectionModeEnabled || isSelectionModeEnabled) {

--- a/tests/ui/components/MoneyReportHeaderSelectionModeTest.tsx
+++ b/tests/ui/components/MoneyReportHeaderSelectionModeTest.tsx
@@ -1,0 +1,120 @@
+import {render} from '@testing-library/react-native';
+
+import MoneyReportHeader from '@components/MoneyReportHeader';
+
+import useOnyx from '@hooks/useOnyx';
+import useTransactionsAndViolationsForReport from '@hooks/useTransactionsAndViolationsForReport';
+
+import {turnOffMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report} from '@src/types/onyx';
+
+import type {UseOnyxResult} from 'react-native-onyx';
+
+import {useIsFocused} from '@react-navigation/native';
+import React from 'react';
+
+import createRandomTransaction from '../../utils/collections/transaction';
+
+const TEST_REPORT_ID = '1001';
+
+const report = {
+    reportID: TEST_REPORT_ID,
+    type: CONST.REPORT.TYPE.EXPENSE,
+} as Report;
+
+const singleTransaction = {...createRandomTransaction(1), reportID: TEST_REPORT_ID, pendingAction: undefined};
+
+function createOnyxResult<T>(value: NonNullable<T> | undefined): UseOnyxResult<T> {
+    return [value, {status: 'loaded'}];
+}
+
+jest.mock('@react-navigation/native', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const actualNavigation = jest.requireActual('@react-navigation/native');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...actualNavigation,
+        __esModule: true,
+        useRoute: jest.fn(() => ({name: 'report', params: {}})),
+        useIsFocused: jest.fn(() => true),
+    };
+});
+
+jest.mock('@libs/actions/MobileSelectionMode', () => ({
+    __esModule: true,
+    turnOnMobileSelectionMode: jest.fn(),
+    turnOffMobileSelectionMode: jest.fn(),
+}));
+
+jest.mock('@components/MoneyReportHeaderModals', () => ({__esModule: true, default: jest.fn(({children}: {children: React.ReactNode}) => children)}));
+jest.mock('@components/HeaderWithBackButton', () => ({__esModule: true, default: jest.fn(() => null)}));
+jest.mock('@components/MoneyReportHeaderActions', () => ({__esModule: true, default: jest.fn(() => null)}));
+jest.mock('@components/MoneyReportHeaderMoreContent', () => ({__esModule: true, default: jest.fn(() => null)}));
+jest.mock('@components/HeaderLoadingBar', () => ({__esModule: true, default: jest.fn(() => null)}));
+jest.mock('@components/MoneyRequestReportView/MoneyRequestReportNavigation', () => ({__esModule: true, default: jest.fn(() => null)}));
+jest.mock('@components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation', () => ({__esModule: true, default: jest.fn(() => null)}));
+jest.mock('@components/Search/SearchContext', () => ({
+    __esModule: true,
+    useSearchSelectionActions: jest.fn(() => ({clearSelectedTransactions: jest.fn()})),
+}));
+
+jest.mock('@hooks/useMobileSelectionMode', () => ({__esModule: true, default: jest.fn(() => true)}));
+jest.mock('@hooks/useReportPrimaryAction', () => ({__esModule: true, default: jest.fn(() => undefined)}));
+jest.mock('@hooks/useThemeStyles', () => ({__esModule: true, default: jest.fn(() => ({}))}));
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({shouldUseNarrowLayout: true, isSmallScreenWidth: true, isMediumScreenWidth: false, isInLandscapeMode: false})),
+}));
+jest.mock('@hooks/useResponsiveLayoutOnWideRHP', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({isWideRHPDisplayedOnWideLayout: false, isSuperWideRHPDisplayedOnWideLayout: false})),
+}));
+jest.mock('@hooks/useTransactionsAndViolationsForReport', () => ({__esModule: true, default: jest.fn()}));
+jest.mock('@hooks/useOnyx', () => jest.fn());
+
+const mockedUseOnyx = jest.mocked(useOnyx);
+const mockedUseIsFocused = jest.mocked(useIsFocused);
+const mockedUseTransactionsAndViolations = jest.mocked(useTransactionsAndViolationsForReport);
+const mockedTurnOffMobileSelectionMode = jest.mocked(turnOffMobileSelectionMode);
+
+describe('MoneyReportHeader mobile selection mode', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedUseTransactionsAndViolations.mockReturnValue({transactions: {t1: singleTransaction}, violations: {}, isLoaded: true});
+        mockedUseOnyx.mockImplementation((key) => {
+            if (key === `${ONYXKEYS.COLLECTION.REPORT}${TEST_REPORT_ID}`) {
+                return createOnyxResult<Report>(report);
+            }
+            return createOnyxResult(undefined);
+        });
+    });
+
+    it('does not turn off selection mode while the report screen is not focused', () => {
+        mockedUseIsFocused.mockReturnValue(false);
+
+        render(
+            <MoneyReportHeader
+                reportID={TEST_REPORT_ID}
+                onBackButtonPress={jest.fn()}
+            />,
+        );
+
+        expect(mockedTurnOffMobileSelectionMode).not.toHaveBeenCalled();
+    });
+
+    it('turns off selection mode when focused with one or no visible transactions', () => {
+        mockedUseIsFocused.mockReturnValue(true);
+
+        render(
+            <MoneyReportHeader
+                reportID={TEST_REPORT_ID}
+                onBackButtonPress={jest.fn()}
+            />,
+        );
+
+        expect(mockedTurnOffMobileSelectionMode).toHaveBeenCalled();
+    });
+});

--- a/tests/unit/useMobileSelectionModeTest.tsx
+++ b/tests/unit/useMobileSelectionModeTest.tsx
@@ -1,0 +1,101 @@
+import {act, renderHook} from '@testing-library/react-native';
+
+import useMobileSelectionMode from '@hooks/useMobileSelectionMode';
+
+import {turnOffMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import {useIsFocused} from '@react-navigation/native';
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+jest.mock('@react-navigation/native', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const actualNavigation = jest.requireActual('@react-navigation/native');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...actualNavigation,
+        __esModule: true,
+        useIsFocused: jest.fn(() => true),
+    };
+});
+
+jest.mock('@libs/actions/MobileSelectionMode', () => ({
+    __esModule: true,
+    turnOnMobileSelectionMode: jest.fn(),
+    turnOffMobileSelectionMode: jest.fn(),
+}));
+
+const mockedUseIsFocused = jest.mocked(useIsFocused);
+const mockedTurnOffMobileSelectionMode = jest.mocked(turnOffMobileSelectionMode);
+
+describe('useMobileSelectionMode', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('does not clear selection mode when a subscriber mounts unfocused while selection is already on', async () => {
+        // Given selection mode is already on, turned on by another (focused) screen
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.RAM_ONLY_MOBILE_SELECTION_MODE, true);
+        });
+        mockedUseIsFocused.mockReturnValue(false);
+
+        // When a subscriber mounts on a still-mounted background screen
+        renderHook(() => useMobileSelectionMode());
+        await waitForBatchedUpdates();
+
+        // Then it must not wipe the selection mode the focused screen owns
+        expect(mockedTurnOffMobileSelectionMode).not.toHaveBeenCalled();
+    });
+
+    it('clears stale selection mode when a subscriber mounts focused while selection is already on', async () => {
+        // Given selection mode was left on from a previous screen
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.RAM_ONLY_MOBILE_SELECTION_MODE, true);
+        });
+        mockedUseIsFocused.mockReturnValue(true);
+
+        // When the subscriber mounts on the focused screen
+        renderHook(() => useMobileSelectionMode());
+        await waitForBatchedUpdates();
+
+        // Then the stale selection mode is cleared
+        expect(mockedTurnOffMobileSelectionMode).toHaveBeenCalled();
+    });
+
+    it('defers the stale-selection cleanup until the screen becomes focused', async () => {
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.RAM_ONLY_MOBILE_SELECTION_MODE, true);
+        });
+        mockedUseIsFocused.mockReturnValue(false);
+
+        const {rerender} = renderHook(() => useMobileSelectionMode());
+        await waitForBatchedUpdates();
+        expect(mockedTurnOffMobileSelectionMode).not.toHaveBeenCalled();
+
+        // When the screen becomes focused, the deferred cleanup runs
+        mockedUseIsFocused.mockReturnValue(true);
+        rerender({});
+        await waitForBatchedUpdates();
+
+        expect(mockedTurnOffMobileSelectionMode).toHaveBeenCalled();
+    });
+
+    it('does not clear selection mode when it was already off at mount', async () => {
+        mockedUseIsFocused.mockReturnValue(true);
+
+        renderHook(() => useMobileSelectionMode());
+        await waitForBatchedUpdates();
+
+        expect(mockedTurnOffMobileSelectionMode).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

Mobile selection mode is a single global Onyx flag. The Concierge rules link pushes a fullscreen tab entry rather than an RHP, so the report you came from stays mounted underneath, and two of its subscribers clear the flag as soon as the Rules page sets it:

- `MoneyReportHeader` clears it in its render body when the report has one visible transaction
- `useMobileSelectionMode` clears it on mount, and `SelectionToolbarGate` mounts `SelectionToolbar` exactly when the flag flips

Focus-gating both clears fixes it, verified red/green on iOS. The hook cleanup is deferred rather than skipped, so the existing stale-selection cleanup still runs once the screen is focused.

The existing `MoneyReportHeaderSelectionModeTest` mocks navigation without `useIsFocused`, so it now stubs it as focused. The new focus-gating tests live in `MoneyReportHeaderFocusSelectionModeTest`.

The focus guard has to cover the render, not just the turn-off. An unfocused report mounted behind the Rules page otherwise still paints the `Select multiple` header the moment selection mode turns on, and iOS swipe-back reveals it for about 0.6s until the report regains focus. Gating the whole branch on focus removes that, verified frame by frame on the iOS simulator. The inner focus check on the single-transaction turn-off is folded into the outer one, so an unfocused report still never clears the flag, same as before.

### Fixed Issues

$ https://github.com/Expensify/App/issues/95132
PROPOSAL: https://github.com/Expensify/App/issues/95132#issuecomment-5006718680

### Tests

Precondition: two or more personal expense rules, and an expense created through a rule so the Concierge message with the `personal expense rules` link exists.

1. On iOS or Android, open the report containing that expense, open the expense, and tap the `personal expense rules` link in the Concierge message
2. Long-press any rule and tap `Select`
3. Verify selection mode stays on: `Select multiple` header, `1 selected`, and checkboxes visible
4. Repeat on a report with two or more expenses and verify selection is kept there too
5. Open Settings > Expense rules directly and verify long-press to select still works
6. Enter selection mode on any list, navigate away, come back, and verify the selection is cleared
7. On iOS, with selection mode on in Expense rules, swipe back to the report and verify the report header is its normal header the whole way, never `Select multiple`

- [x] Verify that no errors appear in the JS console

### Offline tests

Selection mode is a RAM-only Onyx value and the flows above make no API calls, so behaviour is identical offline.

### QA Steps

Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see Reviewing the code)
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the translation method
      - [x] If any non-english text was added/modified, I used JaimeGPT to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in `STYLE.md`) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing StyleUtils function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added unit tests for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or 

https://github.com/user-attachments/assets/6a2d2298-426a-4989-a156-03b161f09bd5

videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/b41ae78b-0be0-4285-a5d8-7f653024451d


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/920375e1-5da5-4666-9e38-22d72e307cd9


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/28ceffe2-87ee-4bc0-84e9-4dd795ed119f


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/f45d6b97-36ee-42d7-ade4-ad05fe729f84


<!-- add screenshots or videos here -->

</details>


