### PR TITLE
[No QA] Fix import/no-cycle - part 2 

### DIFF
--- a/src/components/ConnectToCertiniaFlow/index.tsx
+++ b/src/components/ConnectToCertiniaFlow/index.tsx
@@ -9,7 +9,7 @@ import usePopoverPosition from '@hooks/usePopoverPosition';
 import {isAuthenticationError} from '@libs/actions/connections';
 import Navigation from '@libs/Navigation/Navigation';
 
-import {useAccountingState} from '@pages/workspace/accounting/AccountingContext';
+import {useAccountingState} from '@pages/workspace/accounting/AccountingContext/contexts';
 
 import type {AnchorPosition} from '@styles/index';
 

--- a/src/components/ConnectToNetSuiteFlow/index.tsx
+++ b/src/components/ConnectToNetSuiteFlow/index.tsx
@@ -9,7 +9,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {isAuthenticationError} from '@libs/actions/connections';
 import Navigation from '@libs/Navigation/Navigation';
 
-import {useAccountingState} from '@pages/workspace/accounting/AccountingContext';
+import {useAccountingState} from '@pages/workspace/accounting/AccountingContext/contexts';
 import {getInitialSubPageForNetsuiteTokenInput} from '@pages/workspace/accounting/netsuite/utils';
 
 import type {AnchorPosition} from '@styles/index';

--- a/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
+++ b/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
@@ -12,7 +12,7 @@ import usePopoverPosition from '@hooks/usePopoverPosition';
 
 import {isAuthenticationError} from '@libs/actions/connections';
 
-import {useAccountingState} from '@pages/workspace/accounting/AccountingContext';
+import {useAccountingState} from '@pages/workspace/accounting/AccountingContext/contexts';
 
 import type {AnchorPosition} from '@styles/index';
 

--- a/src/components/MultifactorAuthentication/config/scenarios/ChangePIN.tsx
+++ b/src/components/MultifactorAuthentication/config/scenarios/ChangePIN.tsx
@@ -2,7 +2,7 @@ import {DefaultSuccessScreen} from '@components/MultifactorAuthentication/compon
 import createScreenWithDefaults from '@components/MultifactorAuthentication/components/OutcomeScreen/createScreenWithDefaults';
 import {DefaultClientFailureScreen, DefaultServerFailureScreen} from '@components/MultifactorAuthentication/components/OutcomeScreen/FailureScreen/defaultScreens';
 import type {MultifactorAuthenticationScenarioCustomConfig} from '@components/MultifactorAuthentication/config/types';
-import {useMultifactorAuthenticationState} from '@components/MultifactorAuthentication/Context';
+import {useMultifactorAuthenticationState} from '@components/MultifactorAuthentication/Context/MultifactorAuthenticationStateContext';
 
 import {changePINForCard} from '@libs/actions/MultifactorAuthentication';
 import Navigation from '@libs/Navigation/Navigation';

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,6 +1,6 @@
 import useTheme from '@hooks/useTheme';
 
-import {containsOnlyCustomEmoji} from '@libs/EmojiUtils';
+import {containsOnlyCustomEmoji} from '@libs/CustomEmojiUtils';
 
 import type {TextVariant} from '@styles/typography';
 import {textVariants} from '@styles/typography';

--- a/src/libs/CustomEmojiUtils.ts
+++ b/src/libs/CustomEmojiUtils.ts
@@ -1,0 +1,26 @@
+import CONST from '@src/CONST';
+
+/**
+ * Custom emojis are the private use area code points we render with our own font. These two predicates live
+ * outside EmojiUtils so that components can use them without importing EmojiUtils, which renders components
+ * of its own and would close an import cycle.
+ */
+function containsCustomEmoji(text?: string): boolean {
+    if (!text) {
+        return false;
+    }
+
+    const privateUseAreaRegex = CONST.REGEX.PRIVATE_USER_AREA;
+    return privateUseAreaRegex.test(text);
+}
+
+function containsOnlyCustomEmoji(text?: string): boolean {
+    if (!text) {
+        return false;
+    }
+
+    const privateUseAreaRegex = CONST.REGEX.ONLY_PRIVATE_USER_AREA;
+    return privateUseAreaRegex.test(text);
+}
+
+export {containsCustomEmoji, containsOnlyCustomEmoji};

