### PR TITLE
Fix: make company card CSV import help links reliably tappable on Android

### DIFF
--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -1,11 +1,12 @@
 import Button from '@components/ButtonComposed';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
+import {PressableWithoutFeedback} from '@components/Pressable';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
-import TextLink from '@components/TextLink';
 
+import useEnvironment from '@hooks/useEnvironment';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -19,6 +20,7 @@ import type {PlatformStackRouteProp} from '@navigation/PlatformStackNavigation/t
 import type {WorkspaceSplitNavigatorParamList} from '@navigation/types';
 
 import {setAddNewCompanyCardStepAndData} from '@userActions/CompanyCards';
+import {openLink} from '@userActions/Link';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -47,6 +49,7 @@ const CSV_TEMPLATE_CONTENT = [
 function ImportFromFileStep() {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
+    const {environmentURL} = useEnvironment();
     const {isOffline} = useNetwork();
     const icons = useMemoizedLazyExpensifyIcons(['Download']);
     const route = useRoute<PlatformStackRouteProp<WorkspaceSplitNavigatorParamList, typeof SCREENS.WORKSPACE.DYNAMIC_WORKSPACE_COMPANY_CARDS_ADD_NEW>>();
@@ -62,6 +65,18 @@ function ImportFromFileStep() {
     const downloadTemplate = () => {
         localFileDownload(CSV_TEMPLATE_FILE_NAME, CSV_TEMPLATE_CONTENT, translate);
     };
+
+    // The help text mixes plain copy with two tappable links (a client-side template download and an external help guide).
+    // On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
+    // which makes it unreliable to tap (e.g. at the minimum device font size). Rendering each link as its own PressableWithoutFeedback
+    // gives it a real native touch target, while splitting the plain copy into words keeps the paragraph flowing/wrapping naturally.
+    const createFileFeedHelpTextSegments: Array<{text: string; onPress?: () => void; role?: React.ComponentProps<typeof PressableWithoutFeedback>['role']}> = [
+        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')},
+        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink'), onPress: downloadTemplate, role: CONST.ROLE.BUTTON},
+        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')},
+        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink'), onPress: () => openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL), role: CONST.ROLE.LINK},
+        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd')},
+    ];
 
     const navigateToImport = () => {
         if (!companyCardLayoutName.trim()) {
@@ -89,13 +104,35 @@ function ImportFromFileStep() {
                 contentContainerStyle={styles.flexGrow1}
                 addBottomSafeAreaPadding
             >
-                <Text style={[styles.ph5, styles.mv3, styles.textSupporting]}>
-                    {translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')}
-                    <TextLink onPress={downloadTemplate}>{translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink')}</TextLink>
-                    {translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')}
-                    <TextLink href={CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL}>{translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink')}</TextLink>
-                    {translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd')}
-                </Text>
+                <View style={[styles.ph5, styles.mv3, styles.flexRow, styles.flexWrap, styles.alignItemsCenter]}>
+                    {createFileFeedHelpTextSegments.map((segment, segmentIndex) => {
+                        if (segment.onPress) {
+                            return (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <React.Fragment key={`${segment.text}-${segmentIndex}`}>
+                                    <PressableWithoutFeedback
+                                        role={segment.role}
+                                        accessibilityLabel={segment.text}
+                                        onPress={segment.onPress}
+                                        style={styles.dInlineFlex}
+                                    >
+                                        <Text style={[styles.textSupporting, styles.link]}>{segment.text}</Text>
+                                    </PressableWithoutFeedback>
+                                    <Text style={styles.textSupporting}> </Text>
+                                </React.Fragment>
+                            );
+                        }
+                        return (segment.text.match(/\S+\s*/g) ?? []).map((word, wordIndex) => (
+                            <Text
+                                // eslint-disable-next-line react/no-array-index-key
+                                key={`${segment.text}-${segmentIndex}-${wordIndex}`}
+                                style={styles.textSupporting}
+                            >
+                                {word}
+                            </Text>
+                        ));
+                    })}
+                </View>
                 <MenuItemWithTopDescription
                     description={translate('workspace.companyCards.addNewCard.companyCardLayoutName')}
                     title={companyCardLayoutName}

--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -31,6 +31,8 @@ import {useRoute} from '@react-navigation/native';
 import React, {useState} from 'react';
 import {View} from 'react-native';
 
+import WrappingText from './WrappingText';
+
 // cspell:disable
 // Example CSV shared with customers so they can see how to structure a company card import file.
 // Sourced from the Expensify Classic "Manage Company Cards" help article.
@@ -66,27 +68,6 @@ function ImportFromFileStep() {
         localFileDownload(CSV_TEMPLATE_FILE_NAME, CSV_TEMPLATE_CONTENT, translate);
     };
 
-    // The help text mixes plain copy with two tappable links (a client-side template download and an external help guide).
-    // On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
-    // which makes it unreliable to tap (e.g. at the minimum device font size). Rendering each link as its own PressableWithoutFeedback
-    // gives it a real native touch target, while splitting the plain copy into words keeps the paragraph flowing/wrapping naturally.
-    const renderPlainCopy = (text: string) =>
-        // Keep each word (with its own leading/trailing whitespace) as a separate node so the paragraph wraps in the flexWrap row.
-        // Preserving the run's own spacing means locales that don't use spaces around the links (e.g. Japanese, Chinese) aren't
-        // given extra spaces the translation never intended.
-        (text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
-            <Text
-                // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
-                // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
-                // within a run (the word text alone can't); the array position is what makes it unique.
-                // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
-                key={`${text}-${word}-${wordIndex}`}
-                style={styles.textSupporting}
-            >
-                {word}
-            </Text>
-        ));
-
     const navigateToImport = () => {
         if (!companyCardLayoutName.trim()) {
             setHasError(true);
@@ -114,7 +95,7 @@ function ImportFromFileStep() {
                 addBottomSafeAreaPadding
             >
                 <View style={[styles.ph5, styles.mv3, styles.flexRow, styles.flexWrap, styles.alignItemsCenter]}>
-                    {renderPlainCopy(translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart'))}
+                    <WrappingText text={translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')} />
                     <PressableWithoutFeedback
                         testID="ImportFromFileStep-TemplateLink"
                         role={CONST.ROLE.BUTTON}
@@ -125,7 +106,7 @@ function ImportFromFileStep() {
                     >
                         <Text style={[styles.textSupporting, styles.link]}>{translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink')}</Text>
                     </PressableWithoutFeedback>
-                    {renderPlainCopy(translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle'))}
+                    <WrappingText text={translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')} />
                     <PressableWithoutFeedback
                         testID="ImportFromFileStep-HelpGuideLink"
                         role={CONST.ROLE.LINK}
@@ -142,7 +123,7 @@ function ImportFromFileStep() {
                     >
                         <Text style={[styles.textSupporting, styles.link]}>{translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink')}</Text>
                     </PressableWithoutFeedback>
-                    {renderPlainCopy(translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd'))}
+                    <WrappingText text={translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd')} />
                 </View>
                 <MenuItemWithTopDescription
                     description={translate('workspace.companyCards.addNewCard.companyCardLayoutName')}

--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -74,7 +74,11 @@ function ImportFromFileStep() {
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')},
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink'), onPress: downloadTemplate, role: CONST.ROLE.BUTTON},
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')},
-        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink'), onPress: () => openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL), role: CONST.ROLE.LINK},
+        {
+            text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink'),
+            onPress: () => openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL),
+            role: CONST.ROLE.LINK,
+        },
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd')},
     ];
 

--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -70,14 +70,20 @@ function ImportFromFileStep() {
     // On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
     // which makes it unreliable to tap (e.g. at the minimum device font size). Rendering each link as its own PressableWithoutFeedback
     // gives it a real native touch target, while splitting the plain copy into words keeps the paragraph flowing/wrapping naturally.
-    const createFileFeedHelpTextSegments: Array<{text: string; onPress?: () => void; role?: React.ComponentProps<typeof PressableWithoutFeedback>['role']}> = [
+    const createFileFeedHelpTextSegments: Array<{text: string; onPress?: () => void; role?: React.ComponentProps<typeof PressableWithoutFeedback>['role']; sentryLabel?: string}> = [
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')},
-        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink'), onPress: downloadTemplate, role: CONST.ROLE.BUTTON},
+        {
+            text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink'),
+            onPress: downloadTemplate,
+            role: CONST.ROLE.BUTTON,
+            sentryLabel: 'ImportFromFileStep-TemplateLink',
+        },
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')},
         {
             text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink'),
             onPress: () => openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL),
             role: CONST.ROLE.LINK,
+            sentryLabel: 'ImportFromFileStep-HelpGuideLink',
         },
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd')},
     ];
@@ -117,6 +123,7 @@ function ImportFromFileStep() {
                                     <PressableWithoutFeedback
                                         role={segment.role}
                                         accessibilityLabel={segment.text}
+                                        sentryLabel={segment.sentryLabel}
                                         onPress={segment.onPress}
                                         style={styles.dInlineFlex}
                                     >

--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -127,12 +127,12 @@ function ImportFromFileStep() {
                 addBottomSafeAreaPadding
             >
                 <View style={[styles.ph5, styles.mv3, styles.flexRow, styles.flexWrap, styles.alignItemsCenter]}>
-                    {createFileFeedHelpTextSegments.map((segment, segmentIndex) => {
+                    {createFileFeedHelpTextSegments.map((segment) => {
                         if (segment.onPress) {
                             return (
                                 <PressableWithoutFeedback
-                                    // eslint-disable-next-line react/no-array-index-key
-                                    key={`${segment.text}-${segmentIndex}`}
+                                    // Each link segment's translated text is unique (template vs. help guide), so it's a stable key on its own.
+                                    key={segment.text}
                                     role={segment.role}
                                     href={segment.href}
                                     accessibilityLabel={segment.text}
@@ -149,8 +149,11 @@ function ImportFromFileStep() {
                         // (e.g. Japanese, Chinese) aren't given extra spaces the translation never intended.
                         return (segment.text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
                             <Text
-                                // eslint-disable-next-line react/no-array-index-key
-                                key={`${segment.text}-${segmentIndex}-${wordIndex}`}
+                                // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
+                                // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
+                                // within a segment (segment.text alone can't); the array position is what makes it unique.
+                                // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
+                                key={`${segment.text}-${word}-${wordIndex}`}
                                 style={styles.textSupporting}
                             >
                                 {word}

--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -70,35 +70,22 @@ function ImportFromFileStep() {
     // On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
     // which makes it unreliable to tap (e.g. at the minimum device font size). Rendering each link as its own PressableWithoutFeedback
     // gives it a real native touch target, while splitting the plain copy into words keeps the paragraph flowing/wrapping naturally.
-    const createFileFeedHelpTextSegments: Array<{
-        text: string;
-        onPress?: React.ComponentProps<typeof PressableWithoutFeedback>['onPress'];
-        href?: string;
-        role?: React.ComponentProps<typeof PressableWithoutFeedback>['role'];
-        sentryLabel?: string;
-    }> = [
-        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')},
-        {
-            text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink'),
-            onPress: downloadTemplate,
-            role: CONST.ROLE.BUTTON,
-            sentryLabel: 'ImportFromFileStep-TemplateLink',
-        },
-        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')},
-        {
-            text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink'),
-            // Pass href so the link renders as a real anchor on web (native link behavior: hover URL, open in a new tab, etc.),
-            // while onPress preventDefault()s the anchor's default navigation and routes through openLink on every platform.
-            href: CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL,
-            onPress: (event) => {
-                event?.preventDefault();
-                openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL);
-            },
-            role: CONST.ROLE.LINK,
-            sentryLabel: 'ImportFromFileStep-HelpGuideLink',
-        },
-        {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd')},
-    ];
+    const renderPlainCopy = (text: string) =>
+        // Keep each word (with its own leading/trailing whitespace) as a separate node so the paragraph wraps in the flexWrap row.
+        // Preserving the run's own spacing means locales that don't use spaces around the links (e.g. Japanese, Chinese) aren't
+        // given extra spaces the translation never intended.
+        (text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
+            <Text
+                // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
+                // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
+                // within a run (the word text alone can't); the array position is what makes it unique.
+                // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
+                key={`${text}-${word}-${wordIndex}`}
+                style={styles.textSupporting}
+            >
+                {word}
+            </Text>
+        ));
 
     const navigateToImport = () => {
         if (!companyCardLayoutName.trim()) {
@@ -127,39 +114,35 @@ function ImportFromFileStep() {
                 addBottomSafeAreaPadding
             >
                 <View style={[styles.ph5, styles.mv3, styles.flexRow, styles.flexWrap, styles.alignItemsCenter]}>
-                    {createFileFeedHelpTextSegments.map((segment) => {
-                        if (segment.onPress) {
-                            return (
-                                <PressableWithoutFeedback
-                                    // Each link segment's translated text is unique (template vs. help guide), so it's a stable key on its own.
-                                    key={segment.text}
-                                    role={segment.role}
-                                    href={segment.href}
-                                    accessibilityLabel={segment.text}
-                                    sentryLabel={segment.sentryLabel}
-                                    onPress={segment.onPress}
-                                    style={styles.dInlineFlex}
-                                >
-                                    <Text style={[styles.textSupporting, styles.link]}>{segment.text}</Text>
-                                </PressableWithoutFeedback>
-                            );
-                        }
-                        // Keep each word (with its own leading/trailing whitespace) as a separate node so the paragraph wraps in the
-                        // flexWrap row. Preserving the segment's own spacing means locales that don't use spaces around the links
-                        // (e.g. Japanese, Chinese) aren't given extra spaces the translation never intended.
-                        return (segment.text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
-                            <Text
-                                // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
-                                // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
-                                // within a segment (segment.text alone can't); the array position is what makes it unique.
-                                // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
-                                key={`${segment.text}-${word}-${wordIndex}`}
-                                style={styles.textSupporting}
-                            >
-                                {word}
-                            </Text>
-                        ));
-                    })}
+                    {renderPlainCopy(translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart'))}
+                    <PressableWithoutFeedback
+                        testID="ImportFromFileStep-TemplateLink"
+                        role={CONST.ROLE.BUTTON}
+                        accessibilityLabel={translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink')}
+                        sentryLabel="ImportFromFileStep-TemplateLink"
+                        onPress={downloadTemplate}
+                        style={styles.dInlineFlex}
+                    >
+                        <Text style={[styles.textSupporting, styles.link]}>{translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink')}</Text>
+                    </PressableWithoutFeedback>
+                    {renderPlainCopy(translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle'))}
+                    <PressableWithoutFeedback
+                        testID="ImportFromFileStep-HelpGuideLink"
+                        role={CONST.ROLE.LINK}
+                        // Pass href so the link renders as a real anchor on web (native link behavior: hover URL, open in a new tab, etc.),
+                        // while onPress preventDefault()s the anchor's default navigation and routes through openLink on every platform.
+                        href={CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL}
+                        accessibilityLabel={translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink')}
+                        sentryLabel="ImportFromFileStep-HelpGuideLink"
+                        onPress={(event) => {
+                            event?.preventDefault();
+                            openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL);
+                        }}
+                        style={styles.dInlineFlex}
+                    >
+                        <Text style={[styles.textSupporting, styles.link]}>{translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink')}</Text>
+                    </PressableWithoutFeedback>
+                    {renderPlainCopy(translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionEnd'))}
                 </View>
                 <MenuItemWithTopDescription
                     description={translate('workspace.companyCards.addNewCard.companyCardLayoutName')}

--- a/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/ImportFromFileStep.tsx
@@ -70,7 +70,13 @@ function ImportFromFileStep() {
     // On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
     // which makes it unreliable to tap (e.g. at the minimum device font size). Rendering each link as its own PressableWithoutFeedback
     // gives it a real native touch target, while splitting the plain copy into words keeps the paragraph flowing/wrapping naturally.
-    const createFileFeedHelpTextSegments: Array<{text: string; onPress?: () => void; role?: React.ComponentProps<typeof PressableWithoutFeedback>['role']; sentryLabel?: string}> = [
+    const createFileFeedHelpTextSegments: Array<{
+        text: string;
+        onPress?: React.ComponentProps<typeof PressableWithoutFeedback>['onPress'];
+        href?: string;
+        role?: React.ComponentProps<typeof PressableWithoutFeedback>['role'];
+        sentryLabel?: string;
+    }> = [
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionStart')},
         {
             text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.templateLink'),
@@ -81,7 +87,13 @@ function ImportFromFileStep() {
         {text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.instructionMiddle')},
         {
             text: translate('workspace.companyCards.addNewCard.createFileFeedHelpText.helpGuideLink'),
-            onPress: () => openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL),
+            // Pass href so the link renders as a real anchor on web (native link behavior: hover URL, open in a new tab, etc.),
+            // while onPress preventDefault()s the anchor's default navigation and routes through openLink on every platform.
+            href: CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL,
+            onPress: (event) => {
+                event?.preventDefault();
+                openLink(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, environmentURL);
+            },
             role: CONST.ROLE.LINK,
             sentryLabel: 'ImportFromFileStep-HelpGuideLink',
         },
@@ -118,22 +130,24 @@ function ImportFromFileStep() {
                     {createFileFeedHelpTextSegments.map((segment, segmentIndex) => {
                         if (segment.onPress) {
                             return (
-                                // eslint-disable-next-line react/no-array-index-key
-                                <React.Fragment key={`${segment.text}-${segmentIndex}`}>
-                                    <PressableWithoutFeedback
-                                        role={segment.role}
-                                        accessibilityLabel={segment.text}
-                                        sentryLabel={segment.sentryLabel}
-                                        onPress={segment.onPress}
-                                        style={styles.dInlineFlex}
-                                    >
-                                        <Text style={[styles.textSupporting, styles.link]}>{segment.text}</Text>
-                                    </PressableWithoutFeedback>
-                                    <Text style={styles.textSupporting}> </Text>
-                                </React.Fragment>
+                                <PressableWithoutFeedback
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    key={`${segment.text}-${segmentIndex}`}
+                                    role={segment.role}
+                                    href={segment.href}
+                                    accessibilityLabel={segment.text}
+                                    sentryLabel={segment.sentryLabel}
+                                    onPress={segment.onPress}
+                                    style={styles.dInlineFlex}
+                                >
+                                    <Text style={[styles.textSupporting, styles.link]}>{segment.text}</Text>
+                                </PressableWithoutFeedback>
                             );
                         }
-                        return (segment.text.match(/\S+\s*/g) ?? []).map((word, wordIndex) => (
+                        // Keep each word (with its own leading/trailing whitespace) as a separate node so the paragraph wraps in the
+                        // flexWrap row. Preserving the segment's own spacing means locales that don't use spaces around the links
+                        // (e.g. Japanese, Chinese) aren't given extra spaces the translation never intended.
+                        return (segment.text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
                             <Text
                                 // eslint-disable-next-line react/no-array-index-key
                                 key={`${segment.text}-${segmentIndex}-${wordIndex}`}

--- a/src/pages/workspace/companyCards/addNew/WrappingText.tsx
+++ b/src/pages/workspace/companyCards/addNew/WrappingText.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+type WrappingTextProps = {
+    /** Plain copy to render, split into per-word nodes so it wraps naturally inside a flexWrap row. */
+    text: string;
+};
+
+// The help text mixes plain copy with tappable links (e.g. a client-side template download and an external help guide).
+// On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
+// which makes it unreliable to tap (e.g. at the minimum device font size). The links are therefore rendered as their own
+// PressableWithoutFeedback nodes inside a flexWrap row, and this component renders the plain copy between them as a sequence
+// of per-word <Text> nodes so the paragraph still flows and wraps naturally across the row.
+function WrappingText({text}: WrappingTextProps) {
+    const styles = useThemeStyles();
+
+    // Keep each word (with its own leading/trailing whitespace) as a separate node so the paragraph wraps in the flexWrap row.
+    // Preserving the run's own spacing means locales that don't use spaces around the links (e.g. Japanese, Chinese) aren't
+    // given extra spaces the translation never intended.
+    return (text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
+        <Text
+            // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
+            // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
+            // within a run (the word text alone can't); the array position is what makes it unique.
+            // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
+            key={`${text}-${word}-${wordIndex}`}
+            style={styles.textSupporting}
+        >
+            {word}
+        </Text>
+    ));
+}
+
+WrappingText.displayName = 'WrappingText';
+
+export default WrappingText;
+export type {WrappingTextProps};

--- a/src/pages/workspace/companyCards/addNew/WrappingText.tsx
+++ b/src/pages/workspace/companyCards/addNew/WrappingText.tsx
@@ -1,19 +1,25 @@
-import React from 'react';
-
 import Text from '@components/Text';
 
 import useThemeStyles from '@hooks/useThemeStyles';
+
+import React from 'react';
 
 type WrappingTextProps = {
     /** Plain copy to render, split into per-word nodes so it wraps naturally inside a flexWrap row. */
     text: string;
 };
 
-// The help text mixes plain copy with tappable links (e.g. a client-side template download and an external help guide).
-// On Android, a link nested inline inside a <Text> becomes a ClickableSpan whose touch area is limited to the glyph bounds,
-// which makes it unreliable to tap (e.g. at the minimum device font size). The links are therefore rendered as their own
-// PressableWithoutFeedback nodes inside a flexWrap row, and this component renders the plain copy between them as a sequence
-// of per-word <Text> nodes so the paragraph still flows and wraps naturally across the row.
+/**
+ * Renders plain copy as a sequence of per-word <Text> nodes so it flows and wraps naturally inside a
+ * flexWrap row alongside tappable link nodes.
+ *
+ * The company-card CSV import help text mixes plain copy with tappable links (a client-side template
+ * download and an external help guide). On Android, a link nested inline inside a <Text> becomes a
+ * ClickableSpan whose touch area is limited to the glyph bounds, which makes it unreliable to tap (e.g.
+ * at the minimum device font size). The links are therefore rendered as their own PressableWithoutFeedback
+ * nodes inside a flexWrap row, and this component renders the plain copy between them as per-word <Text>
+ * nodes so the paragraph still flows and wraps naturally across the row.
+ */
 function WrappingText({text}: WrappingTextProps) {
     const styles = useThemeStyles();
 
@@ -37,4 +43,3 @@ function WrappingText({text}: WrappingTextProps) {
 WrappingText.displayName = 'WrappingText';
 
 export default WrappingText;
-export type {WrappingTextProps};

--- a/src/pages/workspace/companyCards/addNew/WrappingText.tsx
+++ b/src/pages/workspace/companyCards/addNew/WrappingText.tsx
@@ -33,8 +33,11 @@ function WrappingText({text}: WrappingTextProps) {
     const {preferredLocale} = useLocalize();
 
     // Segment on word boundaries (rather than a whitespace regex) so locales without spaces (e.g. Japanese, Chinese)
-    // also get real break opportunities, letting the run wrap within itself on narrow screens.
-    const words = Array.from(new Intl.Segmenter(preferredLocale, {granularity: 'word'}).segment(text), (segment) => segment.segment);
+    // also get real break opportunities, letting the run wrap within itself on narrow screens. Hermes doesn't
+    // implement Intl.Segmenter (https://hermesengine.dev/docs/intl/), so fall back to splitting on whitespace,
+    // keeping the separators as their own entries to preserve spacing the same way Segmenter would.
+    const words =
+        typeof Intl.Segmenter === 'function' ? Array.from(new Intl.Segmenter(preferredLocale, {granularity: 'word'}).segment(text), (segment) => segment.segment) : text.split(/(\s+)/);
 
     return (
         <>

--- a/src/pages/workspace/companyCards/addNew/WrappingText.tsx
+++ b/src/pages/workspace/companyCards/addNew/WrappingText.tsx
@@ -4,6 +4,9 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import React from 'react';
 
+// Renders plain paragraph copy as per-word <Text> nodes so it flows and wraps naturally inside a flexWrap
+// row alongside tappable link nodes. Used by the company-card CSV import help text (see JSDoc below).
+
 type WrappingTextProps = {
     /** Plain copy to render, split into per-word nodes so it wraps naturally inside a flexWrap row. */
     text: string;

--- a/src/pages/workspace/companyCards/addNew/WrappingText.tsx
+++ b/src/pages/workspace/companyCards/addNew/WrappingText.tsx
@@ -1,5 +1,6 @@
 import Text from '@components/Text';
 
+import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import React from 'react';
@@ -22,25 +23,38 @@ type WrappingTextProps = {
  * at the minimum device font size). The links are therefore rendered as their own PressableWithoutFeedback
  * nodes inside a flexWrap row, and this component renders the plain copy between them as per-word <Text>
  * nodes so the paragraph still flows and wraps naturally across the row.
+ *
+ * The per-word nodes are hidden from the accessibility tree and a single visually-hidden node carries the
+ * full run as one label, so TalkBack announces coherent prose instead of one node per word while the link
+ * pressables around this component stay independently focusable.
  */
 function WrappingText({text}: WrappingTextProps) {
     const styles = useThemeStyles();
+    const {preferredLocale} = useLocalize();
 
-    // Keep each word (with its own leading/trailing whitespace) as a separate node so the paragraph wraps in the flexWrap row.
-    // Preserving the run's own spacing means locales that don't use spaces around the links (e.g. Japanese, Chinese) aren't
-    // given extra spaces the translation never intended.
-    return (text.match(/\s*\S+\s*/g) ?? []).map((word, wordIndex) => (
-        <Text
-            // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
-            // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
-            // within a run (the word text alone can't); the array position is what makes it unique.
-            // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
-            key={`${text}-${word}-${wordIndex}`}
-            style={styles.textSupporting}
-        >
-            {word}
-        </Text>
-    ));
+    // Segment on word boundaries (rather than a whitespace regex) so locales without spaces (e.g. Japanese, Chinese)
+    // also get real break opportunities, letting the run wrap within itself on narrow screens.
+    const words = Array.from(new Intl.Segmenter(preferredLocale, {granularity: 'word'}).segment(text), (segment) => segment.segment);
+
+    return (
+        <>
+            <Text style={styles.screenReaderOnlyAnchor}>{text}</Text>
+            {words.map((word, wordIndex) => (
+                <Text
+                    // The word list is derived synchronously from a fixed translation and is never reordered, inserted into, or
+                    // filtered, so a word's index is a stable identity. wordIndex is only needed to disambiguate repeated words
+                    // within a run, since the word text alone can't. The array position is what makes it unique.
+                    // eslint-disable-next-line react/no-array-index-key -- index is a stable identity for this static, never-reordered word list
+                    key={`${text}-${word}-${wordIndex}`}
+                    style={styles.textSupporting}
+                    accessible={false}
+                    aria-hidden
+                >
+                    {word}
+                </Text>
+            ))}
+        </>
+    );
 }
 
 WrappingText.displayName = 'WrappingText';

--- a/tests/unit/ImportFromFileStepTest.tsx
+++ b/tests/unit/ImportFromFileStepTest.tsx
@@ -1,0 +1,107 @@
+import {act, fireEvent, render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import * as Link from '@libs/actions/Link';
+import localFileDownload from '@libs/localFileDownload';
+
+import ImportFromFileStep from '@pages/workspace/companyCards/addNew/ImportFromFileStep';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+const POLICY_ID = 'import-from-file-step-test-policy';
+
+// The inline template download is a client-side file write, and the help guide opens an external link.
+// Stub both so the test asserts the presses are wired up without touching the filesystem or the browser.
+jest.mock('@libs/localFileDownload');
+
+jest.mock('@react-navigation/native', () => {
+    // jest.requireActual returns `any` for the untyped React Navigation module
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const actualNav = jest.requireActual('@react-navigation/native');
+
+    // Spreading the untyped requireActual result is intentional for this navigation mock
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...actualNav,
+        useNavigation: () => ({
+            navigate: jest.fn(),
+            goBack: jest.fn(),
+            addListener: () => jest.fn(),
+            isFocused: () => true,
+        }),
+        useIsFocused: () => true,
+        useFocusEffect: jest.fn(),
+        usePreventRemove: jest.fn(),
+        useRoute: () => ({key: 'test-route', name: 'Workspace_Company_Cards_Add_New', params: {policyID: POLICY_ID}}),
+    };
+});
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    getActiveRoute: jest.fn(() => ''),
+    getActiveRouteWithoutParams: jest.fn(() => ''),
+    getTopmostReportId: jest.fn(() => undefined),
+    isNavigationReady: jest.fn(() => Promise.resolve()),
+    setNavigationActionToMicrotaskQueue: jest.fn(),
+    removeScreenFromNavigationState: jest.fn(),
+    dismissModal: jest.fn(),
+}));
+
+function renderImportFromFileStep() {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+            <ImportFromFileStep />
+        </ComposeProviders>,
+    );
+}
+
+describe('ImportFromFileStep inline help links', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+            await waitForBatchedUpdatesWithAct();
+        });
+        renderImportFromFileStep();
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the template link as a Pressable button that triggers the client-side CSV download', () => {
+        const templateLink = screen.getByTestId('ImportFromFileStep-TemplateLink');
+
+        // A Pressable-backed link (not a bare inline <Text>/ClickableSpan) so it gets a real native touch target on Android.
+        expect(templateLink).toHaveProp('role', CONST.ROLE.BUTTON);
+
+        fireEvent.press(templateLink);
+        expect(localFileDownload).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the help guide link as a Pressable that keeps its href and opens the help guide', () => {
+        const openLinkSpy = jest.spyOn(Link, 'openLink').mockImplementation(() => {});
+        const helpGuideLink = screen.getByTestId('ImportFromFileStep-HelpGuideLink');
+
+        // Retains href so web renders a real <a> (native link behavior), while still routing through onPress on every platform.
+        expect(helpGuideLink).toHaveProp('role', CONST.ROLE.LINK);
+        expect(helpGuideLink).toHaveProp('href', CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL);
+
+        fireEvent.press(helpGuideLink);
+        expect(openLinkSpy).toHaveBeenCalledWith(CONST.COMPANY_CARDS_CREATE_FILE_FEED_HELP_URL, expect.any(String));
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixes the deploy blocker where the inline **"help guide"** (and **"Download our template"**) links on the company-card CSV import step were not tappable on Android at the minimum device font size.

The help text was rendered as a single `<Text>` with two bare `<TextLink>` children nested inline. On Android, a link nested inside a `<Text>` becomes a native `ClickableSpan` whose touch area is limited to the glyph bounds, so it can become unreliable to tap (reproduced at the minimum device font size). This is the same rendering an `<a>` gets through `RenderHTML` for non-comment links, so switching back to `RenderHTML` would not have fixed it — and `RenderHTML` can't invoke the client-side template download that #98058 requires.

This change keeps both links inline (preserving the inline template link required by #98058) but renders each link as its own `PressableWithoutFeedback`, which gives it a real native touch target. The surrounding copy is split into words inside a `flexWrap` row so the paragraph still flows and wraps naturally. This mirrors the existing `TextLinkBlock` approach already used in the app for reliably tappable link text.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/99719
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. On Android, set device font size to minimum.
2. Launch Expensify app.
3. Go to Workspace settings > Company cards.
4. Tap Add cards.
5. Select United States > Next.
6. Select Import transactions from files > Next.
7. Tap "guide" in the Help guide link. Verify it opens the help guide.
8. Tap "Download our template" link. Verify it downloads the CSV template.
9. Verify the surrounding paragraph still reads and wraps normally.

- [x] Verify that no errors appear in the JS console

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/6d77813b-eab6-46b2-b2c3-8316335f4ae4


