### PR TITLE
Anchor the validate code countdown to the wall clock

### DIFF
--- a/src/components/ValidateCodeCountdown/index.tsx
+++ b/src/components/ValidateCodeCountdown/index.tsx
@@ -2,6 +2,7 @@ import RenderHTML from '@components/RenderHTML';
 
 import useAccessibilityAnnouncement from '@hooks/useAccessibilityAnnouncement';
 import useLocalize from '@hooks/useLocalize';
+import usePrevious from '@hooks/usePrevious';
 
 import DateUtils from '@libs/DateUtils';
 
@@ -10,6 +11,8 @@ import CONST from '@src/CONST';
 import React, {useEffect, useImperativeHandle, useRef, useState} from 'react';
 
 import type {ValidateCodeCountdownProps} from './types';
+
+const ANNOUNCEMENT_INTERVAL_SECONDS = 10;
 
 function ValidateCodeCountdown({onCountdownFinish, requestedAt, ref}: ValidateCodeCountdownProps) {
     const {translate} = useLocalize();
@@ -63,12 +66,14 @@ function ValidateCodeCountdown({onCountdownFinish, requestedAt, ref}: ValidateCo
         onCountdownFinish();
     }, [timeRemaining, onCountdownFinish]);
 
-    // Announce countdown start/reset/expiration for screen readers.
-    // We check timeRemaining === 1 (not 0) because the component unmounts immediately at 0s, so the expired announcement wouldn't be spoken.
-    // We use timeRemaining % 10 === 1 to announce every 10 seconds (at 21s, 11s, 1s) to avoid overwhelming screen reader users.
+    // Announce every 10 seconds rather than every second, to avoid overwhelming screen reader users. Counting blocks
+    // rather than matching 21s/11s/1s exactly keeps the announcement when a recomputed countdown skips a mark.
+    const remainingAnnouncementBlocks = Math.ceil((timeRemaining - 1) / ANNOUNCEMENT_INTERVAL_SECONDS);
+    const previousAnnouncementBlocks = usePrevious(remainingAnnouncementBlocks);
+
     useAccessibilityAnnouncement(
-        timeRemaining === 1 ? translate('validateCodeForm.timeExpiredAnnouncement') : translate('validateCodeForm.timeRemainingAnnouncement', {count: timeRemaining - 1}),
-        timeRemaining % 10 === 1,
+        timeRemaining <= 1 ? translate('validateCodeForm.timeExpiredAnnouncement') : translate('validateCodeForm.timeRemainingAnnouncement', {count: timeRemaining - 1}),
+        remainingAnnouncementBlocks !== previousAnnouncementBlocks,
         {
             shouldAnnounceOnNative: true,
             shouldAnnounceOnWeb: true,

--- a/src/components/ValidateCodeCountdown/index.tsx
+++ b/src/components/ValidateCodeCountdown/index.tsx
@@ -24,6 +24,7 @@ function ValidateCodeCountdown({onCountdownFinish, requestedAt, ref}: ValidateCo
     const timerRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
     useImperativeHandle(ref, () => ({
+        // Only re-anchors the callers without `requestedAt`; the others stamp a fresh one when they resend.
         resetCountdown: () => {
             setStartedAt(Date.now());
             setTimeRemaining(CONST.REQUEST_CODE_DELAY);
@@ -31,23 +32,36 @@ function ValidateCodeCountdown({onCountdownFinish, requestedAt, ref}: ValidateCo
     }));
 
     useEffect(() => {
-        if (timeRemaining <= 0) {
-            onCountdownFinish();
-            return;
-        }
+        // Each tick arms the next itself: React drops a tick that recomputes the same value, leaving nothing to re-arm the timer.
+        const scheduleTick = () => {
+            // Align to the anchor's second boundary so every tab and reload flips the same second at the same instant.
+            const msUntilNextTick = CONST.MILLISECONDS_PER_SECOND - ((Date.now() - anchor) % CONST.MILLISECONDS_PER_SECOND);
 
-        // Align to the anchor's second boundary so every tab and reload flips the same second at the same instant.
-        const msUntilNextTick = CONST.MILLISECONDS_PER_SECOND - ((Date.now() - anchor) % CONST.MILLISECONDS_PER_SECOND);
+            timerRef.current = setTimeout(() => {
+                // Recompute instead of decrementing: a throttled tab or a suspended app delivers fewer callbacks than seconds.
+                const remaining = DateUtils.getRemainingSecondsInWindow(anchor, CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND);
+                setTimeRemaining(remaining);
 
-        timerRef.current = setTimeout(() => {
-            // Recompute instead of decrementing: a throttled tab or a suspended app delivers fewer callbacks than seconds.
-            setTimeRemaining(DateUtils.getRemainingSecondsInWindow(anchor, CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND));
-        }, msUntilNextTick);
+                if (remaining <= 0) {
+                    return;
+                }
+                scheduleTick();
+            }, msUntilNextTick);
+        };
+
+        scheduleTick();
 
         return () => {
             clearTimeout(timerRef.current);
         };
-    }, [onCountdownFinish, timeRemaining, anchor]);
+    }, [anchor]);
+
+    useEffect(() => {
+        if (timeRemaining > 0) {
+            return;
+        }
+        onCountdownFinish();
+    }, [timeRemaining, onCountdownFinish]);
 
     // Announce countdown start/reset/expiration for screen readers.
     // We check timeRemaining === 1 (not 0) because the component unmounts immediately at 0s, so the expired announcement wouldn't be spoken.

--- a/src/components/ValidateCodeCountdown/index.tsx
+++ b/src/components/ValidateCodeCountdown/index.tsx
@@ -14,14 +14,20 @@ import type {ValidateCodeCountdownProps} from './types';
 function ValidateCodeCountdown({onCountdownFinish, requestedAt, ref}: ValidateCodeCountdownProps) {
     const {translate} = useLocalize();
 
-    // Seed from the time the code was actually requested so a reload mid-countdown resumes at the correct value instead of restarting at the full delay.
+    const [startedAt, setStartedAt] = useState(() => Date.now());
+    const anchor = requestedAt ?? startedAt;
+
+    // Seeding from the request time lets a reload mid-countdown resume instead of restarting at the full delay.
     const [timeRemaining, setTimeRemaining] = useState<number>(
-        () => DateUtils.getRemainingSecondsInWindow(requestedAt, CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND) || CONST.REQUEST_CODE_DELAY,
+        () => DateUtils.getRemainingSecondsInWindow(anchor, CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND) || CONST.REQUEST_CODE_DELAY,
     );
     const timerRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
     useImperativeHandle(ref, () => ({
-        resetCountdown: () => setTimeRemaining(CONST.REQUEST_CODE_DELAY),
+        resetCountdown: () => {
+            setStartedAt(Date.now());
+            setTimeRemaining(CONST.REQUEST_CODE_DELAY);
+        },
     }));
 
     useEffect(() => {
@@ -30,21 +36,18 @@ function ValidateCodeCountdown({onCountdownFinish, requestedAt, ref}: ValidateCo
             return;
         }
 
-        // When anchored to `requestedAt`, align the next tick to the wall-clock second boundary so every tab/reload flips the
-        // displayed second at the same instant instead of drifting by each tab's own mount offset. Without an anchor (the
-        // `hasValidateCodeBeenSent` flows) there is nothing to align to, so fall back to a fixed 1s cadence.
-        const msUntilNextTick = requestedAt ? CONST.MILLISECONDS_PER_SECOND - ((Date.now() - requestedAt) % CONST.MILLISECONDS_PER_SECOND) : CONST.MILLISECONDS_PER_SECOND;
+        // Align to the anchor's second boundary so every tab and reload flips the same second at the same instant.
+        const msUntilNextTick = CONST.MILLISECONDS_PER_SECOND - ((Date.now() - anchor) % CONST.MILLISECONDS_PER_SECOND);
 
         timerRef.current = setTimeout(() => {
-            // With an anchor, re-derive from the wall clock so the countdown self-corrects against setTimeout drift,
-            // background-tab throttling, and cross-tab phase differences. Without one, keep the simple decrement.
-            setTimeRemaining((prev) => (requestedAt ? DateUtils.getRemainingSecondsInWindow(requestedAt, CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND) : prev - 1));
+            // Recompute instead of decrementing: a throttled tab or a suspended app delivers fewer callbacks than seconds.
+            setTimeRemaining(DateUtils.getRemainingSecondsInWindow(anchor, CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND));
         }, msUntilNextTick);
 
         return () => {
             clearTimeout(timerRef.current);
         };
-    }, [onCountdownFinish, timeRemaining, requestedAt]);
+    }, [onCountdownFinish, timeRemaining, anchor]);
 
     // Announce countdown start/reset/expiration for screen readers.
     // We check timeRemaining === 1 (not 0) because the component unmounts immediately at 0s, so the expired announcement wouldn't be spoken.

--- a/src/libs/DateUtils.ts
+++ b/src/libs/DateUtils.ts
@@ -425,7 +425,7 @@ function getRemainingSecondsInWindow(requestedAt: number | undefined, windowMs: 
     const remainingSeconds = Math.ceil((windowMs - (Date.now() - requestedAt)) / CONST.MILLISECONDS_PER_SECOND);
 
     // A backward clock correction leaves `requestedAt` in the future, which would otherwise report more than the window.
-    return Math.min(windowMs / CONST.MILLISECONDS_PER_SECOND, Math.max(0, remainingSeconds));
+    return Math.min(Math.ceil(windowMs / CONST.MILLISECONDS_PER_SECOND), Math.max(0, remainingSeconds));
 }
 
 /**

--- a/src/libs/DateUtils.ts
+++ b/src/libs/DateUtils.ts
@@ -422,7 +422,10 @@ function getRemainingSecondsInWindow(requestedAt: number | undefined, windowMs: 
     if (!requestedAt) {
         return 0;
     }
-    return Math.max(0, Math.ceil((windowMs - (Date.now() - requestedAt)) / CONST.MILLISECONDS_PER_SECOND));
+    const remainingSeconds = Math.ceil((windowMs - (Date.now() - requestedAt)) / CONST.MILLISECONDS_PER_SECOND);
+
+    // A backward clock correction leaves `requestedAt` in the future, which would otherwise report more than the window.
+    return Math.min(windowMs / CONST.MILLISECONDS_PER_SECOND, Math.max(0, remainingSeconds));
 }
 
 /**

--- a/tests/ui/ValidateCodeCountdownTest.tsx
+++ b/tests/ui/ValidateCodeCountdownTest.tsx
@@ -1,0 +1,83 @@
+import {act, render, screen} from '@testing-library/react-native';
+
+import ValidateCodeCountdown from '@components/ValidateCodeCountdown';
+
+import CONST from '@src/CONST';
+
+import type ReactNative from 'react-native';
+
+import React from 'react';
+
+jest.mock('@hooks/useLocalize', () =>
+    jest.fn(() => ({
+        translate: (key: string, params?: {timeRemaining?: string}) => params?.timeRemaining ?? key,
+    })),
+);
+jest.mock('@hooks/useAccessibilityAnnouncement', () => jest.fn());
+jest.mock('@components/RenderHTML', () => {
+    const ReactMock = jest.requireActual<typeof React>('react');
+    const {Text} = jest.requireActual<typeof ReactNative>('react-native');
+
+    return ({html}: {html: string}) => ReactMock.createElement(Text, null, html.replaceAll(/<[^>]*>/g, ''));
+});
+
+const BASE_TIME = new Date('2026-08-21T10:00:00.000Z').valueOf();
+
+// One act per tick so React commits the effect that schedules the next one.
+function tickSeconds(seconds: number) {
+    for (let i = 0; i < seconds; i++) {
+        act(() => jest.advanceTimersByTime(CONST.MILLISECONDS_PER_SECOND));
+    }
+}
+
+// Clock advances with no callback delivered, the way a throttled tab or a backgrounded app behaves.
+function suspendFor(milliseconds: number) {
+    act(() => {
+        jest.setSystemTime(Date.now() + milliseconds);
+        jest.advanceTimersByTime(CONST.MILLISECONDS_PER_SECOND);
+    });
+}
+
+describe('ValidateCodeCountdown', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(BASE_TIME);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('reports the time that actually elapsed after the timer was starved of callbacks', () => {
+        render(<ValidateCodeCountdown onCountdownFinish={jest.fn()} />);
+        expect(screen.getByText('00:30')).toBeOnTheScreen();
+
+        tickSeconds(3);
+        expect(screen.getByText('00:27')).toBeOnTheScreen();
+
+        // 14s of the 30s window are gone once the single resume callback lands.
+        suspendFor(10 * CONST.MILLISECONDS_PER_SECOND);
+        expect(screen.getByText('00:16')).toBeOnTheScreen();
+    });
+
+    it('finishes once the window has elapsed even if the callbacks never arrived', () => {
+        const onCountdownFinish = jest.fn();
+        render(<ValidateCodeCountdown onCountdownFinish={onCountdownFinish} />);
+
+        suspendFor(CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND);
+        expect(onCountdownFinish).toHaveBeenCalled();
+    });
+
+    it('keeps measuring from a persisted requestedAt when one is passed', () => {
+        render(
+            <ValidateCodeCountdown
+                requestedAt={BASE_TIME - 8 * CONST.MILLISECONDS_PER_SECOND}
+                onCountdownFinish={jest.fn()}
+            />,
+        );
+        expect(screen.getByText('00:22')).toBeOnTheScreen();
+
+        suspendFor(10 * CONST.MILLISECONDS_PER_SECOND);
+        expect(screen.getByText('00:11')).toBeOnTheScreen();
+    });
+});

--- a/tests/ui/ValidateCodeCountdownTest.tsx
+++ b/tests/ui/ValidateCodeCountdownTest.tsx
@@ -89,6 +89,16 @@ describe('ValidateCodeCountdown', () => {
         expect(screen.getByText('00:11')).toBeOnTheScreen();
     });
 
+    // A backward clock correction leaves the anchor in the future, where the clamp returns the same value every tick.
+    it('keeps ticking to zero when the clock is corrected backward', () => {
+        const onCountdownFinish = jest.fn();
+        renderCountdown(onCountdownFinish, BASE_TIME + 10 * CONST.MILLISECONDS_PER_SECOND);
+        expect(screen.getByText('00:30')).toBeOnTheScreen();
+
+        tickSeconds(45);
+        expect(onCountdownFinish).toHaveBeenCalled();
+    });
+
     it('measures from the resend time after the countdown is reset', () => {
         const ref = renderCountdown();
 

--- a/tests/ui/ValidateCodeCountdownTest.tsx
+++ b/tests/ui/ValidateCodeCountdownTest.tsx
@@ -1,12 +1,13 @@
 import {act, render, screen} from '@testing-library/react-native';
 
 import ValidateCodeCountdown from '@components/ValidateCodeCountdown';
+import type {ValidateCodeCountdownHandle} from '@components/ValidateCodeCountdown/types';
 
 import CONST from '@src/CONST';
 
 import type ReactNative from 'react-native';
 
-import React from 'react';
+import React, {createRef} from 'react';
 
 jest.mock('@hooks/useLocalize', () =>
     jest.fn(() => ({
@@ -38,6 +39,18 @@ function suspendFor(milliseconds: number) {
     });
 }
 
+function renderCountdown(onCountdownFinish: () => void = jest.fn(), requestedAt?: number) {
+    const ref = createRef<ValidateCodeCountdownHandle>();
+    render(
+        <ValidateCodeCountdown
+            ref={ref}
+            requestedAt={requestedAt}
+            onCountdownFinish={onCountdownFinish}
+        />,
+    );
+    return ref;
+}
+
 describe('ValidateCodeCountdown', () => {
     beforeEach(() => {
         jest.useFakeTimers();
@@ -49,7 +62,7 @@ describe('ValidateCodeCountdown', () => {
     });
 
     it('reports the time that actually elapsed after the timer was starved of callbacks', () => {
-        render(<ValidateCodeCountdown onCountdownFinish={jest.fn()} />);
+        renderCountdown();
         expect(screen.getByText('00:30')).toBeOnTheScreen();
 
         tickSeconds(3);
@@ -62,22 +75,28 @@ describe('ValidateCodeCountdown', () => {
 
     it('finishes once the window has elapsed even if the callbacks never arrived', () => {
         const onCountdownFinish = jest.fn();
-        render(<ValidateCodeCountdown onCountdownFinish={onCountdownFinish} />);
+        renderCountdown(onCountdownFinish);
 
         suspendFor(CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND);
         expect(onCountdownFinish).toHaveBeenCalled();
     });
 
     it('keeps measuring from a persisted requestedAt when one is passed', () => {
-        render(
-            <ValidateCodeCountdown
-                requestedAt={BASE_TIME - 8 * CONST.MILLISECONDS_PER_SECOND}
-                onCountdownFinish={jest.fn()}
-            />,
-        );
+        renderCountdown(jest.fn(), BASE_TIME - 8 * CONST.MILLISECONDS_PER_SECOND);
         expect(screen.getByText('00:22')).toBeOnTheScreen();
 
         suspendFor(10 * CONST.MILLISECONDS_PER_SECOND);
         expect(screen.getByText('00:11')).toBeOnTheScreen();
+    });
+
+    it('measures from the resend time after the countdown is reset', () => {
+        const ref = renderCountdown();
+
+        tickSeconds(5);
+        act(() => ref.current?.resetCountdown());
+        expect(screen.getByText('00:30')).toBeOnTheScreen();
+
+        suspendFor(10 * CONST.MILLISECONDS_PER_SECOND);
+        expect(screen.getByText('00:19')).toBeOnTheScreen();
     });
 });

--- a/tests/ui/ValidateCodeCountdownTest.tsx
+++ b/tests/ui/ValidateCodeCountdownTest.tsx
@@ -14,7 +14,12 @@ jest.mock('@hooks/useLocalize', () =>
         translate: (key: string, params?: {timeRemaining?: string}) => params?.timeRemaining ?? key,
     })),
 );
-jest.mock('@hooks/useAccessibilityAnnouncement', () => jest.fn());
+const mockAnnounce = jest.fn<void, [string, boolean]>();
+
+jest.mock('@hooks/useAccessibilityAnnouncement', () => ({
+    __esModule: true,
+    default: (message: string, shouldAnnounceMessage: boolean) => mockAnnounce(message, shouldAnnounceMessage),
+}));
 jest.mock('@components/RenderHTML', () => {
     const ReactMock = jest.requireActual<typeof React>('react');
     const {Text} = jest.requireActual<typeof ReactNative>('react-native');
@@ -24,7 +29,11 @@ jest.mock('@components/RenderHTML', () => {
 
 const BASE_TIME = new Date('2026-08-21T10:00:00.000Z').valueOf();
 
-// One act per tick so React commits the effect that schedules the next one.
+function announcedMessages() {
+    return mockAnnounce.mock.calls.filter(([, shouldAnnounceMessage]) => shouldAnnounceMessage).map(([message]) => message);
+}
+
+// One act per tick so React commits each second; batching them skips the intermediate values.
 function tickSeconds(seconds: number) {
     for (let i = 0; i < seconds; i++) {
         act(() => jest.advanceTimersByTime(CONST.MILLISECONDS_PER_SECOND));
@@ -55,6 +64,7 @@ describe('ValidateCodeCountdown', () => {
     beforeEach(() => {
         jest.useFakeTimers();
         jest.setSystemTime(BASE_TIME);
+        mockAnnounce.mockClear();
     });
 
     afterEach(() => {
@@ -97,6 +107,21 @@ describe('ValidateCodeCountdown', () => {
 
         tickSeconds(45);
         expect(onCountdownFinish).toHaveBeenCalled();
+    });
+
+    it('announces the milestones a ticking countdown passes through', () => {
+        renderCountdown();
+
+        tickSeconds(CONST.REQUEST_CODE_DELAY);
+        expect(announcedMessages()).toEqual(['validateCodeForm.timeRemainingAnnouncement', 'validateCodeForm.timeRemainingAnnouncement', 'validateCodeForm.timeExpiredAnnouncement']);
+    });
+
+    // Recomputing skips values, so an exact-match gate would ask for nothing at all about a window that expired.
+    it('asks for the expiry announcement when the countdown skips straight to zero', () => {
+        renderCountdown();
+
+        suspendFor(CONST.REQUEST_CODE_DELAY * CONST.MILLISECONDS_PER_SECOND);
+        expect(announcedMessages()).toContain('validateCodeForm.timeExpiredAnnouncement');
     });
 
     it('measures from the resend time after the countdown is reset', () => {

--- a/tests/unit/DateUtilsTest.ts
+++ b/tests/unit/DateUtilsTest.ts
@@ -728,6 +728,11 @@ describe('DateUtils', () => {
         it('should clamp to 0 once the window has elapsed', () => {
             expect(DateUtils.getRemainingSecondsInWindow(Date.now() - 31 * 1000, windowMs)).toBe(0);
         });
+
+        // A backward clock correction leaves the request timestamp in the future.
+        it('should clamp to the full window when the timestamp is in the future', () => {
+            expect(DateUtils.getRemainingSecondsInWindow(Date.now() + 10 * 1000, windowMs)).toBe(30);
+        });
     });
 
     describe('getTimeOfDayGreetingKey', () => {

--- a/tests/unit/DateUtilsTest.ts
+++ b/tests/unit/DateUtilsTest.ts
@@ -729,7 +729,6 @@ describe('DateUtils', () => {
             expect(DateUtils.getRemainingSecondsInWindow(Date.now() - 31 * 1000, windowMs)).toBe(0);
         });
 
-        // A backward clock correction leaves the request timestamp in the future.
         it('should clamp to the full window when the timestamp is in the future', () => {
             expect(DateUtils.getRemainingSecondsInWindow(Date.now() + 10 * 1000, windowMs)).toBe(30);
         });


### PR DESCRIPTION
### Explanation of Change

`ValidateCodeCountdown` only recomputed the remaining time from the wall clock when a caller passed `requestedAt`. Without that prop the tick handler fell back to `prev - 1`, so it measured how many timer callbacks were delivered rather than how much time had passed. A browser throttles timers in a hidden tab and a mobile OS suspends them entirely while the app is backgrounded, so the countdown lagged real time on web and looked paused on native.

The countdown now always has a wall-clock anchor: `requestedAt` when the caller persists one, and otherwise the moment the countdown started (re-anchored by `resetCountdown` on resend). Every tick re-derives from that anchor, so the decrementing branch is gone.

This covers all three render sites. The sign-in form and `MultifactorAuthentication/ValidateCodeResendButton` never pass `requestedAt`, and `ValidateCodeActionModal` passes `undefined` for the `hasValidateCodeBeenSent` flows.

### Fixed Issues
$ https://github.com/Expensify/App/issues/99191
PROPOSAL: https://github.com/Expensify/App/issues/99191#issuecomment-5442681213

### Tests

1. Open the sign-in page and enter the email of an existing account.
2. Request the magic code and note the countdown, for example `Request a new code in 00:29`.
3. Switch to another browser tab for about 15 seconds, then switch back.
4. Verify the countdown dropped by roughly the time you were away (about `00:13`), not by one or two seconds.
5. Wait for the countdown to reach `00:00` and verify the resend link appears.
6. Press the resend link and verify the countdown restarts at `00:30`, then repeat steps 3 and 4 to confirm it still tracks real time.
7. On Android and iOS, repeat steps 2 to 4 by sending the app to the background instead of switching tabs.
8. Repeat steps 2 to 4 on Settings > Profile > Contact methods for a new contact method, to confirm the shared countdown still behaves in the modal flow.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Request a magic code on the sign-in page so the countdown is running.
2. Turn off your network connection.
3. Verify the countdown is replaced by the resend link and that the link is disabled.
4. Turn the network back on and verify the resend link becomes usable again.

### QA Steps

1. Open the sign-in page on staging and enter the email of an existing account.
2. Request the magic code and note the countdown value.
3. Switch to another tab (web) or background the app (native) for about 15 seconds, then return.
4. Verify the remaining time reflects the time that actually passed rather than appearing frozen or running slow.
5. Verify the countdown still reaches `00:00` and the resend link appears.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/381c02a9-781e-4dd4-bd2a-88a4d1b61789


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/f64232a9-960f-4570-b44a-f65e6e87e4e3


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/9a9beab6-7095-4c86-b870-b5aed1a0bbf1


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/da63f7e4-60c2-4c0b-afe3-ac66e2e1cf3d



<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/user-attachments/assets/475baa0f-8758-4bf9-82ed-81005a79ded8




<!-- add screenshots or videos here -->

</details> 