--- a/src/libs/EmojiUtils.tsx
+++ b/src/libs/EmojiUtils.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import type {getEmojiTrie as getEmojiTrieType} from './EmojiTrie';
 
 import {isSafari} from './Browser';
+import {containsCustomEmoji, containsOnlyCustomEmoji} from './CustomEmojiUtils';
 import memoize from './memoize';
 
 type HeaderIndices = {code: string; index: number; icon: IconAsset};
@@ -871,24 +872,6 @@ function getProcessedText(processedTextArray: TextWithEmoji[], style: StyleProp<
             text
         ),
     );
-}
-
-function containsCustomEmoji(text?: string): boolean {
-    if (!text) {
-        return false;
-    }
-
-    const privateUseAreaRegex = CONST.REGEX.PRIVATE_USER_AREA;
-    return privateUseAreaRegex.test(text);
-}
-
-function containsOnlyCustomEmoji(text?: string): boolean {
-    if (!text) {
-        return false;
-    }
-
-    const privateUseAreaRegex = CONST.REGEX.ONLY_PRIVATE_USER_AREA;
-    return privateUseAreaRegex.test(text);
 }
 
 /**

--- a/src/libs/GPSDraftDetailsUtils.ts
+++ b/src/libs/GPSDraftDetailsUtils.ts
@@ -6,13 +6,13 @@ import {stopGpsTripNotification} from '@pages/iou/request/step/IOURequestStepDis
 import type {GpsDraftDetails} from '@src/types/onyx';
 import type {GPSPoint, TrimmedGPSPoint} from '@src/types/onyx/GpsDraftDetails';
 import type {Routes, Waypoint} from '@src/types/onyx/Transaction';
-import geodesicDistance from '@src/utils/geodesicDistance';
 
 import type {SetRequired} from 'type-fest';
 
-import {hasStartedLocationUpdatesAsync, reverseGeocodeAsync, stopLocationUpdatesAsync} from 'expo-location';
+import {hasStartedLocationUpdatesAsync, stopLocationUpdatesAsync} from 'expo-location';
 
 import {removeLastSegment, setEndWaypointAddress, setIsTracking} from './actions/GPSDraftDetails';
+import {addressFromGpsPoint, calculateTrimmedEndPoint, coordinatesToString} from './GPSPointUtils';
 import {roundToTwoDecimalPlaces} from './NumberUtils';
 
 type GPSWaypointCollection = Record<string, SetRequired<Waypoint, 'keyForList' | 'lat' | 'lng' | 'address'>>;
@@ -115,27 +115,6 @@ function getStringifiedGPSCoordinates(gpsDraftDetails: GpsDraftDetails | undefin
     return JSON.stringify(updatedGpsPoints.map((points) => points.map(({lat, long}) => ({lng: long, lat}))));
 }
 
-async function addressFromGpsPoint(gpsPoint: {lat: number; long: number}): Promise<string | null> {
-    try {
-        const [location] = await reverseGeocodeAsync({latitude: gpsPoint.lat, longitude: gpsPoint.long});
-
-        if (!location) {
-            return null;
-        }
-
-        const address: string = location?.formattedAddress ?? [location?.name, location?.city, location?.region].filter(Boolean).join(', ');
-
-        return address;
-    } catch (error) {
-        console.error('[GPS distance request] Failed to reverse geocode location to postal address: ', error);
-        return null;
-    }
-}
-
-function coordinatesToString(gpsPoint: {lat: number; long: number}): string {
-    return `${gpsPoint.lat},${gpsPoint.long}`;
-}
-
 function isLastSegmentEmptyOrHasOnlyOnePoint(lastSegment: GPSPoint[]): boolean {
     if (lastSegment.length <= 1) {
         return true;
@@ -214,42 +193,6 @@ function getGpsPoints(gpsDraftDetails: GpsDraftDetails | undefined): GPSPoint[][
 
 function getFirstGpsPoint(gpsDraftDetails: GpsDraftDetails | undefined): GPSPoint | undefined {
     return gpsDraftDetails?.gpsPoints?.at(0)?.at(0);
-}
-
-function calculateTrimmedEndPoint(gpsPoints: GPSPoint[][], targetDistanceMeters: number): TrimmedGPSPoint | null {
-    let distanceTraveled = 0;
-
-    for (let segmentIndex = 0; segmentIndex < gpsPoints.length; segmentIndex++) {
-        const segment = gpsPoints.at(segmentIndex);
-
-        if (!segment) {
-            continue;
-        }
-
-        for (let pointIndex = 1; pointIndex < segment.length; pointIndex++) {
-            const previousPoint = segment.at(pointIndex - 1);
-            const currentPoint = segment.at(pointIndex);
-
-            if (!previousPoint || !currentPoint) {
-                continue;
-            }
-            const distanceBetweenPoints = geodesicDistance(previousPoint, currentPoint);
-
-            if (distanceTraveled + distanceBetweenPoints >= targetDistanceMeters) {
-                const fractionToInclude = distanceBetweenPoints === 0 ? 0 : (targetDistanceMeters - distanceTraveled) / distanceBetweenPoints;
-                const interpolatedPoint = {
-                    lat: previousPoint.lat + fractionToInclude * (currentPoint.lat - previousPoint.lat),
-                    long: previousPoint.long + fractionToInclude * (currentPoint.long - previousPoint.long),
-                };
-
-                return {...interpolatedPoint, segmentIndex, precedingPointIndex: pointIndex - 1};
-            }
-
-            distanceTraveled += distanceBetweenPoints;
-        }
-    }
-
-    return null;
 }
 
 function getTrimmedGpsTrip(gpsDraftDetails: GpsDraftDetails | undefined, trimmedEndPoint?: TrimmedGPSPoint): GPSPoint[][];

--- a/src/libs/GPSPointUtils.ts
+++ b/src/libs/GPSPointUtils.ts
@@ -1,0 +1,68 @@
+import type {GPSPoint, TrimmedGPSPoint} from '@src/types/onyx/GpsDraftDetails';
+import geodesicDistance from '@src/utils/geodesicDistance';
+
+import {reverseGeocodeAsync} from 'expo-location';
+
+/**
+ * Point level helpers for GPS distance requests. These live outside GPSDraftDetailsUtils so that
+ * actions/GPSDraftDetails can use them without importing GPSDraftDetailsUtils, which imports the action
+ * module back and would close an import cycle.
+ */
+async function addressFromGpsPoint(gpsPoint: {lat: number; long: number}): Promise<string | null> {
+    try {
+        const [location] = await reverseGeocodeAsync({latitude: gpsPoint.lat, longitude: gpsPoint.long});
+
+        if (!location) {
+            return null;
+        }
+
+        const address: string = location?.formattedAddress ?? [location?.name, location?.city, location?.region].filter(Boolean).join(', ');
+
+        return address;
+    } catch (error) {
+        console.error('[GPS distance request] Failed to reverse geocode location to postal address: ', error);
+        return null;
+    }
+}
+
+function coordinatesToString(gpsPoint: {lat: number; long: number}): string {
+    return `${gpsPoint.lat},${gpsPoint.long}`;
+}
+
+function calculateTrimmedEndPoint(gpsPoints: GPSPoint[][], targetDistanceMeters: number): TrimmedGPSPoint | null {
+    let distanceTraveled = 0;
+
+    for (let segmentIndex = 0; segmentIndex < gpsPoints.length; segmentIndex++) {
+        const segment = gpsPoints.at(segmentIndex);
+
+        if (!segment) {
+            continue;
+        }
+
+        for (let pointIndex = 1; pointIndex < segment.length; pointIndex++) {
+            const previousPoint = segment.at(pointIndex - 1);
+            const currentPoint = segment.at(pointIndex);
+
+            if (!previousPoint || !currentPoint) {
+                continue;
+            }
+            const distanceBetweenPoints = geodesicDistance(previousPoint, currentPoint);
+
+            if (distanceTraveled + distanceBetweenPoints >= targetDistanceMeters) {
+                const fractionToInclude = distanceBetweenPoints === 0 ? 0 : (targetDistanceMeters - distanceTraveled) / distanceBetweenPoints;
+                const interpolatedPoint = {
+                    lat: previousPoint.lat + fractionToInclude * (currentPoint.lat - previousPoint.lat),
+                    long: previousPoint.long + fractionToInclude * (currentPoint.long - previousPoint.long),
+                };
+
+                return {...interpolatedPoint, segmentIndex, precedingPointIndex: pointIndex - 1};
+            }
+
+            distanceTraveled += distanceBetweenPoints;
+        }
+    }
+
+    return null;
+}
+
+export {addressFromGpsPoint, coordinatesToString, calculateTrimmedEndPoint};

