### PR TITLE
[No QA] Fix - Add bank account forward path ignores shouldSetUpUSBankAccount

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -156,10 +156,15 @@ const DYNAMIC_ROUTES = {
             SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT,
             SCREENS.SEARCH.ROOT,
         ],
-        // Entry points that already know the user is adding a personal deposit account (e.g. a queued reimbursement) pass true so the
-        // bank account purpose screen isn't shown after validation.
-        getRoute: (shouldSkipPurposeSelection?: boolean) => `add-bank-account/verify-account${shouldSkipPurposeSelection ? '?shouldSkipPurposeSelection=true' : ''}` as const,
-        queryParams: ['shouldSkipPurposeSelection'],
+        // Entry points that already know the user is adding a personal deposit account (e.g. a queued reimbursement).
+        getRoute: (shouldSkipPurposeSelection?: boolean, shouldSetUpUSBankAccount?: boolean) =>
+            getUrlWithParams('add-bank-account/verify-account', {
+                // If true the bank account purpose screen isn't shown after validation
+                shouldSkipPurposeSelection: shouldSkipPurposeSelection ? 'true' : undefined,
+                // If true US bank account setup flow must be started after validation
+                shouldSetUpUSBankAccount: shouldSetUpUSBankAccount ? 'true' : undefined,
+            }),
+        queryParams: ['shouldSkipPurposeSelection', 'shouldSetUpUSBankAccount'],
     },
     BANK_ACCOUNT_VERIFY_ACCOUNT: {
         path: 'verify-bank-account',

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -131,8 +131,11 @@ type SettingsNavigatorParamList = {
     };
     [SCREENS.SETTINGS.DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT]:
         | {
-              /** Whether the bank account purpose screen should be skipped after the account is validated */
-              shouldSkipPurposeSelection?: boolean;
+              /** Whether the bank account purpose screen should be skipped after the account is validated. */
+              shouldSkipPurposeSelection?: 'true';
+
+              /** Whether the US bank account flow should open after the account is validated. */
+              shouldSetUpUSBankAccount?: 'true';
           }
         | undefined;
     [SCREENS.SETTINGS.DYNAMIC_EXIT_SURVEY_REASON]: undefined;

--- a/src/libs/Url.ts
+++ b/src/libs/Url.ts
@@ -130,7 +130,7 @@ function getSearchParamFromPath(path: string, param: string) {
     return getParamFromQueryString(backToQueryString);
 }
 
-type UrlWithParams<TBase extends string> = `${TBase}${'' | `?${string}` | `&${string}`}`;
+type UrlWithParams<TBase extends string> = TBase | `${TBase}${`?${string}` | `&${string}`}`;
 type UrlParams = {backTo?: string; forwardTo?: string} & Record<string, string | number | undefined>;
 /**
  * Generate a URL with properly encoded query parameters.
@@ -139,7 +139,8 @@ type UrlParams = {backTo?: string; forwardTo?: string} & Record<string, string |
  * @param params - Object containing key-value pairs for query parameters.
  * @returns A URL string with encoded query parameters.
  */
-function getUrlWithParams<TBase extends string, TParams extends UrlParams>(baseUrl: TBase, params: TParams): UrlWithParams<TBase> {
+function getUrlWithParams<TBase extends string, TParams extends UrlParams>(baseUrl: TBase, params: TParams): UrlWithParams<TBase>;
+function getUrlWithParams(baseUrl: string, params: UrlParams): string {
     const [path, existingQuery] = baseUrl.split('?', 2);
     const searchParams = new URLSearchParams(existingQuery || '');
 
@@ -150,7 +151,7 @@ function getUrlWithParams<TBase extends string, TParams extends UrlParams>(baseU
     }
 
     const queryString = searchParams.toString();
-    return (queryString ? `${path}?${queryString}` : path) as UrlWithParams<TBase>;
+    return queryString ? `${path}?${queryString}` : path;
 }
 
 /**

--- a/src/libs/actions/BankAccounts.ts
+++ b/src/libs/actions/BankAccounts.ts
@@ -159,7 +159,7 @@ function openPersonalBankAccountSetupView({
 
         if (!isUserValidated) {
             // This flow always adds a personal deposit account, so the purpose screen is skipped once the account is validated.
-            Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.ADD_BANK_ACCOUNT_VERIFY_ACCOUNT.getRoute(true)));
+            Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.ADD_BANK_ACCOUNT_VERIFY_ACCOUNT.getRoute(true, shouldSetUpUSBankAccount)));
             return;
         }
         if (shouldSetUpUSBankAccount) {

--- a/src/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPage.tsx
+++ b/src/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPage.tsx
@@ -17,12 +17,20 @@ import React, {useMemo} from 'react';
 type DynamicAddBankAccountVerifyAccountPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT>;
 
 function DynamicAddBankAccountVerifyAccountPage({route}: DynamicAddBankAccountVerifyAccountPageProps) {
-    const {shouldSkipPurposeSelection} = route.params ?? {};
+    const {shouldSkipPurposeSelection, shouldSetUpUSBankAccount} = route.params ?? {};
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.ADD_BANK_ACCOUNT_VERIFY_ACCOUNT.path);
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
     const currentUserEmail = getCurrentUserEmail();
     const isAdmin = useMemo(() => hasActiveAdminWorkspaces(currentUserEmail ?? '', allPolicies), [currentUserEmail, allPolicies]);
-    const navigateForwardTo = isAdmin && !shouldSkipPurposeSelection ? ROUTES.SETTINGS_BANK_ACCOUNT_PURPOSE : ROUTES.SETTINGS_ADD_BANK_ACCOUNT.getRoute(backPath);
+    // This forward path must agree with the validated branch of openPersonalBankAccountSetupView.
+    let navigateForwardTo;
+    if (shouldSetUpUSBankAccount === 'true') {
+        navigateForwardTo = ROUTES.SETTINGS_ADD_US_BANK_ACCOUNT.getRoute();
+    } else if (isAdmin && shouldSkipPurposeSelection !== 'true') {
+        navigateForwardTo = ROUTES.SETTINGS_BANK_ACCOUNT_PURPOSE;
+    } else {
+        navigateForwardTo = ROUTES.SETTINGS_ADD_BANK_ACCOUNT.getRoute(backPath);
+    }
 
     return (
         <VerifyAccountPageBase

--- a/tests/actions/BankAccountsTest.ts
+++ b/tests/actions/BankAccountsTest.ts
@@ -1,10 +1,11 @@
 import {clearPersonalBankAccount, connectBankAccountWithPlaid, openPersonalBankAccountSetupView} from '@libs/actions/BankAccounts';
 import {WRITE_COMMANDS} from '@libs/API/types';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {ReimbursementAccountForm} from '@src/types/form/ReimbursementAccountForm';
 import type PlaidBankAccount from '@src/types/onyx/PlaidBankAccount';
 
@@ -173,6 +174,14 @@ describe('actions/BankAccounts', () => {
             await waitForBatchedUpdates();
 
             expect(Navigation.navigate).toHaveBeenCalledWith(ROUTES.SETTINGS_ADD_US_BANK_ACCOUNT.getRoute());
+        });
+
+        test('carries shouldSetUpUSBankAccount to the verify account page when the user is not validated', async () => {
+            openPersonalBankAccountSetupView({shouldSetUpUSBankAccount: true, isUserValidated: false});
+            await waitForBatchedUpdates();
+
+            expect(Navigation.navigate).toHaveBeenCalledWith(createDynamicRoute(DYNAMIC_ROUTES.ADD_BANK_ACCOUNT_VERIFY_ACCOUNT.getRoute(true, true)));
+            expect(Navigation.navigate).toHaveBeenCalledWith(expect.stringContaining('shouldSetUpUSBankAccount=true'));
         });
     });
 

--- a/tests/unit/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPageTest.tsx
+++ b/tests/unit/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPageTest.tsx
@@ -19,11 +19,11 @@ import Onyx from 'react-native-onyx';
 
 import waitForBatchedUpdates from '../../../../utils/waitForBatchedUpdates';
 
-const mockVerifyAccountPageBase = jest.fn(() => null);
+const mockVerifyAccountPageBase = jest.fn<null, [Record<string, unknown>]>(() => null);
 
 jest.mock('@pages/settings/VerifyAccountPageBase', () => ({
     __esModule: true,
-    default: () => mockVerifyAccountPageBase(),
+    default: (props: Record<string, unknown>) => mockVerifyAccountPageBase(props),
 }));
 
 jest.mock('@hooks/useDynamicBackPath', () => jest.fn(() => 'settings/wallet'));

--- a/tests/unit/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPageTest.tsx
+++ b/tests/unit/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPageTest.tsx
@@ -23,7 +23,7 @@ const mockVerifyAccountPageBase = jest.fn(() => null);
 
 jest.mock('@pages/settings/VerifyAccountPageBase', () => ({
     __esModule: true,
-    default: (props: Record<string, unknown>) => mockVerifyAccountPageBase(props),
+    default: () => mockVerifyAccountPageBase(),
 }));
 
 jest.mock('@hooks/useDynamicBackPath', () => jest.fn(() => 'settings/wallet'));

--- a/tests/unit/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPageTest.tsx
+++ b/tests/unit/pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPageTest.tsx
@@ -1,0 +1,97 @@
+import {render} from '@testing-library/react-native';
+
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import {navigationRef} from '@libs/Navigation/Navigation';
+import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
+import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+import {hasActiveAdminWorkspaces} from '@libs/PolicyUtils';
+
+import DynamicAddBankAccountVerifyAccountPage from '@pages/settings/Wallet/DynamicAddBankAccountVerifyAccountPage';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
+
+import {NavigationContainer} from '@react-navigation/native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdates from '../../../../utils/waitForBatchedUpdates';
+
+const mockVerifyAccountPageBase = jest.fn(() => null);
+
+jest.mock('@pages/settings/VerifyAccountPageBase', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => mockVerifyAccountPageBase(props),
+}));
+
+jest.mock('@hooks/useDynamicBackPath', () => jest.fn(() => 'settings/wallet'));
+
+jest.mock('@libs/PolicyUtils', () => ({
+    ...jest.requireActual<Record<string, unknown>>('@libs/PolicyUtils'),
+    hasActiveAdminWorkspaces: jest.fn(),
+}));
+
+const mockedHasActiveAdminWorkspaces = jest.mocked(hasActiveAdminWorkspaces);
+
+const Stack = createPlatformStackNavigator<SettingsNavigatorParamList>();
+
+function renderPage(params: SettingsNavigatorParamList[typeof SCREENS.SETTINGS.DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT]) {
+    return render(
+        <OnyxListItemProvider>
+            <NavigationContainer ref={navigationRef}>
+                <Stack.Navigator initialRouteName={SCREENS.SETTINGS.DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT}>
+                    <Stack.Screen
+                        name={SCREENS.SETTINGS.DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT}
+                        component={DynamicAddBankAccountVerifyAccountPage}
+                        initialParams={params}
+                    />
+                </Stack.Navigator>
+            </NavigationContainer>
+        </OnyxListItemProvider>,
+    );
+}
+
+describe('DynamicAddBankAccountVerifyAccountPage', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(() => {
+        mockVerifyAccountPageBase.mockClear();
+        return Onyx.clear().then(waitForBatchedUpdates);
+    });
+
+    // The forward path must mirror the validated branch of openPersonalBankAccountSetupView: shouldSetUpUSBankAccount wins over
+    // the purpose screen, so a user who validates here lands in the same flow a validated user is sent to directly.
+    it.each([
+        {
+            name: 'US bank account flow when shouldSetUpUSBankAccount is set (admin)',
+            params: {shouldSetUpUSBankAccount: 'true'} as const,
+            isAdmin: true,
+            expected: ROUTES.SETTINGS_ADD_US_BANK_ACCOUNT.getRoute(),
+        },
+        {
+            name: 'US bank account flow when shouldSetUpUSBankAccount is set (non-admin)',
+            params: {shouldSetUpUSBankAccount: 'true'} as const,
+            isAdmin: false,
+            expected: ROUTES.SETTINGS_ADD_US_BANK_ACCOUNT.getRoute(),
+        },
+        {name: 'purpose screen for admins without any flags', params: undefined, isAdmin: true, expected: ROUTES.SETTINGS_BANK_ACCOUNT_PURPOSE},
+        {name: 'add bank account for non-admins without any flags', params: undefined, isAdmin: false, expected: ROUTES.SETTINGS_ADD_BANK_ACCOUNT.getRoute('settings/wallet')},
+        {
+            name: 'add bank account for admins when shouldSkipPurposeSelection is set',
+            params: {shouldSkipPurposeSelection: 'true'} as const,
+            isAdmin: true,
+            expected: ROUTES.SETTINGS_ADD_BANK_ACCOUNT.getRoute('settings/wallet'),
+        },
+    ])('forwards to the $name', async ({params, isAdmin, expected}) => {
+        mockedHasActiveAdminWorkspaces.mockReturnValue(isAdmin);
+
+        renderPage(params);
+        await waitForBatchedUpdates();
+
+        expect(mockVerifyAccountPageBase).toHaveBeenCalledWith(expect.objectContaining({navigateForwardTo: expected}));
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

The `add-bank-account` verify page now mirrors the `shouldSetUpUSBankAccount` flag from `openPersonalBankAccountSetupView `via a query param and forwards to the US bank account flow after validation, so the post-verification path can no longer silently diverge from where a validated user is sent directly.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98069
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

> [!IMPORTANT]
> The flow is unreachable by user (as issue states). Following test steps can be forced on web.

1. Open app in web browser
2. Use unvalidated account or paste `Onyx.merge('account', {validated: false});` in the console
3. Paste `/add-bank-account/verify-account?shouldSkipPurposeSelection=true&shouldSetUpUSBankAccount=true` url 
4. Verify that the "Verify account" magic-code RHP is shown.
5. Validate with magic code or  paste `Onyx.merge('account', {validated: true);` in the console
6.  Verify that the app forwards to `/settings/wallet/add-us-bank-account` (US bank account flow)

7. Repeat step 2
8.  Paste `/add-bank-account/verify-account?shouldSkipPurposeSelection=true`  url (w/o `shouldSetUpUSBankAccount` ) 
9. Validate with magic code or  paste `Onyx.merge('account', {validated: true);` in the console
10. Verify app forwards to `/settings/wallet/add-bank-account/country`  



### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

N/A

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/92b97c3b-d69b-441e-87b7-fe61df6ff736


</details>
