### PR TITLE
[No QA] Fade Spend page results on query changes (temp branch for adhoc iOS build)

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -7759,7 +7759,7 @@ const CONST = {
         SAVED_SEARCH_PREFIX: 'savedSearch_',
         GROUP_PREFIX: 'group_',
         ANIMATION: {
-            FADE_DURATION: 200,
+            FADE_DURATION: 150,
         },
         TODO_BADGE_MAX_COUNT: 50,
         TOP_SEARCH_LIMIT: 10,

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -7759,7 +7759,15 @@ const CONST = {
         SAVED_SEARCH_PREFIX: 'savedSearch_',
         GROUP_PREFIX: 'group_',
         ANIMATION: {
-            FADE_DURATION: 150,
+            FADE_DURATION: 120,
+
+            // How long the outgoing results stay put before they start fading. The incoming results mount straight
+            // away but hydrate behind them, so this window is what keeps their placeholder skeleton off screen.
+            SWAP_HOLD_DURATION: 100,
+
+            // How long the results area may keep showing the previous query's results while a new query loads. Past
+            // this, a slow query gives up the stale results and swaps to the skeleton so the wait is visible.
+            MAX_STALE_HOLD_DURATION: 1000,
         },
         TODO_BADGE_MAX_COUNT: 50,
         TOP_SEARCH_LIMIT: 10,

--- a/src/components/Search/SearchLoadingSkeleton.tsx
+++ b/src/components/Search/SearchLoadingSkeleton.tsx
@@ -10,7 +10,8 @@ import CONST from '@src/CONST';
 import type {StyleProp, ViewStyle} from 'react-native';
 
 import React from 'react';
-import Animated, {FadeIn, FadeOut} from 'react-native-reanimated';
+import {StyleSheet} from 'react-native';
+import Animated, {FadeOut} from 'react-native-reanimated';
 
 type SearchLoadingSkeletonProps = {
     containerStyle?: StyleProp<ViewStyle>;
@@ -20,10 +21,11 @@ function SearchLoadingSkeleton({containerStyle}: SearchLoadingSkeletonProps) {
     const styles = useThemeStyles();
 
     return (
+        // The skeleton is absolutely filled so that its exit fade overlays the incoming results instead of
+        // sharing the parent's column layout with them, which would halve both heights for the fade duration.
         <Animated.View
-            entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
             exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
-            style={[styles.flex1]}
+            style={[styles.flex1, StyleSheet.absoluteFill]}
             onLayout={() => {
                 endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: false});
                 endNavigateToReportsFirstPaint(CONST.TELEMETRY.NAVIGATE_TO_REPORTS_START_TYPE.COLD);

--- a/src/components/Search/SearchWithNavigationDeferredMount.tsx
+++ b/src/components/Search/SearchWithNavigationDeferredMount.tsx
@@ -13,6 +13,8 @@ import CONST from '@src/CONST';
 import type {ComponentProps} from 'react';
 
 import React from 'react';
+import {StyleSheet} from 'react-native';
+import Animated, {FadeOut} from 'react-native-reanimated';
 
 import Search from './index';
 
@@ -39,11 +41,18 @@ function SearchWithNavigationDeferredMount(props: ComponentProps<typeof Search>)
         <NavigationDeferredMount
             waitForUpcomingTransition={false}
             placeholder={
-                <SearchRowSkeleton
-                    shouldAnimate
-                    onLayout={handleSkeletonLayout}
-                    containerStyle={containerStyle}
-                />
+                // Absolutely filled so the exit fade overlays the incoming Search content rather than sharing
+                // the parent's column layout with it, which would halve both heights for the fade duration.
+                <Animated.View
+                    exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                    style={[styles.flex1, StyleSheet.absoluteFill]}
+                >
+                    <SearchRowSkeleton
+                        shouldAnimate
+                        onLayout={handleSkeletonLayout}
+                        containerStyle={containerStyle}
+                    />
+                </Animated.View>
             }
         >
             <Search {...props} />

--- a/src/components/Search/hooks/useUpdateFilterQuery.tsx
+++ b/src/components/Search/hooks/useUpdateFilterQuery.tsx
@@ -3,6 +3,7 @@ import type {SearchQueryJSON} from '@components/Search/types';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 
+import HapticFeedback from '@libs/HapticFeedback';
 import Navigation from '@libs/Navigation/Navigation';
 import {markQueryAsRefinement} from '@libs/SearchQueryRefinement';
 import {buildFilterQueryWithSortDefaults} from '@libs/SearchQueryUtils';
@@ -50,6 +51,7 @@ function useUpdateFilterQuery(queryJSON: SearchQueryJSON | undefined) {
             return;
         }
 
+        HapticFeedback.press();
         markQueryAsRefinement(queryString);
         Navigation.setParams({q: queryString, rawQuery: undefined});
     }

--- a/src/components/Search/hooks/useUpdateFilterQuery.tsx
+++ b/src/components/Search/hooks/useUpdateFilterQuery.tsx
@@ -4,6 +4,7 @@ import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 
 import Navigation from '@libs/Navigation/Navigation';
+import {markQueryAsRefinement} from '@libs/SearchQueryRefinement';
 import {buildFilterQueryWithSortDefaults} from '@libs/SearchQueryUtils';
 import {filterValidHasValues} from '@libs/SearchUIUtils';
 
@@ -49,6 +50,7 @@ function useUpdateFilterQuery(queryJSON: SearchQueryJSON | undefined) {
             return;
         }
 
+        markQueryAsRefinement(queryString);
         Navigation.setParams({q: queryString, rawQuery: undefined});
     }
 

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -88,7 +88,7 @@ import {findFocusedRoute, useFocusEffect, useIsFocused, useNavigation} from '@re
 import * as Sentry from '@sentry/react-native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
-import Animated, {FadeIn, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
+import Animated, {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 
 import type {ReportActionListItemType, SearchListItem, TransactionGroupListItemType, TransactionListItemType, TransactionReportGroupListItemType} from './SearchList/ListItem/types';
 import type {CommonSearchViewProps} from './searchViewProps';
@@ -1064,10 +1064,7 @@ function Search({
     ) {
         cancelNavigationSpans();
         return (
-            <Animated.View
-                entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
-                style={[styles.flex1, isInLandscapeMode ? undefined : [shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3]]}
-            >
+            <View style={[styles.flex1, isInLandscapeMode ? undefined : [shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3]]}>
                 <EmptySearchView
                     similarSearchHash={similarSearchHash}
                     type={type}
@@ -1077,7 +1074,7 @@ function Search({
                     onScroll={onSearchListScroll}
                     contentContainerStyle={isInLandscapeMode ? styles.searchListContentContainerStyles(!!hasFilterBars) : undefined}
                 />
-            </Animated.View>
+            </View>
         );
     }
 
@@ -1114,10 +1111,7 @@ function Search({
                     onLayout={onLayoutChart}
                     scrollEventThrottle={CONST.TIMING.MIN_SMOOTH_SCROLL_EVENT_THROTTLE}
                 >
-                    <Animated.View
-                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
-                        style={[shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3, styles.mh4, styles.mb4, styles.flex1]}
-                    >
+                    <View style={[shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3, styles.mh4, styles.mb4, styles.flex1]}>
                         <SearchChartWrapper
                             title={chartTitle}
                             groupBy={validGroupBy}
@@ -1130,7 +1124,7 @@ function Search({
                                 isLoading={shouldShowLoadingState}
                             />
                         </SearchChartWrapper>
-                    </Animated.View>
+                    </View>
                 </Animated.ScrollView>
             </SearchScopeProvider>
         );
@@ -1238,15 +1232,7 @@ function Search({
                 isExpenseReportType={isExpenseReportType}
                 isSearchResultsEmpty={isSearchResultsEmpty}
             >
-                <Animated.View style={[styles.flex1, animatedStyle]}>
-                    {/* The inner view owns the mount fade so it composes with the outer column-change opacity instead of fighting it. */}
-                    <Animated.View
-                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
-                        style={styles.flex1}
-                    >
-                        {searchListContent}
-                    </Animated.View>
-                </Animated.View>
+                <Animated.View style={[styles.flex1, animatedStyle]}>{searchListContent}</Animated.View>
             </SearchWriteActionsProvider>
         </SearchScopeProvider>
     );

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -88,7 +88,7 @@ import {findFocusedRoute, useFocusEffect, useIsFocused, useNavigation} from '@re
 import * as Sentry from '@sentry/react-native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
-import Animated, {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
+import Animated, {FadeIn, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 
 import type {ReportActionListItemType, SearchListItem, TransactionGroupListItemType, TransactionListItemType, TransactionReportGroupListItemType} from './SearchList/ListItem/types';
 import type {CommonSearchViewProps} from './searchViewProps';
@@ -1064,7 +1064,10 @@ function Search({
     ) {
         cancelNavigationSpans();
         return (
-            <View style={[styles.flex1, isInLandscapeMode ? undefined : [shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3]]}>
+            <Animated.View
+                entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                style={[styles.flex1, isInLandscapeMode ? undefined : [shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3]]}
+            >
                 <EmptySearchView
                     similarSearchHash={similarSearchHash}
                     type={type}
@@ -1074,7 +1077,7 @@ function Search({
                     onScroll={onSearchListScroll}
                     contentContainerStyle={isInLandscapeMode ? styles.searchListContentContainerStyles(!!hasFilterBars) : undefined}
                 />
-            </View>
+            </Animated.View>
         );
     }
 
@@ -1111,7 +1114,10 @@ function Search({
                     onLayout={onLayoutChart}
                     scrollEventThrottle={CONST.TIMING.MIN_SMOOTH_SCROLL_EVENT_THROTTLE}
                 >
-                    <View style={[shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3, styles.mh4, styles.mb4, styles.flex1]}>
+                    <Animated.View
+                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                        style={[shouldUseNarrowLayout ? styles.searchListContentContainerStyles(!!hasFilterBars) : styles.mt3, styles.mh4, styles.mb4, styles.flex1]}
+                    >
                         <SearchChartWrapper
                             title={chartTitle}
                             groupBy={validGroupBy}
@@ -1124,7 +1130,7 @@ function Search({
                                 isLoading={shouldShowLoadingState}
                             />
                         </SearchChartWrapper>
-                    </View>
+                    </Animated.View>
                 </Animated.ScrollView>
             </SearchScopeProvider>
         );
@@ -1232,7 +1238,15 @@ function Search({
                 isExpenseReportType={isExpenseReportType}
                 isSearchResultsEmpty={isSearchResultsEmpty}
             >
-                <Animated.View style={[styles.flex1, animatedStyle]}>{searchListContent}</Animated.View>
+                <Animated.View style={[styles.flex1, animatedStyle]}>
+                    {/* The inner view owns the mount fade so it composes with the outer column-change opacity instead of fighting it. */}
+                    <Animated.View
+                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                        style={styles.flex1}
+                    >
+                        {searchListContent}
+                    </Animated.View>
+                </Animated.View>
             </SearchWriteActionsProvider>
         </SearchScopeProvider>
     );

--- a/src/libs/SearchNavigationUtils.ts
+++ b/src/libs/SearchNavigationUtils.ts
@@ -1,9 +1,11 @@
 import ROUTES from '@src/ROUTES';
 
 import {setSearchContext} from './actions/Search';
+import HapticFeedback from './HapticFeedback';
 import Navigation from './Navigation/Navigation';
 
 function navigateToCannedSpendSearch(searchQuery: string, clearSelectedTransactions: () => void) {
+    HapticFeedback.press();
     clearSelectedTransactions();
     setSearchContext(false);
     Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: searchQuery}));

--- a/src/libs/SearchQueryRefinement.ts
+++ b/src/libs/SearchQueryRefinement.ts
@@ -1,0 +1,24 @@
+import type {SearchQueryString} from '@components/Search/types';
+
+/**
+ * Records which search query was produced by refining the filters of the list already on screen.
+ *
+ * The results area holds the previous query's results through its swap animation so a filter tweak doesn't flash a
+ * skeleton. That only reads correctly for a refinement: navigating to a sidebar item or a saved search asks for a
+ * different search, where holding the old results would show rows unrelated to the destination. A query alone can't
+ * tell the two apart — both arrive as a new `q` on the same screen — so the filter path records its query here.
+ *
+ * Only the most recent query is kept: an unknown query is treated as a different search, so a missed mark costs a
+ * skeleton rather than showing stale results.
+ */
+let refinedQuery: SearchQueryString | undefined;
+
+function markQueryAsRefinement(query: SearchQueryString) {
+    refinedQuery = query;
+}
+
+function isQueryARefinement(query: SearchQueryString | undefined) {
+    return !!query && refinedQuery === query;
+}
+
+export {markQueryAsRefinement, isQueryARefinement};

--- a/src/pages/Search/SavedSearchList.tsx
+++ b/src/pages/Search/SavedSearchList.tsx
@@ -14,6 +14,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import {setSearchContext} from '@libs/actions/Search';
 import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
+import HapticFeedback from '@libs/HapticFeedback';
 import Navigation from '@libs/Navigation/Navigation';
 import {getAllTaxRates} from '@libs/PolicyUtils';
 import type {SavedSearchMenuItem} from '@libs/SearchUIUtils';
@@ -61,6 +62,7 @@ function buildSavedSearchMenuItem({item, key, index, hash, title, getOverflowMen
         role: CONST.ROLE.TAB,
         sentryLabel: CONST.SENTRY_LABEL.SEARCH.SAVED_SEARCH_MENU_ITEM,
         onPress: () => {
+            HapticFeedback.press();
             setSearchContext(false);
             Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: item?.query ?? '', name: item?.name}));
         },

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -1,6 +1,6 @@
 import {ReportSubmitToPopoverHost, SEARCH_REPORT_SUBMIT_TO_POPOVER_ANCHOR_ALIGNMENT} from '@components/ReportSubmitToPopoverAnchor';
 import {useSearchQueryContext, useSearchResultsActions, useSearchResultsContext, useSearchSelectionActions} from '@components/Search/SearchContext';
-import type {SearchParams} from '@components/Search/types';
+import type {SearchParams, SearchQueryJSON} from '@components/Search/types';
 import {usePlaybackActionsContext} from '@components/VideoPlayerContexts/PlaybackContext';
 
 import useDocumentTitle from '@hooks/useDocumentTitle';
@@ -20,8 +20,10 @@ import {searchInServer} from '@libs/actions/Report';
 import {clearFooterConversion, search} from '@libs/actions/Search';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
+import {isQueryARefinement} from '@libs/SearchQueryRefinement';
 import {isSearchDataLoaded} from '@libs/SearchUIUtils';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
 import {hasFilterBarsSelector} from '@src/selectors/AdvancedSearchFiltersForm';
@@ -111,6 +113,43 @@ function SearchPage({route}: SearchPageProps) {
         setIsSorting(false);
     }, [currentSearchResults?.isLoading, isSorting, prevIsLoading]);
 
+    const [lastResolvedSearch, setLastResolvedSearch] = useState<{queryJSON: SearchQueryJSON; searchResults: SearchResults} | undefined>(undefined);
+
+    // Changing a filter builds a query that has never been cached, so keying the results area on the requested
+    // query would mount it with no data and flash a skeleton in the middle of the fade. Key it on the last query
+    // that actually resolved instead: the current results stay on screen until the new ones arrive, then the area
+    // swaps once. Adjusted during rendering for the same reason as lastNonEmptySearchResults above — the values
+    // below are consumed in this render, and the reference check bounds the loop to one extra pass.
+    // isCurrentSearchResolved, not a raw hash comparison: a response folds sort defaults into its own hash, so the
+    // requested and returned hashes legitimately differ and isSearchDataLoaded is what reconciles them.
+    const isSearchResolvedForCurrentQuery = isCurrentSearchResolved && !!searchResults && !!currentSearchQueryJSON;
+    if (isSearchResolvedForCurrentQuery && currentSearchQueryJSON && searchResults && lastResolvedSearch?.searchResults !== searchResults) {
+        setLastResolvedSearch({queryJSON: currentSearchQueryJSON, searchResults});
+    }
+
+    // A slow query would otherwise leave the previous results up indefinitely with nothing to show a wait is happening
+    // (the wide layout has no loading bar). Keyed by hash rather than reset on resolve so the effect never has to call
+    // setState synchronously; a hash that no longer matches simply stops counting.
+    const [staleHoldTimedOutHash, setStaleHoldTimedOutHash] = useState<number | undefined>(undefined);
+    const currentQueryHash = currentSearchQueryJSON?.hash;
+
+    useEffect(() => {
+        if (isSearchResolvedForCurrentQuery || currentQueryHash === undefined) {
+            return;
+        }
+
+        const timeoutID = setTimeout(() => setStaleHoldTimedOutHash(currentQueryHash), CONST.SEARCH.ANIMATION.MAX_STALE_HOLD_DURATION);
+        return () => clearTimeout(timeoutID);
+    }, [isSearchResolvedForCurrentQuery, currentQueryHash]);
+
+    const hasStaleHoldTimedOut = staleHoldTimedOutHash !== undefined && staleHoldTimedOutHash === currentQueryHash;
+
+    // Only a filter refinement is worth holding for. A sidebar item or saved search is a different search, so its
+    // results area starts from the skeleton rather than showing rows that belong to the query the user just left.
+    const shouldHoldLastResolvedSearch = !isSearchResolvedForCurrentQuery && !!lastResolvedSearch && !hasStaleHoldTimedOut && isQueryARefinement(currentSearchQueryJSON?.inputQuery);
+    const contentQueryJSON = shouldHoldLastResolvedSearch ? lastResolvedSearch.queryJSON : currentSearchQueryJSON;
+    const contentSearchResults = shouldHoldLastResolvedSearch ? lastResolvedSearch.searchResults : searchResults;
+
     const handleSearchAction = useCallback((value: SearchParams | string) => {
         if (typeof value === 'string') {
             searchInServer(value);
@@ -143,6 +182,8 @@ function SearchPage({route}: SearchPageProps) {
                         <SearchPageNarrow
                             queryJSON={currentSearchQueryJSON}
                             searchResults={searchResults}
+                            contentQueryJSON={contentQueryJSON}
+                            contentSearchResults={contentSearchResults}
                             isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
                             onSortPressedCallback={onSortPressedCallback}
                             searchOverlayContent={searchOverlayContent}
@@ -154,6 +195,8 @@ function SearchPage({route}: SearchPageProps) {
                         <SearchPageWide
                             queryJSON={currentSearchQueryJSON}
                             searchResults={searchResults}
+                            contentQueryJSON={contentQueryJSON}
+                            contentSearchResults={contentSearchResults}
                             isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
                             handleSearchAction={handleSearchAction}
                             onSortPressedCallback={onSortPressedCallback}

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -55,6 +55,13 @@ const ANIMATION_DURATION_IN_MS = 300;
 type SearchPageNarrowProps = {
     queryJSON?: SearchQueryJSON;
     searchResults?: SearchResults;
+
+    /** The last query whose results resolved. Drives the results area so it holds the current results while a new query loads. */
+    contentQueryJSON?: SearchQueryJSON;
+
+    /** Results for `contentQueryJSON`. */
+    contentSearchResults?: SearchResults;
+
     isMobileSelectionModeEnabled: boolean;
     onSortPressedCallback: () => void;
     /** Overlay rendered above Search content during expense-creation flows (SearchStaticList or null). */
@@ -72,6 +79,8 @@ const tabBarContent = <TabBarBottomContent selectedTab={NAVIGATION_TABS.SEARCH} 
 function SearchPageNarrow({
     queryJSON,
     searchResults,
+    contentQueryJSON,
+    contentSearchResults,
     isMobileSelectionModeEnabled,
     onSortPressedCallback,
     searchOverlayContent,
@@ -79,7 +88,7 @@ function SearchPageNarrow({
     hasFilterBars,
     isOverlayActive,
 }: SearchPageNarrowProps) {
-    const shouldShowLoadingSkeleton = useSearchLoadingState(queryJSON, searchResults);
+    const shouldShowLoadingSkeleton = useSearchLoadingState(contentQueryJSON, contentSearchResults);
     const {translate} = useLocalize();
     const {windowHeight} = useWindowDimensions();
     const styles = useThemeStyles();
@@ -208,7 +217,8 @@ function SearchPageNarrow({
         }, [isHeaderInteractive, isInteractive, startTransition]),
     );
 
-    if (!queryJSON) {
+    // contentQueryJSON falls back to queryJSON upstream, so the two are always absent together.
+    if (!queryJSON || !contentQueryJSON) {
         return (
             <ScreenWrapper
                 testID="SearchPageNarrow"
@@ -309,9 +319,9 @@ function SearchPageNarrow({
                             <>
                                 {isInteractive && (
                                     <Search
-                                        searchResults={searchResults}
-                                        queryJSON={queryJSON}
-                                        key={queryJSON.hash}
+                                        searchResults={contentSearchResults}
+                                        queryJSON={contentQueryJSON}
+                                        key={contentQueryJSON.hash}
                                         contentContainerStyle={contentContainerStyle}
                                         handleSearch={handleSearchAction}
                                         isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
@@ -336,21 +346,23 @@ function SearchPageNarrow({
                             <>
                                 {/* skipEntering keeps the delayed fade off the very first mount, so opening Search cold paints immediately. */}
                                 <LayoutAnimationConfig skipEntering>
-                                    {/* Changing the search type or a filter changes the hash, which remounts this layer: the outgoing one
-                                        fades out and the incoming one waits for it to finish before fading in. Both layers are absolutely
-                                        filled so the outgoing fade overlays the incoming layer instead of sharing the column layout. */}
+                                    {/* A resolved query change remounts this layer. The outgoing one holds, then fades out; the incoming
+                                        one stays hidden until that finishes, which also hides its own mount. Both layers are absolutely
+                                        filled so they stack during the hold instead of sharing the column layout. */}
                                     <Animated.View
-                                        key={queryJSON.hash}
-                                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(CONST.SEARCH.ANIMATION.FADE_DURATION)}
-                                        exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                                        key={contentQueryJSON.hash}
+                                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(
+                                            CONST.SEARCH.ANIMATION.SWAP_HOLD_DURATION + CONST.SEARCH.ANIMATION.FADE_DURATION,
+                                        )}
+                                        exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(CONST.SEARCH.ANIMATION.SWAP_HOLD_DURATION)}
                                         style={StyleSheet.absoluteFill}
                                     >
                                         {shouldShowLoadingSkeleton ? (
                                             <SearchLoadingSkeleton containerStyle={styles.searchListContentContainerStyles(hasFilterBars)} />
                                         ) : (
                                             <SearchWithNavigationDeferredMount
-                                                searchResults={searchResults}
-                                                queryJSON={queryJSON}
+                                                searchResults={contentSearchResults}
+                                                queryJSON={contentQueryJSON}
                                                 onSearchListScroll={scrollHandler}
                                                 contentContainerStyle={contentContainerStyle}
                                                 handleSearch={handleSearchAction}

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -43,7 +43,7 @@ import type {SearchResults} from '@src/types/onyx';
 import {useFocusEffect, useNavigation, useRoute} from '@react-navigation/native';
 import React, {useCallback, useContext, useEffect, useRef, useState, useTransition} from 'react';
 import {StyleSheet, View} from 'react-native';
-import Animated, {clamp, useAnimatedScrollHandler, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
+import Animated, {clamp, FadeIn, FadeOut, LayoutAnimationConfig, useAnimatedScrollHandler, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import {scheduleOnRN} from 'react-native-worklets';
 
 import {SearchActionsBarSwitch, SearchFiltersBarSwitch, SearchPageInputSwitch, SearchTypeMenuSwitch} from './Switches';
@@ -334,22 +334,34 @@ function SearchPageNarrow({
                         )}
                         {!useStaticRendering && (
                             <>
-                                {shouldShowLoadingSkeleton ? (
-                                    <SearchLoadingSkeleton containerStyle={styles.searchListContentContainerStyles(hasFilterBars)} />
-                                ) : (
-                                    <SearchWithNavigationDeferredMount
-                                        searchResults={searchResults}
-                                        queryJSON={queryJSON}
+                                {/* skipEntering keeps the delayed fade off the very first mount, so opening Search cold paints immediately. */}
+                                <LayoutAnimationConfig skipEntering>
+                                    {/* Changing the search type or a filter changes the hash, which remounts this layer: the outgoing one
+                                        fades out and the incoming one waits for it to finish before fading in. Both layers are absolutely
+                                        filled so the outgoing fade overlays the incoming layer instead of sharing the column layout. */}
+                                    <Animated.View
                                         key={queryJSON.hash}
-                                        onSearchListScroll={scrollHandler}
-                                        contentContainerStyle={contentContainerStyle}
-                                        handleSearch={handleSearchAction}
-                                        isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                                        onDestinationVisible={endSubmitNavigationSpans}
-                                        onContentReady={onSearchContentReady}
-                                        hasFilterBars={hasFilterBars}
-                                    />
-                                )}
+                                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                                        exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                                        style={StyleSheet.absoluteFill}
+                                    >
+                                        {shouldShowLoadingSkeleton ? (
+                                            <SearchLoadingSkeleton containerStyle={styles.searchListContentContainerStyles(hasFilterBars)} />
+                                        ) : (
+                                            <SearchWithNavigationDeferredMount
+                                                searchResults={searchResults}
+                                                queryJSON={queryJSON}
+                                                onSearchListScroll={scrollHandler}
+                                                contentContainerStyle={contentContainerStyle}
+                                                handleSearch={handleSearchAction}
+                                                isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                                                onDestinationVisible={endSubmitNavigationSpans}
+                                                onContentReady={onSearchContentReady}
+                                                hasFilterBars={hasFilterBars}
+                                            />
+                                        )}
+                                    </Animated.View>
+                                </LayoutAnimationConfig>
                                 {shouldRenderLayoutProbe && <View onLayout={onSearchLayout} />}
                                 {!!searchOverlayContent && (
                                     <View

--- a/src/pages/Search/SearchPageWide.tsx
+++ b/src/pages/Search/SearchPageWide.tsx
@@ -37,6 +37,13 @@ import Animated, {FadeIn, FadeOut, LayoutAnimationConfig} from 'react-native-rea
 type SearchPageWideProps = {
     queryJSON?: SearchQueryJSON;
     searchResults: OnyxEntry<SearchResults>;
+
+    /** The last query whose results resolved. Drives the results area so it holds the current results while a new query loads. */
+    contentQueryJSON?: SearchQueryJSON;
+
+    /** Results for `contentQueryJSON`. */
+    contentSearchResults: OnyxEntry<SearchResults>;
+
     isMobileSelectionModeEnabled: boolean;
     handleSearchAction: (value: SearchParams | string) => void;
     onSortPressedCallback: () => void;
@@ -50,6 +57,8 @@ type SearchPageWideProps = {
 function SearchPageWide({
     queryJSON,
     searchResults,
+    contentQueryJSON,
+    contentSearchResults,
     isMobileSelectionModeEnabled,
     handleSearchAction,
     onSortPressedCallback,
@@ -57,7 +66,7 @@ function SearchPageWide({
     searchOverlayContent,
     onSearchContentReady,
 }: SearchPageWideProps) {
-    const shouldShowLoadingSkeleton = useSearchLoadingState(queryJSON, searchResults);
+    const shouldShowLoadingSkeleton = useSearchLoadingState(contentQueryJSON, contentSearchResults);
     const styles = useThemeStyles();
     const {currentSearchKey} = useSearchQueryContext();
     const {hasSelectedTransactions} = useSearchSelectionContext();
@@ -113,7 +122,7 @@ function SearchPageWide({
                     onBackButtonPress={handleOnBackButtonPress}
                     shouldShowLink={false}
                 >
-                    {!!queryJSON && (
+                    {!!queryJSON && !!contentQueryJSON && (
                         <>
                             <SearchPageHeaderWide queryJSON={queryJSON} />
                             <SearchActionsBarWide
@@ -124,21 +133,23 @@ function SearchPageWide({
                             <View style={styles.flex1}>
                                 {/* skipEntering keeps the delayed fade off the very first mount, so opening Search cold paints immediately. */}
                                 <LayoutAnimationConfig skipEntering>
-                                    {/* Changing the search type or a filter changes the hash, which remounts this layer: the outgoing one
-                                        fades out and the incoming one waits for it to finish before fading in. Both layers are absolutely
-                                        filled so the outgoing fade overlays the incoming layer instead of sharing the column layout. */}
+                                    {/* A resolved query change remounts this layer. The outgoing one holds, then fades out; the incoming
+                                        one stays hidden until that finishes, which also hides its own mount. Both layers are absolutely
+                                        filled so they stack during the hold instead of sharing the column layout. */}
                                     <Animated.View
-                                        key={queryJSON.hash}
-                                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(CONST.SEARCH.ANIMATION.FADE_DURATION)}
-                                        exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                                        key={contentQueryJSON.hash}
+                                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(
+                                            CONST.SEARCH.ANIMATION.SWAP_HOLD_DURATION + CONST.SEARCH.ANIMATION.FADE_DURATION,
+                                        )}
+                                        exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(CONST.SEARCH.ANIMATION.SWAP_HOLD_DURATION)}
                                         style={StyleSheet.absoluteFill}
                                     >
                                         {shouldShowLoadingSkeleton ? (
                                             <SearchLoadingSkeleton />
                                         ) : (
                                             <SearchWithNavigationDeferredMount
-                                                queryJSON={queryJSON}
-                                                searchResults={searchResults}
+                                                queryJSON={contentQueryJSON}
+                                                searchResults={contentSearchResults}
                                                 handleSearch={handleSearchAction}
                                                 isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
                                                 onSearchListScroll={scrollHandler}

--- a/src/pages/Search/SearchPageWide.tsx
+++ b/src/pages/Search/SearchPageWide.tsx
@@ -22,6 +22,7 @@ import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
 
 import Navigation from '@navigation/Navigation';
 
+import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {SearchResults} from '@src/types/onyx';
@@ -31,7 +32,7 @@ import type {OnyxEntry} from 'react-native-onyx';
 
 import React, {useCallback, useContext, useMemo, useRef} from 'react';
 import {StyleSheet, View} from 'react-native';
-import Animated from 'react-native-reanimated';
+import Animated, {FadeIn, FadeOut, LayoutAnimationConfig} from 'react-native-reanimated';
 
 type SearchPageWideProps = {
     queryJSON?: SearchQueryJSON;
@@ -121,21 +122,33 @@ function SearchPageWide({
                                 onSort={onSortPressedCallback}
                             />
                             <View style={styles.flex1}>
-                                {shouldShowLoadingSkeleton ? (
-                                    <SearchLoadingSkeleton />
-                                ) : (
-                                    <SearchWithNavigationDeferredMount
+                                {/* skipEntering keeps the delayed fade off the very first mount, so opening Search cold paints immediately. */}
+                                <LayoutAnimationConfig skipEntering>
+                                    {/* Changing the search type or a filter changes the hash, which remounts this layer: the outgoing one
+                                        fades out and the incoming one waits for it to finish before fading in. Both layers are absolutely
+                                        filled so the outgoing fade overlays the incoming layer instead of sharing the column layout. */}
+                                    <Animated.View
                                         key={queryJSON.hash}
-                                        queryJSON={queryJSON}
-                                        searchResults={searchResults}
-                                        handleSearch={handleSearchAction}
-                                        isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                                        onSearchListScroll={scrollHandler}
-                                        onSortPressedCallback={onSortPressedCallback}
-                                        onDestinationVisible={endSubmitNavigationSpans}
-                                        onContentReady={onSearchContentReady}
-                                    />
-                                )}
+                                        entering={FadeIn.duration(CONST.SEARCH.ANIMATION.FADE_DURATION).delay(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                                        exiting={FadeOut.duration(CONST.SEARCH.ANIMATION.FADE_DURATION)}
+                                        style={StyleSheet.absoluteFill}
+                                    >
+                                        {shouldShowLoadingSkeleton ? (
+                                            <SearchLoadingSkeleton />
+                                        ) : (
+                                            <SearchWithNavigationDeferredMount
+                                                queryJSON={queryJSON}
+                                                searchResults={searchResults}
+                                                handleSearch={handleSearchAction}
+                                                isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                                                onSearchListScroll={scrollHandler}
+                                                onSortPressedCallback={onSortPressedCallback}
+                                                onDestinationVisible={endSubmitNavigationSpans}
+                                                onContentReady={onSearchContentReady}
+                                            />
+                                        )}
+                                    </Animated.View>
+                                </LayoutAnimationConfig>
                                 {!!searchOverlayContent && <View style={[StyleSheet.absoluteFill, styles.appBG]}>{searchOverlayContent}</View>}
                             </View>
                             <SearchSelectionFooter searchResults={searchResults} />

--- a/src/pages/Search/SearchTypeMenuNarrow.tsx
+++ b/src/pages/Search/SearchTypeMenuNarrow.tsx
@@ -21,6 +21,7 @@ import useTodoCounts from '@hooks/useTodoCounts';
 
 import {setSearchContext} from '@libs/actions/Search';
 import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
+import HapticFeedback from '@libs/HapticFeedback';
 import {getAllTaxRates} from '@libs/PolicyUtils';
 import {getItemBadgeText, getOverflowMenu, SAVED_SEARCH_FALLBACK_ICON_NAME, SAVED_SEARCH_ICON_NAMES, SEARCH_TYPE_MENU_ICON_NAMES} from '@libs/SearchUIUtils';
 
@@ -221,6 +222,7 @@ function SearchTypeMenuNarrow({queryJSON, onTabPress}: SearchTypeMenuNarrowProps
         if (!searchData) {
             return;
         }
+        HapticFeedback.press();
         onTabPress?.();
         setSearchContext(false);
         navigation.dispatch({


### PR DESCRIPTION
### Explanation of Change

Temporary branch, opened to get a clean adhoc iOS build. Same commits as `youssef-spend-page-fade-transitions`.

- Spend page results fade out, then the new results fade in, on search type and filter changes.
- The results area is keyed on the last query that _resolved_, so a filter change holds the current results instead of flashing a skeleton mid-fade. Holding applies only to filter refinements; a sidebar item or saved search starts from the skeleton. Bounded to 1s so a slow query still shows a skeleton.
- Subtle haptic (`impactLight`) on the tap that changes the query. Native only.

### Fixed Issues

$
PROPOSAL:

### Tests

1. Open the Spend page.
2. Click Reports in the sidebar, then Expenses. Verify the results fade out and the new results fade in, with no skeleton flashing mid-fade.
3. Change a filter in the filter bar. Verify the current results stay put and then swap once, with no skeleton.
4. Click a saved search in the sidebar. Verify the skeleton appears rather than the previous results.
5. Throttle the network to slow 3G, then change a filter. Verify the previous results give way to the skeleton after about a second.
6. On a simulator or device, repeat steps 2-4 and verify a subtle haptic fires on each tap.
7. Enable Reduce motion in system settings, repeat step 2, and verify content swaps instantly with no fade.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Change the search type in the sidebar. Verify the results swap without a skeleton, since `useSearchLoadingState` returns false while offline.

### QA Steps

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