--- a/src/libs/actions/GPSDraftDetails.ts
+++ b/src/libs/actions/GPSDraftDetails.ts
@@ -1,4 +1,4 @@
-import {addressFromGpsPoint, calculateTrimmedEndPoint, coordinatesToString} from '@libs/GPSDraftDetailsUtils';
+import {addressFromGpsPoint, calculateTrimmedEndPoint, coordinatesToString} from '@libs/GPSPointUtils';
 
 import {GPS_DISTANCE_INTERVAL_METERS} from '@pages/iou/request/step/IOURequestStepDistanceGPS/const';
 import {updateGpsTripNotificationDistance} from '@pages/iou/request/step/IOURequestStepDistanceGPS/GPSNotifications';

--- a/src/pages/workspace/accounting/AccountingContext/contexts.ts
+++ b/src/pages/workspace/accounting/AccountingContext/contexts.ts
@@ -1,0 +1,23 @@
+import {createContext, useContext} from 'react';
+
+import type {AccountingActionsContextType, AccountingStateContextType} from './types';
+
+import {defaultAccountingActionsContextValue, defaultAccountingStateContextValue} from './default';
+
+/**
+ * The contexts and their hooks live here rather than next to the provider so that the integration flow
+ * components can read the accounting state without importing the provider, which imports the flow components
+ * back through accounting/utils and would close an import cycle.
+ */
+const AccountingStateContext = createContext<AccountingStateContextType>(defaultAccountingStateContextValue);
+const AccountingActionsContext = createContext<AccountingActionsContextType>(defaultAccountingActionsContextValue);
+
+function useAccountingState(): AccountingStateContextType {
+    return useContext(AccountingStateContext);
+}
+
+function useAccountingActions(): AccountingActionsContextType {
+    return useContext(AccountingActionsContext);
+}
+
+export {AccountingActionsContext, AccountingStateContext, useAccountingActions, useAccountingState};

