### PR TITLE
Count in-flight Pusher applies as applied when detecting update gaps

### DIFF
--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -24,6 +24,12 @@ let lastUpdateIDAppliedToClient: number | undefined = 0;
 // applied so queued WRITE responses don't look like gaps; reset if the flush fails so recovery can kick in.
 let lastUpdateIDPendingFlush = 0;
 
+// Highest update ID accepted into the Pusher apply chain but not yet persisted. applyPusherOnyxUpdates serializes
+// every event through pusherEventsPromise, so the watermark trails an update the client already holds by p50 209ms
+// and p90 1.7s in production. Gap detection treats these as applied, otherwise the next event in the chain reads as
+// a gap and pauses the queue to refetch data we are in the middle of applying.
+let lastUpdateIDPendingApply = 0;
+
 function getEffectiveLastUpdateID(): number {
     return Math.max(lastUpdateIDAppliedToClient ?? 0, lastUpdateIDPendingFlush);
 }
@@ -38,10 +44,11 @@ Onyx.connectWithoutView({
     callback: (val) => {
         lastUpdateIDAppliedToClient = val;
 
-        // The persisted watermark is only ever cleared by Onyx.clear (sign-out), so drop the pending marker
+        // The persisted watermark is only ever cleared by Onyx.clear (sign-out), so drop the pending markers
         // too — a stale value from the previous session would mask real gaps after signing back in.
         if (val === undefined) {
             lastUpdateIDPendingFlush = 0;
+            lastUpdateIDPendingApply = 0;
         }
     },
 });
