### PR TITLE
Fix missing Profile GBR when home address is required

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8260,6 +8260,7 @@ const CONST = {
         HAS_LOGIN_LIST_ERROR: 'hasLoginListError',
         HAS_WALLET_TERMS_ERRORS: 'hasWalletTermsErrors',
         HAS_LOGIN_LIST_INFO: 'hasLoginListInfo',
+        HAS_HOME_ADDRESS_INFO: 'hasHomeAddressInfo',
         HAS_SUBSCRIPTION_INFO: 'hasSubscriptionInfo',
         HAS_PHONE_NUMBER_ERROR: 'hasPhoneNumberError',
         HAS_PENDING_CARD_INFO: 'hasPendingCardInfo',

--- a/src/hooks/useAccountIndicatorChecks.ts
+++ b/src/hooks/useAccountIndicatorChecks.ts
@@ -4,6 +4,8 @@ import {hasPendingExpensifyCardAction} from '@libs/CardUtils';
 import {hasSubscriptionGreenDotInfo, hasSubscriptionRedDotError} from '@libs/SubscriptionUtils';
 import {expensifyLoginsSelector, hasDeviceManagementError, hasLoginListError, hasLoginListInfo} from '@libs/UserUtils';
 
+import useTimeSensitiveHomeAddress from '@pages/home/TimeSensitiveSection/hooks/useTimeSensitiveHomeAddress';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type IndicatorStatus from '@src/types/utils/IndicatorStatus';
@@ -42,6 +44,7 @@ function useAccountIndicatorChecks(): AccountIndicatorChecksResult {
         companyCards: {shouldShowRBR: hasCompanyCardFeedErrors},
     } = useCardFeedErrors();
     const {isPolicyAdmin} = usePoliciesWithCardFeedErrors();
+    const {shouldShowAddHomeAddress} = useTimeSensitiveHomeAddress();
 
     const accountChecks: Partial<Record<IndicatorStatus, boolean>> = {
         [CONST.INDICATOR_STATUS.HAS_USER_WALLET_ERRORS]: Object.keys(userWallet?.errors ?? {}).length > 0,
@@ -69,6 +72,7 @@ function useAccountIndicatorChecks(): AccountIndicatorChecksResult {
 
     const infoChecks: Partial<Record<IndicatorStatus, boolean>> = {
         [CONST.INDICATOR_STATUS.HAS_LOGIN_LIST_INFO]: !!loginList && hasLoginListInfo(loginList, session?.email),
+        [CONST.INDICATOR_STATUS.HAS_HOME_ADDRESS_INFO]: shouldShowAddHomeAddress,
         [CONST.INDICATOR_STATUS.HAS_PENDING_CARD_INFO]: hasPendingExpensifyCardAction(allCards, privatePersonalDetails),
         [CONST.INDICATOR_STATUS.HAS_SUBSCRIPTION_INFO]: hasSubscriptionGreenDotInfo(
             stripeCustomerId,

--- a/src/libs/UserUtils.ts
+++ b/src/libs/UserUtils.ts
@@ -190,12 +190,13 @@ function getProfilePageBrickRoadIndicator(
     privatePersonalDetails: OnyxEntry<PrivatePersonalDetails>,
     vacationDelegate: OnyxEntry<VacationDelegate>,
     email: string | undefined,
+    shouldShowAddHomeAddress = false,
 ): LoginListIndicator {
     const hasPhoneNumberError = !!privatePersonalDetails?.errorFields?.phoneNumber;
     if (hasLoginListError(loginList) || hasPhoneNumberError || !isEmptyObject(vacationDelegate?.errors)) {
         return CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR;
     }
-    if (hasLoginListInfo(loginList, email)) {
+    if (hasLoginListInfo(loginList, email) || shouldShowAddHomeAddress) {
         return CONST.BRICK_ROAD_INDICATOR_STATUS.INFO;
     }
 

--- a/src/pages/settings/useInitialSettingsPageMenuData.ts
+++ b/src/pages/settings/useInitialSettingsPageMenuData.ts
@@ -26,6 +26,7 @@ import {getFreeTrialText, hasSubscriptionRedDotError} from '@libs/SubscriptionUt
 import {shouldHideOldAppRedirect} from '@libs/TryNewDotUtils';
 import {expensifyLoginsSelector, getProfilePageBrickRoadIndicator, hasDeviceManagementError} from '@libs/UserUtils';
 
+import useTimeSensitiveHomeAddress from '@pages/home/TimeSensitiveSection/hooks/useTimeSensitiveHomeAddress';
 import {BACKGROUND_LOCATION_TRACKING_TASK_NAME} from '@pages/iou/request/step/IOURequestStepDistanceGPS/const';
 import {stopGpsTripNotification} from '@pages/iou/request/step/IOURequestStepDistanceGPS/GPSNotifications';
 
@@ -85,6 +86,7 @@ function useInitialSettingsPageMenuData(currentUserPersonalDetails: CurrentUserP
     const {translate} = useLocalize();
     const hasActivatedWallet = ([CONST.WALLET.TIER_NAME.GOLD, CONST.WALLET.TIER_NAME.PLATINUM] as string[]).includes(userWallet?.tierName ?? '');
     const hasLockedBankAccount = bankAccountList ? Object.values(bankAccountList).some((bankAccount) => bankAccount.accountData?.state === CONST.BANK_ACCOUNT.STATE.LOCKED) : false;
+    const {shouldShowAddHomeAddress} = useTimeSensitiveHomeAddress();
     const [firstDayFreeTrial] = useOnyx(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL);
     const [isTrackingGPS = false] = useOnyx(ONYXKEYS.GPS_DRAFT_DETAILS, {
         selector: isTrackingSelector,
@@ -233,7 +235,7 @@ function useInitialSettingsPageMenuData(currentUserPersonalDetails: CurrentUserP
         surveyCompletedWithinLastMonth = daysSinceLastSurvey < surveyThresholdInDays;
     }
 
-    const profileBrickRoadIndicator = getProfilePageBrickRoadIndicator(loginList, privatePersonalDetails, vacationDelegate, session?.email);
+    const profileBrickRoadIndicator = getProfilePageBrickRoadIndicator(loginList, privatePersonalDetails, vacationDelegate, session?.email, shouldShowAddHomeAddress);
     const securityBrickRoadIndicator = hasDeviceManagementErrorValue ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined;
     const accountItems = navigationAccountMenuItemsData.items.map((item): MenuData => {
         if (item.screenName === SCREENS.SETTINGS.PROFILE.ROOT) {

--- a/tests/ui/InitialSettingsPageTest.tsx
+++ b/tests/ui/InitialSettingsPageTest.tsx
@@ -250,6 +250,26 @@ describe('InitialSettingsPage - agent account', () => {
         });
     });
 
+    it('shows info GBR on Profile when commuter exclusions require a missing home address', async () => {
+        await setupUser('user@expensify.com');
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}1`, {
+                id: '1',
+                name: 'Boulder Development',
+                commuterExclusions: {method: 'homeAndOffice'},
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('decoration-Profile-rbr').children).toEqual([CONST.BRICK_ROAD_INDICATOR_STATUS.INFO]);
+        });
+    });
+
     it('shows Subscription for agent account', async () => {
         mockUseSubscriptionPlan.mockReturnValue(CONST.POLICY.TYPE.TEAM);
         await setupUser('testbot_123@expensify.ai', true);

--- a/tests/unit/useAccountTabIndicatorStatusTest.ts
+++ b/tests/unit/useAccountTabIndicatorStatusTest.ts
@@ -73,6 +73,11 @@ const TEST_CASES = {
         indicatorColor: defaultTheme.success,
         status: CONST.INDICATOR_STATUS.HAS_LOGIN_LIST_INFO,
     },
+    hasHomeAddressInfo: {
+        name: 'has missing home address info',
+        indicatorColor: defaultTheme.success,
+        status: CONST.INDICATOR_STATUS.HAS_HOME_ADDRESS_INFO,
+    },
     hasEmployeeCardFeedErrors: accountCardFeedTestCases.employee,
     hasPolicyAdminCardFeedErrors: accountCardFeedTestCases.admin,
     hasLockedBankAccount: {
@@ -156,6 +161,14 @@ const getMockForTestCase = ({name, status}: IndicatorTestCase) =>
                     : undefined,
         },
         [ONYXKEYS.PRIVATE_PERSONAL_DETAILS]: {
+            addresses:
+                status === CONST.INDICATOR_STATUS.HAS_HOME_ADDRESS_INFO
+                    ? []
+                    : [
+                          {
+                              street: '123 Test St',
+                          },
+                      ],
             errorFields:
                 status === CONST.INDICATOR_STATUS.HAS_PHONE_NUMBER_ERROR
                     ? {
@@ -172,6 +185,7 @@ const getMockForTestCase = ({name, status}: IndicatorTestCase) =>
             owner: name === accountCardFeedTestCases.admin.name ? 'johndoe12@expensify.com' : 'otheruser@expensify.com',
             role: name === accountCardFeedTestCases.admin.name ? 'admin' : 'user',
             policyAccountID: cardFeed.policyAccountID,
+            commuterExclusions: status === CONST.INDICATOR_STATUS.HAS_HOME_ADDRESS_INFO ? {method: CONST.POLICY.COMMUTER_EXCLUSION_METHOD.HOME_AND_OFFICE} : undefined,
         },
         [ONYXKEYS.CARD_LIST]: {
             card123: {


### PR DESCRIPTION
### Explanation of Change
This PR updates the initial Settings menu so the `Account -> Profile` row shows an info GBR as soon as commuter exclusions require a home address and the user does not have one saved.

The fix keeps the existing home-address detection in App and threads `shouldShowAddHomeAddress` into `getProfilePageBrickRoadIndicator(...)`, so the parent Profile row becomes formally flagged immediately instead of waiting for the user to enter the Profile page.

### Fixed Issues
$ https://github.com/Expensify/App/issues/99720
PROPOSAL: N/A

### Tests
1. Open an account that belongs to a workspace with Distance enabled and commuter exclusions set to `Calculate by home and office`.
2. Make sure the account does not have a saved home address.
3. Go to `Settings > Account > Profile`.
4. Verify 
    - The `Profile` menu row shows an info GBR.
    - The account tab GBR
5. Open `Profile`.
6. Verify the `Home address` row still shows the same info GBR.
7. Add a home address.
8. Verify the GBR disappears from both `Profile` and `Home address`.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<img width="1540" height="962" alt="Screenshot 2026-08-29 at 8 53 26 PM" src="https://github.com/user-attachments/assets/3290df58-46db-46b5-bcbb-e9c9d63f9975" />