--- a/src/pages/workspace/accounting/AccountingContext/index.tsx
+++ b/src/pages/workspace/accounting/AccountingContext/index.tsx
@@ -21,14 +21,12 @@ import type {RefObject} from 'react';
 import type {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 
-import React, {createContext, useCallback, useContext, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 
-import type {AccountingActionsContextType, AccountingStateContextType, ActiveIntegration, ActiveIntegrationState} from './types';
+import type {ActiveIntegration, ActiveIntegrationState} from './types';
 
-import {defaultAccountingActionsContextValue, defaultAccountingStateContextValue, popoverAnchorRefsInitialValue} from './default';
-
-const AccountingStateContext = createContext<AccountingStateContextType>(defaultAccountingStateContextValue);
-const AccountingActionsContext = createContext<AccountingActionsContextType>(defaultAccountingActionsContextValue);
+import {AccountingActionsContext, AccountingStateContext, useAccountingActions, useAccountingState} from './contexts';
+import {popoverAnchorRefsInitialValue} from './default';
 
 type AccountingContextProviderProps = ChildrenProps & {
     policy: OnyxEntry<Policy>;
@@ -199,14 +197,6 @@ function AccountingContextProvider({children, policy}: AccountingContextProvider
             </AccountingActionsContext.Provider>
         </AccountingStateContext.Provider>
     );
-}
-
-function useAccountingState(): AccountingStateContextType {
-    return useContext(AccountingStateContext);
-}
-
-function useAccountingActions(): AccountingActionsContextType {
-    return useContext(AccountingActionsContext);
 }
 
 export {AccountingContextProvider, useAccountingState, useAccountingActions};

--- a/tests/unit/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.test.tsx
+++ b/tests/unit/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.test.tsx
@@ -55,7 +55,7 @@ jest.mock('@libs/actions/connections', () => ({
     isAuthenticationError: jest.fn(() => false),
 }));
 
-jest.mock('@pages/workspace/accounting/AccountingContext', () => ({
+jest.mock('@pages/workspace/accounting/AccountingContext/contexts', () => ({
     useAccountingState: jest.fn(() => ({popoverAnchorRefs: undefined})),
 }));
 


### PR DESCRIPTION


<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Break four independent import cycles by extracting leaf modules and context hooks. No logic changes, already guarded with tests, ts and lint.

Breaks four circular imports. They are independent of each other, and each one is its own small cluster of 2
to 7 mutually dependent modules that dissolves completely when a single import moves.

Oxlint's `import/no-cycle` reports these; ESLint's copy of the same rule reports 0 because its resolver never
resolves our `@libs/...` style aliases, so it never builds a module graph. This is prep work for the Oxlint
migration, where the rule becomes a blocking check.

| Cycle | Fix |
| --- | --- |
| `components/Text.tsx` <-> `libs/EmojiUtils.tsx` | `containsCustomEmoji` and `containsOnlyCustomEmoji` move to a new leaf `libs/CustomEmojiUtils.ts`. `EmojiUtils` re-exports them, so its other consumers are untouched. |
| `libs/GPSDraftDetailsUtils.ts` <-> `libs/actions/GPSDraftDetails.ts` | `addressFromGpsPoint`, `coordinatesToString` and `calculateTrimmedEndPoint` move to a new leaf `libs/GPSPointUtils.ts`. `GPSDraftDetailsUtils` re-exports them. |
| MultifactorAuthentication `config` <-> `Context` (7 files) | `ChangePIN.tsx` imports `useMultifactorAuthenticationState` from the module that defines it instead of the `Context` barrel, matching what `AuthenticationMethodDescription.tsx` already does. |
| accounting `utils` <-> `AccountingContext` (6 files) | The two `createContext` calls and their hooks move to `AccountingContext/contexts.ts`. The three integration flow components read the hook from there. `index.tsx` re-exports it, so the pages are untouched. |

No function body changes, no Onyx write moves, no new side effects: the three new modules are pure functions
and two `createContext` calls. `createContext` is still called exactly once per context.

One test edit: `BaseConnectToQuickbooksOnlineFlow.test.tsx` mocks the accounting context, so its `jest.mock`
path follows the component's import. Numbers counted already with PR1: https://github.com/Expensify/App/pull/99670

| | Before | After |
| --- | --- | --- |
| `import/no-cycle` findings | 478 | **458** |
| Files reported on | 130 | **113** |


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99650
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Open app
2. Send emoji
3. Verify emoji is visible

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


https://github.com/user-attachments/assets/fc9c2187-8f46-4e29-a585-46d51e97e31c

