### PR TITLE
Revert #98123 to resolve Authorized Payer deploy blockers

### DIFF
--- a/src/components/WorkspaceMemberRoleList.tsx
+++ b/src/components/WorkspaceMemberRoleList.tsx
@@ -34,12 +34,9 @@ type WorkspaceMemberRoleListProps = {
     navigateBackTo?: Route;
     isLoading?: boolean;
     onSelectRole?: (value: ListItemType) => void;
-
-    /** When provided, restricts the selectable roles to this set (e.g. an Authorized Payer may only be an Admin or Payments Admin) */
-    allowedRoles?: Array<ValueOf<typeof CONST.POLICY.ROLE>>;
 };
 
-function WorkspaceMemberRoleList({role, policy, navigateBackTo = undefined, isLoading = false, onSelectRole = () => {}, allowedRoles = undefined}: WorkspaceMemberRoleListProps) {
+function WorkspaceMemberRoleList({role, policy, navigateBackTo = undefined, isLoading = false, onSelectRole = () => {}}: WorkspaceMemberRoleListProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {login: currentUserLogin = ''} = useCurrentUserPersonalDetails();
@@ -89,9 +86,7 @@ function WorkspaceMemberRoleList({role, policy, navigateBackTo = undefined, isLo
         },
     ];
 
-    const availableRoleItems: ListItemType[] = workspaceRoles.filter(
-        (item) => canMemberAssignRole(policy, currentUserLogin, item.value) && (!allowedRoles || allowedRoles.includes(item.value)),
-    );
+    const availableRoleItems: ListItemType[] = workspaceRoles.filter((item) => canMemberAssignRole(policy, currentUserLogin, item.value));
 
     return (
         <>

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -712,19 +712,6 @@ function getReimburserEmail(policy: OnyxEntry<Policy>): string | undefined {
     return policy.reimburser ?? policy.achAccount?.reimburser ?? (isManualReimbursement ? policy.owner : undefined);
 }
 
-/**
- * Whether the given role is allowed to pay (reimburse) on a workspace.
- */
-function canRolePay(role: string | undefined): boolean {
-    return !!role && ROLE_PERMISSION_BUNDLES[role]?.[CONST.POLICY.POLICY_FEATURE.WORKFLOWS_PAYMENTS] === CONST.POLICY.POLICY_FEATURE_ACCESS.WRITE;
-}
-
-/**
- * The roles that are allowed to pay (reimburse) on a workspace, derived from the WORKFLOWS_PAYMENTS permission. The
- * Authorized Payer (reimburser) must always hold one of these, so any role change for a payer is restricted to this set.
- */
-const PAYER_ROLES = Object.values(CONST.POLICY.ROLE).filter(canRolePay);
-
 function isPolicyPayer(policy: OnyxEntry<Policy>, currentUserLogin: string | undefined): boolean {
     if (!policy) {
         return false;
@@ -3231,8 +3218,6 @@ export {
     isPolicyMember,
     isPolicyPayer,
     getReimburserEmail,
-    PAYER_ROLES,
-    canRolePay,
     arePaymentsEnabled,
     isSubmitterAndApprover,
     isSubmitAndClose,

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -607,8 +607,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             options.push(memberOption);
         }
 
-        // Admin is a valid payer role, so the payer may be promoted to Admin (Admin and Payments Admin are the two roles that can pay).
-        if (hasAtLeastOneNonAdminRole && canAssignElevatedRoles) {
+        if (hasAtLeastOneNonAdminRole && !hasAtLeastOnePayer && canAssignElevatedRoles) {
             options.push(adminOption);
         }
 
@@ -630,8 +629,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             options.push(peopleAdminOption);
         }
 
-        // Payments Admin is a valid payer role, so the payer may be changed to Payments Admin (Admin and Payments Admin are the two roles that can pay).
-        if (hasAtLeastOneNonPaymentsAdminRole && isControlPolicy(policy) && canAssignElevatedRoles) {
+        if (hasAtLeastOneNonPaymentsAdminRole && isControlPolicy(policy) && !hasAtLeastOnePayer && canAssignElevatedRoles) {
             options.push(paymentsAdminOption);
         }
 

--- a/src/pages/workspace/members/WorkspaceMemberDetailsPage.tsx
+++ b/src/pages/workspace/members/WorkspaceMemberDetailsPage.tsx
@@ -16,6 +16,7 @@ import {useCompanyCardFeedIcons} from '@hooks/useCompanyCardIcons';
 import useConfirmModal from '@hooks/useConfirmModal';
 import {useCurrencyListActions} from '@hooks/useCurrencyList';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useEnvironment from '@hooks/useEnvironment';
 import useExpensifyCardFeeds from '@hooks/useExpensifyCardFeeds';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -41,7 +42,6 @@ import {
     getReimburserEmail,
     isControlPolicy,
     isPolicyApprover,
-    PAYER_ROLES,
     tryNavigateToSubmitWorkspaceUpgrade,
 } from '@libs/PolicyUtils';
 import shouldRenderTransferOwnerButton from '@libs/shouldRenderTransferOwnerButton';
@@ -115,6 +115,7 @@ function WorkspaceMemberDetailsPage({personalDetails, policy, route}: WorkspaceM
     const illustrations = useThemeIllustrations();
     const companyCardFeedIcons = useCompanyCardFeedIcons();
     const {accountID: currentUserAccountID, login: currentUserLogin = ''} = useCurrentUserPersonalDetails();
+    const {environmentURL} = useEnvironment();
     const [cardFeeds] = useCardFeeds(policyID);
     const [cardList] = useOnyx(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}`);
     const [customCardNames] = useOnyx(ONYXKEYS.NVP_EXPENSIFY_COMPANY_CARDS_CUSTOM_NAMES);
@@ -142,14 +143,12 @@ function WorkspaceMemberDetailsPage({personalDetails, policy, route}: WorkspaceM
     const ownerDetails = personalDetails?.[policy?.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID] ?? ({} as PersonalDetails);
     const policyOwnerDisplayName = temporaryGetDisplayNameOrDefault({passedPersonalDetails: ownerDetails, translate, formatPhoneNumber}) ?? policy?.owner ?? '';
     const {cardList: assignableCards, ...workspaceCards} = getAllCardsForWorkspace(workspaceAccountID, cardList, cardFeeds, expensifyCardSettings);
+    const workspaceWorkflowsPageURL = `${environmentURL}/${ROUTES.WORKSPACE_WORKFLOWS.getRoute(policyID, CONST.TAB.WORKFLOWS.PAYMENTS)}`;
     const isSMSLogin = Str.isSMSLogin(memberLogin);
     const phoneNumber = getPhoneNumber(details);
     const reimburserEmail = getReimburserEmail(policy);
     const isReimburser = !!reimburserEmail && reimburserEmail === memberLogin;
-    // Only let the Authorized Payer change roles when there is another payer role they can actually move to.
-    const assignablePayerRoles = PAYER_ROLES.filter((payerRole) => canMemberAssignRole(policy, currentUserLogin, payerRole));
-    const canReimburserChangeRole = assignablePayerRoles.some((payerRole) => payerRole !== member?.role);
-    const canEditSelectedMemberRole = !isSelectedMemberOwner && !isSelectedMemberCurrentUser && canManageSelectedMemberRole && (!isReimburser || canReimburserChangeRole);
+    const canEditSelectedMemberRole = !isSelectedMemberOwner && !isSelectedMemberCurrentUser && !isReimburser && canManageSelectedMemberRole;
     const {isAccountLocked} = useLockedAccountState();
     const {showLockedAccountModal} = useLockedAccountActions();
 
@@ -402,6 +401,8 @@ function WorkspaceMemberDetailsPage({personalDetails, policy, route}: WorkspaceM
                                     }
                                     Navigation.navigate(ROUTES.WORKSPACE_MEMBER_DETAILS_ROLE.getRoute(policyID, accountID));
                                 }}
+                                hintText={isReimburser ? translate('common.roleCannotBeChanged', workspaceWorkflowsPageURL) : undefined}
+                                shouldRenderHintAsHTML
                             />
                             {isControlPolicy(policy) && (
                                 <>

--- a/src/pages/workspace/members/WorkspaceMemberDetailsRolePage.tsx
+++ b/src/pages/workspace/members/WorkspaceMemberDetailsRolePage.tsx
@@ -11,7 +11,7 @@ import {isRuleBotEnforcingRules} from '@libs/AgentRulesUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
-import {canMemberAssignRole, canRolePay, getReimburserEmail, PAYER_ROLES} from '@libs/PolicyUtils';
+import {canMemberAssignRole} from '@libs/PolicyUtils';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import withPolicyAndFullscreenLoading from '@pages/workspace/withPolicyAndFullscreenLoading';
@@ -40,10 +40,6 @@ function WorkspaceMemberDetailsRolePage({policy, personalDetails, route}: Worksp
     const memberLogin = personalDetails?.[accountID]?.login ?? '';
     const member = policy?.employeeList?.[memberLogin];
     const canManageSelectedMemberRole = canMemberAssignRole(policy, currentUserLogin, member?.role);
-    // The Authorized Payer (reimburser) must stay a valid payer, so restrict them to the roles that can pay (for example Admin or Payments Admin).
-    const reimburserEmail = getReimburserEmail(policy);
-    const isReimburser = !!reimburserEmail && reimburserEmail === memberLogin;
-    const allowedRoles = isReimburser ? [...PAYER_ROLES] : undefined;
     useRedirectSubmitWorkspaceFeatureUpgrade({
         policy,
         backTo: ROUTES.WORKSPACE_MEMBER_DETAILS.getRoute(policyID, accountID),
@@ -55,10 +51,6 @@ function WorkspaceMemberDetailsRolePage({policy, personalDetails, route}: Worksp
             return;
         }
         if (!canMemberAssignRole(policy, currentUserLogin, value)) {
-            return;
-        }
-        // Guard the direct-navigation path: a reimburser must stay a valid payer, so reject any role that cannot pay.
-        if (isReimburser && !canRolePay(value)) {
             return;
         }
         if (value !== CONST.POLICY.ROLE.ADMIN && isRuleBotEnforcingRules(accountID, policy)) {
@@ -84,7 +76,6 @@ function WorkspaceMemberDetailsRolePage({policy, personalDetails, route}: Worksp
                     role={member?.role}
                     policy={policy}
                     onSelectRole={changeRole}
-                    allowedRoles={allowedRoles}
                     navigateBackTo={ROUTES.WORKSPACE_MEMBER_DETAILS.getRoute(policyID, accountID)}
                 />
             </ScreenWrapper>

--- a/tests/ui/WorkspaceMemberDetailsPageTest.tsx
+++ b/tests/ui/WorkspaceMemberDetailsPageTest.tsx
@@ -68,8 +68,6 @@ describe('WorkspaceMemberDetailsPage', () => {
     const primaryAccountID = 7777;
     const primaryEmail = 'primary@example.com';
     const secondaryEmail = 'secondary@example.com';
-    const adminPayerAccountID = 8888;
-    const adminPayerEmail = 'adminpayer@example.com';
 
     const policy = {
         ...LHNTestUtils.getFakePolicy(),
@@ -86,7 +84,6 @@ describe('WorkspaceMemberDetailsPage', () => {
             [invitedEmail]: {email: invitedEmail, role: CONST.POLICY.ROLE.USER},
             [phoneLogin]: {email: phoneLogin, role: CONST.POLICY.ROLE.USER},
             [primaryEmail]: {email: primaryEmail, role: CONST.POLICY.ROLE.USER},
-            [adminPayerEmail]: {email: adminPayerEmail, role: CONST.POLICY.ROLE.ADMIN},
         },
     };
 
@@ -106,7 +103,6 @@ describe('WorkspaceMemberDetailsPage', () => {
                 [invitedAccountID]: TestHelper.buildPersonalDetails(invitedEmail, invitedAccountID, 'Invited'),
                 [phoneAccountID]: TestHelper.buildPersonalDetails(phoneLogin, phoneAccountID, 'Phone'),
                 [primaryAccountID]: TestHelper.buildPersonalDetails(primaryEmail, primaryAccountID, 'Primary'),
-                [adminPayerAccountID]: TestHelper.buildPersonalDetails(adminPayerEmail, adminPayerAccountID, 'AdminPayer'),
             });
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
         });
@@ -223,80 +219,6 @@ describe('WorkspaceMemberDetailsPage', () => {
             expect(screen.getByText(TestHelper.translateLocal('workspace.rules.agentRules.unableToRemoveTitle'))).toBeOnTheScreen();
         });
         expect(screen.queryByText(TestHelper.translateLocal('workspace.people.removeMemberTitle'))).not.toBeOnTheScreen();
-
-        unmount();
-        await waitForBatchedUpdatesWithAct();
-    });
-
-    it('should not lock the Role field for a non-admin Authorized Payer so they can be promoted to Admin', async () => {
-        // Make the invited member (a plain USER) the workspace Authorized Payer.
-        await act(async () => {
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, {
-                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
-                reimburser: invitedEmail,
-            });
-        });
-
-        const {unmount} = renderPage({policyID: policy.id, accountID: String(invitedAccountID)});
-        await waitForBatchedUpdatesWithAct();
-
-        await waitFor(() => {
-            expect(screen.getByTestId('WorkspaceMemberDetailsPage')).toBeOnTheScreen();
-        });
-
-        // The locked hint must NOT be shown — a non-admin payer can still be promoted to Admin.
-        expect(screen.queryByText(/Role can/)).not.toBeOnTheScreen();
-
-        unmount();
-        await waitForBatchedUpdatesWithAct();
-    });
-
-    it('should not lock the Role field for an Authorized Payer who is already an Admin so they can be changed to Payments Admin', async () => {
-        // The admin member is the workspace Authorized Payer — Payments Admin is also a valid payer, so a lateral change is allowed.
-        await act(async () => {
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, {
-                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
-                reimburser: adminPayerEmail,
-            });
-        });
-
-        const {unmount} = renderPage({policyID: policy.id, accountID: String(adminPayerAccountID)});
-        await waitForBatchedUpdatesWithAct();
-
-        await waitFor(() => {
-            expect(screen.getByTestId('WorkspaceMemberDetailsPage')).toBeOnTheScreen();
-        });
-
-        // The locked hint must NOT be shown — an admin payer can still be changed to Payments Admin, another valid payer role.
-        expect(screen.queryByText(/Role can/)).not.toBeOnTheScreen();
-
-        unmount();
-        await waitForBatchedUpdatesWithAct();
-    });
-
-    it('should keep the Role field interactive for an admin Authorized Payer on a non-Control workspace because Editor also holds the payments permission', async () => {
-        // On a Team (non-Control) workspace, Payments Admin is not assignable, but Editor also holds the WORKFLOWS_PAYMENTS
-        // permission, so an admin payer still has another valid payer role to switch to. The Role row must stay interactive.
-        await act(async () => {
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, {
-                type: CONST.POLICY.TYPE.TEAM,
-                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
-                reimburser: adminPayerEmail,
-            });
-        });
-
-        const {unmount} = renderPage({policyID: policy.id, accountID: String(adminPayerAccountID)});
-        await waitForBatchedUpdatesWithAct();
-
-        await waitFor(() => {
-            expect(screen.getByTestId('WorkspaceMemberDetailsPage')).toBeOnTheScreen();
-        });
-
-        const roleItem = await screen.findByTestId('member-role-menu-item');
-
-        // Editor is another payer role the admin payer can switch to, so the row is interactive with no lock hint.
-        expect(roleItem).not.toBeDisabled();
-        expect(screen.queryByText(/Role can/)).not.toBeOnTheScreen();
 
         unmount();
         await waitForBatchedUpdatesWithAct();

--- a/tests/ui/WorkspaceMembersTest.tsx
+++ b/tests/ui/WorkspaceMembersTest.tsx
@@ -432,10 +432,11 @@ describe('WorkspaceMembers', () => {
             await waitForBatchedUpdatesWithAct();
         });
 
-        it('should hide demotions but offer Make payments admin when the selected member is the Authorized Payer resolved via policy.reimburser', async () => {
+        it('should hide role-change options when the selected member is the Authorized Payer resolved via policy.reimburser', async () => {
             // Given a workspace whose Authorized Payer is an admin configured through policy.reimburser
-            // (the canonical resolution) rather than achAccount.reimburser. Demotions to roles that cannot
-            // pay must stay hidden, but changing to Payments Admin (the other valid payer role) must be offered.
+            // (the canonical resolution) rather than achAccount.reimburser. On the buggy code the guard
+            // only read achAccount.reimburser, so it failed to recognize this payer and wrongly offered
+            // the role-change options.
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, {
                     reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
@@ -461,7 +462,7 @@ describe('WorkspaceMembers', () => {
                 expect(screen.getByTestId(`PopoverMenuItem-${removeText}`)).toBeOnTheScreen();
             });
 
-            // ...the demotions that would strip the payer of pay capability are hidden
+            // ...and none of the role-change options are offered for the payer
             const makeMemberText = TestHelper.translateLocal('workspace.people.makeMember', {count: 1});
             expect(screen.queryByTestId(`PopoverMenuItem-${makeMemberText}`)).not.toBeOnTheScreen();
 
@@ -471,18 +472,16 @@ describe('WorkspaceMembers', () => {
             const makeCardAdminText = TestHelper.translateLocal('workspace.people.makeCardAdmin', {count: 1});
             expect(screen.queryByTestId(`PopoverMenuItem-${makeCardAdminText}`)).not.toBeOnTheScreen();
 
-            // ...but Make payments admin IS offered — Payments Admin is a valid payer role
-            const makePaymentsAdminText = TestHelper.translateLocal('workspace.people.makePaymentsAdmin', {count: 1});
-            expect(screen.getByTestId(`PopoverMenuItem-${makePaymentsAdminText}`)).toBeOnTheScreen();
-
             unmount();
             await waitForBatchedUpdatesWithAct();
         });
 
-        it('should offer Make workspace admin but hide demotions when the selected member is a Payments Admin who is the Authorized Payer', async () => {
-            // Given a Payments Admin who is also the Authorized Payer. Admin and Payments Admin are both valid
-            // payer roles, so promoting this payer to Admin keeps them a valid payer and must be offered.
-            // Every demotion to a role that cannot pay (Member, Auditor, Card Admin) stays gated on the payer.
+        it('should hide the Make workspace admin option when the selected member is a Payments Admin who is the Authorized Payer', async () => {
+            // Given a Payments Admin who is also the Authorized Payer. PAYMENTS_ADMIN is the only non-admin
+            // role with write access to WORKFLOWS_PAYMENTS, so it is the sole role that can hold the payer
+            // role without already being an admin — which makes it the only path that can reach the
+            // "Make workspace admin" option. Every other role-change option is already gated on the payer,
+            // but adminOption was not, so it was wrongly offered for this payer.
             await act(async () => {
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, {
                     reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
@@ -511,16 +510,9 @@ describe('WorkspaceMembers', () => {
                 expect(screen.getByTestId(`PopoverMenuItem-${removeText}`)).toBeOnTheScreen();
             });
 
-            // ...and "Make workspace admin" IS offered — Admin is a valid payer role
+            // ...but "Make workspace admin" is hidden for the payer, even though their role is not admin
             const makeAdminText = TestHelper.translateLocal('workspace.people.makeAdmin', {count: 1});
-            expect(screen.getByTestId(`PopoverMenuItem-${makeAdminText}`)).toBeOnTheScreen();
-
-            // ...but the demotions that would strip the payer of pay capability stay hidden
-            const makeMemberText = TestHelper.translateLocal('workspace.people.makeMember', {count: 1});
-            expect(screen.queryByTestId(`PopoverMenuItem-${makeMemberText}`)).not.toBeOnTheScreen();
-
-            const makeAuditorText = TestHelper.translateLocal('workspace.people.makeAuditor', {count: 1});
-            expect(screen.queryByTestId(`PopoverMenuItem-${makeAuditorText}`)).not.toBeOnTheScreen();
+            expect(screen.queryByTestId(`PopoverMenuItem-${makeAdminText}`)).not.toBeOnTheScreen();
 
             unmount();
             await waitForBatchedUpdatesWithAct();


### PR DESCRIPTION
### Explanation of Change

This reverts merge commit 3287483393f9fca2c2f2d31775495808511968a1 (PR #98123) on top of the current main branch.

Two staging deploy blockers identified #98123 as the causing PR:
- #99716: changing an Authorized Payer from Admin to Payments Admin reaches a backend-unsupported flow and errors.
- #99734: after downgrading Control to Collect, the payer-role filter collapses to Admin only and hides Member.

Both investigations recommend the same safe response: restore the pre-#98123 locked Role row and its Workflows guidance while the product/backend constraints are clarified. The revert is clean and limited to the original seven files.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99716
$ https://github.com/Expensify/App/issues/99734
PROPOSAL: https://github.com/Expensify/App/issues/99734#issuecomment-5449511744

### Tests

Automated verification completed:
- npm run fmt
- npm run lint-changed
- npm run typecheck
- npm run react-compiler-compliance-check -- check-changed
- npm test -- tests/ui/WorkspaceMemberDetailsPageTest.tsx tests/ui/WorkspaceMembersTest.tsx --runInBand (2 suites, 19 tests)

Manual verification for reviewer/QA:
1. On a Control workspace, set an Admin as Authorized Payer.
2. Open that member in Workspace > Members and verify the Role row is locked with the payer guidance.
3. Verify a role change cannot be initiated from the role deeplink.
4. Downgrade the workspace to Collect and verify the Authorized Payer Role row remains locked instead of showing a misleading Admin-only list.
5. Open a non-payer member and verify role editing still behaves as before.
6. Verify no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Open the Authorized Payer member details.
3. Verify the Role row remains read-only and no role-change request is queued.
4. Return online and verify no role change or error appears.

### QA Steps

Same as the manual verification steps in the Tests section. Please cover both Control and Collect workspaces.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issues in the Fixed Issues section above
- [x] I wrote clear testing steps that cover the revert
    - [x] I added steps for local testing in the Tests section
    - [x] I added steps for the expected offline behavior in the Offline tests section
    - [x] I added steps for Staging testing in the QA Steps section
    - [x] I added steps covering the failure scenarios reported in both blockers
    - [ ] I turned off my network connection and tested it while offline
    - [ ] I tested this PR with a High Traffic account against the staging or production API
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the manual tests on all supported platforms
- [ ] I verified there are no console errors during manual testing
- [x] I followed the existing code patterns; this is an exact revert of #98123
- [x] I verified no new code pattern, copy, CSS, or assets are introduced
- [x] I ran the existing unit tests covering the impacted member-role components

### Screenshots/Videos

Not included: this is an urgent exact revert; reviewer/QA manual verification remains listed above.