### PR TITLE
Ignore third-party OnyxDB read rejections in Sentry

### DIFF
--- a/src/setup/telemetry/setupSentry.ts
+++ b/src/setup/telemetry/setupSentry.ts
@@ -61,8 +61,9 @@ function setupSentry(): void {
             // UPDATE_REQUIRED is not a real error and makes our errors in Spotnana spike and get rate limited when we bump the app min version, so ignore it
             CONST.ERROR.UPDATE_REQUIRED,
             // Bare-string rejections from the Convert Experiments script in web/index.html, which reads OnyxDB directly.
-            // They carry no stack frames, so thirdPartyErrorFilterIntegration cannot tag them.
-            /No data found for key/,
+            // They carry no stack frames for thirdPartyErrorFilterIntegration to tag; the prefix limits this to the
+            // browser SDK's rejection wording, so a real Error carrying the same text still reports.
+            /^Non-Error promise rejection captured with value: No data found for key/,
         ],
         denyUrls: EXTENSION_DENY_URLS,
         beforeSendTransaction: processBeforeSendTransactions,

--- a/src/setup/telemetry/setupSentry.ts
+++ b/src/setup/telemetry/setupSentry.ts
@@ -57,8 +57,13 @@ function setupSentry(): void {
         integrations,
         environment: CONFIG.ENVIRONMENT,
         release: `${pkg.name}@${pkg.version}`,
-        // UPDATE_REQUIRED is not a real error and makes our errors in Spotnana spike and get rate limited when we bump the app min version, so ignore it
-        ignoreErrors: [CONST.ERROR.UPDATE_REQUIRED],
+        ignoreErrors: [
+            // UPDATE_REQUIRED is not a real error and makes our errors in Spotnana spike and get rate limited when we bump the app min version, so ignore it
+            CONST.ERROR.UPDATE_REQUIRED,
+            // Bare-string rejections from the Convert Experiments script in web/index.html, which reads OnyxDB directly.
+            // They carry no stack frames, so thirdPartyErrorFilterIntegration cannot tag them.
+            /No data found for key/,
+        ],
         denyUrls: EXTENSION_DENY_URLS,
         beforeSendTransaction: processBeforeSendTransactions,
         enableLogs: true,

--- a/tests/unit/setupSentryTest.ts
+++ b/tests/unit/setupSentryTest.ts
@@ -39,4 +39,8 @@ describe('setupSentry', () => {
     it('keeps unhandled rejections that do not come from that third-party OnyxDB read', () => {
         expect(isIgnored(rejectionMessage("undefined is not an object (evaluating 'report.reportID')"))).toBe(false);
     });
+
+    it('keeps a thrown Error carrying the same text, which unlike a bare rejection has a stack to act on', () => {
+        expect(isIgnored('No data found for key reportActions_123')).toBe(false);
+    });
 });

--- a/tests/unit/setupSentryTest.ts
+++ b/tests/unit/setupSentryTest.ts
@@ -1,0 +1,42 @@
+import setupSentry from '@src/setup/telemetry/setupSentry';
+
+import {stringMatchesSomePattern} from '@sentry/core';
+
+jest.mock('@sentry/react-native', () => ({
+    init: jest.fn(),
+    setTag: jest.fn(),
+}));
+
+jest.mock('@libs/telemetry/integrations', () => ({}));
+
+const sentryMock = jest.requireMock<{init: jest.Mock<void, [{ignoreErrors?: Array<string | RegExp>}]>; setTag: jest.Mock}>('@sentry/react-native');
+
+/** How the browser SDK words a promise rejected with a string. It carries no stack frames, so `ignoreErrors` is the only filter that can match it. */
+function rejectionMessage(reason: string): string {
+    return `Non-Error promise rejection captured with value: ${reason}`;
+}
+
+/** Runs Sentry's own matcher over the patterns setupSentry registered, the way `eventFiltersIntegration` does. */
+function isIgnored(message: string): boolean {
+    const initOptions = sentryMock.init.mock.calls.at(0)?.at(0);
+    if (!initOptions) {
+        throw new Error('setupSentry did not call Sentry.init');
+    }
+
+    return stringMatchesSomePattern(message, initOptions.ignoreErrors ?? []);
+}
+
+describe('setupSentry', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        setupSentry();
+    });
+
+    it('drops the bare-string rejection the Convert Experiments script emits when it reads a missing OnyxDB key', () => {
+        expect(isIgnored(rejectionMessage('No data found for key reportActions_undefined'))).toBe(true);
+    });
+
+    it('keeps unhandled rejections that do not come from that third-party OnyxDB read', () => {
+        expect(isIgnored(rejectionMessage("undefined is not an object (evaluating 'report.reportID')"))).toBe(false);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

The Convert Experiments script loaded by `web/index.html` reads OnyxDB directly and rejects with bare strings such as `No data found for key reportActions_undefined`. Because the rejection value is a string and not an `Error`, the event reaches Sentry with no stack frames, so `thirdPartyErrorFilterIntegration` (which tags by frame origin) cannot tag it.

`ignoreErrors` matches on the message instead of the stack, so it does catch these. This adds a `/No data found for key/` pattern to it, covering the whole family of keys that helper reads, plus a regression test.

No app behaviour changes; this only affects which events are reported to Sentry.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98793
PROPOSAL: https://github.com/Expensify/App/issues/98793#issuecomment-5403524285

### Tests

1. Run `npx jest tests/unit/setupSentryTest.ts` and verify both tests pass.
2. Open `src/setup/telemetry/setupSentry.ts` and delete the `/No data found for key/` entry from the `ignoreErrors` array.
3. Re-run `npx jest tests/unit/setupSentryTest.ts` and verify the first test now fails, confirming the test actually covers the fix.
4. Restore the deleted entry and re-run the test, verifying it passes again.
5. Run the app on web, sign in, and verify no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Sign in on web and load the Inbox.
2. Turn off your network connection.
3. Verify the app behaves exactly as it did before this change: the offline indicator appears and navigation still works.
4. Turn the network back on and verify the app reconnects normally.

The change only controls which events are reported to Sentry, so it touches no network or Onyx read path.

### QA Steps

1. Open https://staging.new.expensify.com in Chrome.
2. Open DevTools with `Cmd+Option+J` (macOS) or `Ctrl+Shift+J` (Windows) and select the Console tab.
3. Sign up with a brand-new email address.
4. Complete the onboarding flow through every step until you land on the Inbox.
5. Verify onboarding behaves exactly as before: each step accepts input, the Continue button advances, and no step is skipped or blocked.
6. In the Console, verify no red error containing the text `No data found for key` appears at any point.
7. Open a chat, send a message, and verify it sends and no new red errors appear in the Console.
8. Reload the page and verify the app loads back into the Inbox with no red errors in the Console.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

No UI changes, the fix only changes which events are reported to Sentry.

<details>
<summary>Android: Native</summary>

No UI changes.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

No UI changes.

</details>

<details>
<summary>iOS: Native</summary>

No UI changes.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

No UI changes.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

No UI changes.

</details>