@@ -209,6 +216,10 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
                 return result;
             })
             .catch((error) => {
+                // The updates never landed, so stop counting them as applied — the next gap check then sees the
+                // missing range against the persisted watermark and triggers recovery.
+                lastUpdateIDPendingApply = 0;
+
                 if (shouldAdvanceLastUpdateID) {
                     Log.alert('[OnyxUpdateManagerError] Applying the updates failed, not advancing lastUpdateID so the client can recover on the next reconnect', {
                         type,
@@ -241,6 +252,9 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
         return advanceLastUpdateIDAfterApply(applyPromise);
     }
     if (type === CONST.ONYX_UPDATE_TYPES.PUSHER && updates) {
+        if (shouldAdvanceLastUpdateID) {
+            lastUpdateIDPendingApply = Math.max(lastUpdateIDPendingApply, Number(lastUpdateID));
+        }
         return advanceLastUpdateIDAfterApply(applyPusherOnyxUpdates(updates, Number(lastUpdateID)));
     }
     if (type === CONST.ONYX_UPDATE_TYPES.AIRSHIP && updates) {
@@ -282,9 +296,10 @@ function doesClientNeedToBeUpdated({previousUpdateID, clientLastUpdateID}: DoesC
         return false;
     }
 
-    // Updates staged for the deferred WRITE flush count as applied here, otherwise the responses of queued
-    // WRITE requests would look like gaps until the flush runs and needlessly pause the queue to refetch.
-    const lastUpdateIDFromClient = Math.max(clientLastUpdateID ?? lastUpdateIDAppliedToClient ?? 0, lastUpdateIDPendingFlush);
+    // Updates staged for the deferred WRITE flush, and Pusher updates still working through the apply chain, count
+    // as applied here. Otherwise the responses of queued WRITE requests, and the event chained on an update we are
+    // already applying, would look like gaps and needlessly pause the queue to refetch data the client already has.
+    const lastUpdateIDFromClient = Math.max(clientLastUpdateID ?? lastUpdateIDAppliedToClient ?? 0, lastUpdateIDPendingFlush, lastUpdateIDPendingApply);
 
     // If we don't have any value in lastUpdateIDFromClient, this is the first time we're receiving anything, so we need to do a last reconnectApp
     if (!lastUpdateIDFromClient) {

--- a/tests/actions/ApplyOnyxUpdatesReliablyTest.ts
+++ b/tests/actions/ApplyOnyxUpdatesReliablyTest.ts
@@ -1,0 +1,102 @@
+import applyOnyxUpdatesReliably from '@libs/actions/applyOnyxUpdatesReliably';
+import {isPaused as isSequentialQueuePaused, unpause as unpauseSequentialQueue} from '@libs/Network/SequentialQueue';
+import PusherUtils from '@libs/PusherUtils';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {OnyxUpdatesFromServer} from '@src/types/onyx';
+
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+const pusherUpdate = (previousUpdateID: number, lastUpdateID: number): OnyxUpdatesFromServer<never> => ({
+    type: CONST.ONYX_UPDATE_TYPES.PUSHER,
+    previousUpdateID,
+    lastUpdateID,
+    updates: [{eventType: 'onyxApiUpdate', data: []}],
+});
+
+describe('actions/applyOnyxUpdatesReliably', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        unpauseSequentialQueue();
+        await Onyx.clear();
+        await Onyx.set(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 10);
+        await waitForBatchedUpdates();
+    });
+
+    it('does not pause the queue for an event chained on an update that is still being applied', async () => {
+        // Given update 20 arrived over Pusher and its apply is held mid-flight, so the watermark is still at 10
+        let releaseApply: () => void = () => {};
+        const handlerSpy = jest.spyOn(PusherUtils, 'triggerMultiEventHandler').mockReturnValueOnce(
+            new Promise<void>((resolve) => {
+                releaseApply = resolve;
+            }),
+        );
+        const heldApply = applyOnyxUpdatesReliably(pusherUpdate(10, 20));
+        await waitForBatchedUpdates();
+
+        // When the next event arrives, chained on the update we are still applying
+        const chainedApply = applyOnyxUpdatesReliably(pusherUpdate(20, 30));
+        await waitForBatchedUpdates();
+
+        // Then the queue is not paused to refetch data the client already received
+        expect(isSequentialQueuePaused()).toBe(false);
+
+        releaseApply();
+        await heldApply;
+        await chainedApply;
+        handlerSpy.mockRestore();
+    });
+
+    it('does not let an update left mid-apply by the previous session mask a gap after signing back in', async () => {
+        // Given update 20 arrived over Pusher and its apply is held mid-flight
+        let releaseApply: () => void = () => {};
+        const handlerSpy = jest.spyOn(PusherUtils, 'triggerMultiEventHandler').mockReturnValueOnce(
+            new Promise<void>((resolve) => {
+                releaseApply = resolve;
+            }),
+        );
+        const heldApply = applyOnyxUpdatesReliably(pusherUpdate(10, 20));
+        await waitForBatchedUpdates();
+
+        // When the user signs out, which clears the persisted watermark
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+
+        // And an event chained on update 20 arrives in the new session
+        const chainedApply = applyOnyxUpdatesReliably(pusherUpdate(20, 30));
+        await waitForBatchedUpdates();
+
+        // Then the queue is paused, because the new session never received update 20
+        expect(isSequentialQueuePaused()).toBe(true);
+
+        releaseApply();
+        await heldApply;
+        await chainedApply;
+        handlerSpy.mockRestore();
+    });
+
+    // A failed apply leaves the module-level Pusher chain rejected, which poisons every later Pusher apply, so keep
+    // this case last and add new ones above it.
+    it('pauses the queue when the update it was waiting on failed to apply', async () => {
+        // Given applying update 20 from Pusher failed
+        const handlerSpy = jest.spyOn(PusherUtils, 'triggerMultiEventHandler').mockRejectedValueOnce(new Error('storage write failed'));
+        await expect(applyOnyxUpdatesReliably(pusherUpdate(10, 20))).rejects.toThrow('storage write failed');
+        await waitForBatchedUpdates();
+
+        // When an event chained on that update arrives
+        const chainedApply = applyOnyxUpdatesReliably(pusherUpdate(20, 30));
+        chainedApply.catch(() => {});
+        await waitForBatchedUpdates();
+
+        // Then the queue is paused so the update that never landed can be refetched
+        expect(isSequentialQueuePaused()).toBe(true);
+
+        handlerSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

The client keeps one number: the last update ID it has applied. Every Pusher event carries the ID of the update that should come immediately before it. When that predecessor is ahead of the client's number, the client concludes it missed something, pauses the write queue and fetches the missing range.

Pusher updates do not apply the moment they arrive. `applyPusherOnyxUpdates` chains every event onto one module-level promise so events apply in order, and the watermark only moves once that chain settles. Between arrival and settle the client holds the update but its number still says otherwise, so the very next event in the chain reads as a gap. The client pauses its own write queue and asks the server for data it is part-way through writing.

I measured the size of this over one production hour, 2026-08-26 09:00-10:00 UTC, by joining three client log lines per session on the update ID: the gap detection, the Pusher arrival of the update it named as missing, and that update's apply completing. Across **7,316 gap detections**, 1,794 (**24.5%**) had the update delivered before the gap fired and applied after it. Median arrival to detection was 209ms, median detection to apply 229ms.

For scale, the rest of the same 7,316: 54.6% never showed a Pusher arrival at all, which is mostly our own WRITEs being excluded from the push by design; 13.4% arrived *after* the gap fired, i.e. genuine reordering; 12.5% arrived but their apply was not observed; 0.3% were a watermark-write race. Restricting to the detections where both an arrival and an apply were recorded, this bucket is 74.0% of 1,978 — but that denominator selects for the very thing being measured, so 24.5% is the number to judge this change by.

So the client now tracks the highest update ID it has accepted into the Pusher apply chain and counts that as applied while it is in flight. This mirrors `lastUpdateIDPendingFlush`, which already does the same for WRITE updates staged for the deferred flush. The marker is reset if the apply fails, so an update that never landed goes back to being a gap and recovery can refetch it, and on sign-out, so a value left over from the previous session cannot hide a real gap in the next one.

There is no clear-on-success path because none is needed: a successful apply advances the persisted watermark to at least the marker, so a leftover value can never raise the maximum.

This is one of three mechanisms behind these gaps and it does not touch the other two. Reordering (13.4%) needs a short grace window before committing to pause-and-fetch. The larger bucket, our own WRITEs arriving only over HTTPS because we exclude the originating socket from the push, needs the gap check to know a write is in flight; the pending-flush marker structurally cannot cover it, because at that moment the client has not yet been told its own update ID.

### Fixed Issues

$
PROPOSAL: N/A

Internal tracking: callstack-internal/expensify-issues#2875 (measurement in [this comment](https://github.com/callstack-internal/expensify-issues/issues/2875#issuecomment-5450687054)), sub-issue of #2739. A public Expensify/App issue still needs opening for this one, per the one-issue-per-PR convention used for #98777.

### Tests

1. Check out this branch and run `npm run test -- tests/actions/ApplyOnyxUpdatesReliablyTest.ts`.
2. All three cases pass here. Each one fails on `main`, and each was written before the fix:
   - `does not pause the queue for an event chained on an update that is still being applied` — the behaviour this PR changes.
   - `does not let an update left mid-apply by the previous session mask a gap after signing back in` — covers the sign-out reset.
   - `pauses the queue when the update it was waiting on failed to apply` — covers the failure reset, i.e. a real gap is still detected.
3. The tests assert on `SequentialQueue.isPaused()` rather than on the marker, so they describe the queue behaviour and not the mechanism.
4. Regression: `npm run test -- tests/unit/OnyxUpdatesTest.ts tests/unit/OnyxUpdateManagerTest.ts tests/actions/OnyxUpdateManagerTest.ts tests/unit/SequentialQueueTest.ts` — 88 passing, unchanged.

### Known issue found while writing this, not fixed here

`pusherEventsPromise` is only ever reassigned from itself and has no `.catch`, so a single rejected Pusher apply leaves it rejected and every later Pusher update for that session rejects too. Rare (`[OnyxUpdateManagerError]` runs about one per ten-minute band fleet-wide) but total when it happens. It shows up in the test file as the failure case having to run last. Worth its own issue.

### Offline tests

Same as tests above; this path is exercised by Pusher events and does not require a specific offline flow.

### QA Steps

No user-visible behaviour changes on its own. Verified by the unit tests above.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes
- [x] I added steps for local testing in the `Tests` section
- [x] I added unit tests for the changes

