### PR TITLE
Fix Home-Tapping disabled Send button with empty text removes focus and closes keypad

### DIFF
--- a/src/libs/NavigationFocusReturn/index.ts
+++ b/src/libs/NavigationFocusReturn/index.ts
@@ -184,6 +184,15 @@ function isFocusRestoreInProgress(): boolean {
     return isRestoringFocus;
 }
 
+/** Seeds the trigger candidate for focus restoration */
+function seedTriggerCandidate(element: HTMLElement): void {
+    if (getHadTabNavigation()) {
+        return;
+    }
+    lastMouseTrigger = element;
+    lastMouseTriggerAt = performance.now();
+}
+
 /* Empty = nothing focusable yet (detached mid-remount, missing attributes); caller's retry budget owns cleanup, not this function. */
 function pickRestoreCandidates(entry: TriggerEntry): HTMLElement[] {
     const candidates: HTMLElement[] = [];
@@ -290,6 +299,7 @@ function restoreTriggerForRoute(routeKey: string, restoreBaseline: Element | nul
         if (after === candidate) {
             triggerMap.delete(routeKey);
             lastRestoreTarget = candidate;
+            seedTriggerCandidate(candidate);
             scheduleReturnHoldRelease();
             return true;
         }
@@ -297,6 +307,7 @@ function restoreTriggerForRoute(routeKey: string, restoreBaseline: Element | nul
         if (after !== before && after && after !== document.body) {
             triggerMap.delete(routeKey);
             lastRestoreTarget = after instanceof HTMLElement ? after : candidate;
+            seedTriggerCandidate(lastRestoreTarget);
             scheduleReturnHoldRelease();
             return true;
         }

--- a/src/pages/home/ForYouSection/ConciergePromptBox.tsx
+++ b/src/pages/home/ForYouSection/ConciergePromptBox.tsx
@@ -199,12 +199,15 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
             </View>
             <View style={styles.pRelative}>
                 <View
+                    testID="ConciergePromptBox"
                     style={[
                         isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
                         styles.flexRow,
                         styles.chatItemComposeBox,
                         isExceedingMaxLength && styles.borderColorDanger,
                     ]}
+                    // Claim taps here so that the ScrollView does not and we don't lose focus on disabled Send button tap
+                    onStartShouldSetResponder={() => true}
                 >
                     <View style={styles.composerButtonColumn}>
                         <View style={styles.composerButtonStack}>
@@ -337,6 +340,7 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
                             icon={icons.Send}
                             label={translate('common.send')}
                             onPress={submit}
+                            onMouseDown={(e) => e.preventDefault()}
                         />
                     </View>
                 </View>

--- a/tests/ui/ConciergePromptBoxTest.tsx
+++ b/tests/ui/ConciergePromptBoxTest.tsx
@@ -16,6 +16,8 @@ import {isAnonymousUser, signOutAndRedirectToSignIn} from '@userActions/Session'
 import CONST from '@src/CONST';
 import type {FileObject} from '@src/types/utils/Attachment';
 
+import type {ViewProps} from 'react-native';
+
 import React, {useState} from 'react';
 
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
@@ -219,6 +221,20 @@ describe('ConciergePromptBox', () => {
             // Then neither the send nor the "+" button can be used
             expect(screen.getByLabelText(SEND_BUTTON)).toBeDisabled();
             expect(screen.getByLabelText(PLUS_BUTTON)).toBeDisabled();
+        });
+    });
+
+    describe('focus', () => {
+        it('claims taps that land on the box itself', () => {
+            // Given a rendered prompt box
+            render(<ConciergePromptBoxWrapper />);
+
+            // When the box is asked whether it wants the touch
+            // Then it claims it, so the surrounding ScrollView never becomes the responder and cannot blur the input,
+            // and nothing is handled on release, so the tap neither steals nor grants focus
+            const box = screen.getByTestId('ConciergePromptBox');
+            expect(fireEvent(box, 'startShouldSetResponder')).toBe(true);
+            expect((box.props as ViewProps).onResponderRelease).toBeUndefined();
         });
     });
 

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -1978,6 +1978,30 @@ describe('restoreTriggerForRoute', () => {
         expect(launcherSpy).not.toHaveBeenCalled();
     });
 
+    it('re-seeds the redirect target (not the captured primary) as the trigger candidate for the next round trip', () => {
+        // Mouse modality: focusin does not re-record the restored element, so seedTriggerCandidate is the only source.
+        simulateMouse();
+        const primary = appendButton();
+        const redirectTarget = appendButton();
+        setLastMouseTriggerForTests(primary);
+        captureTriggerForRoute('route-a');
+
+        // Primary's .focus() handler redirects focus to redirectTarget (simulating a composite widget).
+        const focusSpy = jest.spyOn(primary, 'focus').mockImplementation(() => {
+            redirectTarget.focus();
+        });
+        expect(restoreTriggerForRoute('route-a')).toBe(true);
+        expect(document.activeElement).toBe(redirectTarget);
+        focusSpy.mockRestore();
+
+        // Second round trip, no click in between. The capture must reach for the element that actually holds focus,
+        // not the primary whose onFocus bounced away from it.
+        redirectTarget.blur();
+        captureTriggerForRoute('route-b');
+        expect(restoreTriggerForRoute('route-b')).toBe(true);
+        expect(document.activeElement).toBe(redirectTarget);
+    });
+
     it('must not treat pre-existing non-body focus as an onFocus redirect when the candidate silently no-ops', () => {
         const launcher = appendButton();
         const primary = appendButton();
@@ -2383,6 +2407,37 @@ describe('handleStateChange integration', () => {
         // Either the scheduled restore fired or we consume it manually — both prove capture happened.
         const stored = restoreTriggerForRoute('a');
         expect(stored || document.activeElement === trigger).toBe(true);
+    });
+
+    it('restores on every round trip when the navigation is keyboard-shortcut driven in mouse modality (issue #99569)', () => {
+        withFakeTimers(() => {
+            handleStateChange(onA);
+
+            // User clicks into a composer and types — pointerdown puts us in mouse modality, so focusin never
+            // records lastInteractiveElement, and Cmd+Shift+K latches no Enter/Space activation.
+            const composer = document.createElement('textarea');
+            document.body.appendChild(composer);
+            composer.dispatchEvent(new MouseEvent('pointerdown', {bubbles: true}));
+            composer.focus();
+
+            // Round trip 1: open the RHP with the shortcut, then click Back.
+            handleStateChange(onAB);
+            const backButton = appendButton();
+            backButton.dispatchEvent(new MouseEvent('pointerdown', {bubbles: true}));
+            backButton.remove();
+            composer.blur();
+            handleStateChange(onA);
+            flushTransitions();
+            expect(document.activeElement).toBe(composer);
+
+            // Round trip 2: the shortcut again, with no click on the composer in between. The backward transition
+            // cleared the click-tracked trigger, so only the restore's re-seed can supply it.
+            handleStateChange(onAB);
+            composer.blur();
+            handleStateChange(onA);
+            flushTransitions();
+            expect(document.activeElement).toBe(composer);
+        });
     });
 
     it('should do nothing when the focused route has not changed', () => {

--- a/tests/unit/NavigationFocusReturnTest.ts
+++ b/tests/unit/NavigationFocusReturnTest.ts
@@ -2413,7 +2413,7 @@ describe('handleStateChange integration', () => {
         withFakeTimers(() => {
             handleStateChange(onA);
 
-            // User clicks into a composer and types — pointerdown puts us in mouse modality, so focusin never
+            // User clicks into a composer and types, which puts us in mouse modality, so focusin never
             // records lastInteractiveElement, and Cmd+Shift+K latches no Enter/Space activation.
             const composer = document.createElement('textarea');
             document.body.appendChild(composer);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Tapping the disabled Send button (or the box itself) in the Home Concierge prompt blurred the composer and dismissed the keyboard. `ConciergePromptBox` now claims the touch via `onStartShouldSetResponder` so the surrounding `ScrollView` never becomes the responder, and `SubmitDraftButton` gets `onMouseDown={(e) => e.preventDefault()}` to keep focus on web. Added a UI test.

`NavigationFocusReturn` now re-seeds the restored element as the mouse trigger candidate, so repeated CMD+SHIFT+K / CMD+J RHP round trips keep restoring focus.



### Fixed Issues

$ https://github.com/Expensify/App/issues/99573
$ https://github.com/Expensify/App/issues/99569
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

Tapping disabled Send button with empty text removes focus and closes keypad:

1. Launch app
2. In Home, keep cursor on search box
3. Note box is outlined green active with keypad opened and since no text -> send button grey inactive
4. Tap grey send button
5. Verify tapping the grey/inactive Send button when the compose/search box is empty should have consistent behavior across Home and Concierge. The button should remain inactive and should not dismiss the keyboard or remove focus.

Prompt box is not focused after closing CMD+SHIFT+K or CMD+J RHP for the second time:

1. Go to Home.
2. Type anything on Concierge prompt box.
3. Press CMD+SHIFT+K or CMD+J.
4. Click RHP back button.
5. Verify Prompt box is focused.
6. Press CMD+SHIFT+K or CMD+J.
7. Click RHP back button.
8. Verify Prompt box will be focused after closing CMD+SHIFT+K or CMD+J RHP.


 


- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/046d432f-68fd-4ef2-ac5d-7257f1395111



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/c269ef68-1d28-4c6c-b216-0f4f07f38107


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/5277c86e-240c-44c2-8e65-8dca76f120a6


https://github.com/user-attachments/assets/9178460b-c351-4f54-a9cd-89efe3dbc686

https://github.com/user-attachments/assets/a38dfad3-4377-4ce0-9e5f-601c2d473309



<!-- add screenshots or videos here -->

</details>
