### PR TITLE
Fix empty states style on rules revamp tabs

### DIFF
--- a/src/components/Search/SearchList/ListItem/ExpenseReportListItem.tsx
+++ b/src/components/Search/SearchList/ListItem/ExpenseReportListItem.tsx
@@ -382,12 +382,16 @@ function ExpenseReportListItemInner<TItem extends ListItem>({
         [styles, isLargeScreenWidth],
     );
 
+    // The animated style is applied inline, so the `borderRadius: 0` it carries wins over the static
+    // `tableTopRadius`/`tableBottomRadius` below and squares off the list's outer corners. Skip it for the first
+    // and last rows only, so every other row keeps its existing (already square) behavior.
+    const shouldApplyAnimatedBorderRadius = !isLargeScreenWidth && !isFirstItem && !isLastItem;
     const animatedHighlightStyle = useAnimatedHighlightStyle({
         borderRadius: 0,
         shouldHighlight: item?.shouldAnimateInHighlight ?? false,
         highlightColor: theme.messageHighlightBG,
         backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG,
-        shouldApplyOtherStyles: !isLargeScreenWidth,
+        shouldApplyOtherStyles: shouldApplyAnimatedBorderRadius,
     });
 
     const shouldShowViolationDescription = isOpenExpenseReport(reportItem) || isProcessingReport(reportItem);

--- a/src/components/Search/SearchList/ListItem/TransactionListItem/TransactionListItemNarrow.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/TransactionListItemNarrow.tsx
@@ -68,14 +68,27 @@ function TransactionListItemNarrow<TItem extends ListItem>({
         onSelectRow(item, transactionPreviewData, event);
     };
 
-    const pressableStyle = [styles.transactionListItemStyle, styles.p4, styles.noBorderRadius, isSelected && styles.activeComponentBG, {...styles.flexColumn, ...styles.alignItemsStretch}];
+    const pressableStyle = [
+        styles.transactionListItemStyle,
+        styles.p4,
+        styles.noBorderRadius,
+        isSelected && styles.activeComponentBG,
+        // A selected row paints an opaque background here, on top of the rounded wrapper below, so the outer
+        // corners have to be rounded on this element too or the list's top/bottom corners look square.
+        isFirstItem && styles.tableTopRadius,
+        isLastItem && styles.tableBottomRadius,
+        {...styles.flexColumn, ...styles.alignItemsStretch},
+    ];
 
+    // The animated style is applied inline, so the `borderRadius: 0` it carries wins over the static
+    // `tableTopRadius`/`tableBottomRadius` on the wrapper below. Skip it for the first and last rows only,
+    // so every other row keeps its existing (already square) behavior.
     const animatedHighlightStyle = useAnimatedHighlightStyle({
         borderRadius: 0,
         shouldHighlight: item?.shouldAnimateInHighlight ?? false,
         highlightColor: theme.messageHighlightBG,
         backgroundColor: isSelected ? theme.activeComponentBG : theme.highlightBG,
-        shouldApplyOtherStyles: true,
+        shouldApplyOtherStyles: !isFirstItem && !isLastItem,
     });
 
     // The highlight animation is applied to the row wrapper, which sits behind this pressable. A focused

--- a/src/pages/workspace/rules/tabs/RulesAgentsTab.tsx
+++ b/src/pages/workspace/rules/tabs/RulesAgentsTab.tsx
@@ -71,7 +71,7 @@ function RulesAgentsTab({policyID, canWriteRules, showReadOnlyModal, headerCompo
                         headerContentStyles={styles.agentsRulesEmptyStateIllustration}
                         title={translate('workspace.rules.agentRulesEmptyState.title')}
                         subtitle={translate('workspace.rules.agentRulesEmptyState.subtitle')}
-                        subtitleStyles={[styles.textLabel, styles.textSupporting]}
+                        subtitleStyles={[styles.textSupporting]}
                         minModalHeight={0}
                         cardContentStyles={styles.ph0}
                         containerStyles={[styles.alignItemsCenter, styles.w100, styles.alignSelfCenter, StyleUtils.getMaximumWidth(variables.cardRulesEmptyStateMaxWidth)]}

--- a/src/pages/workspace/rules/tabs/RulesCardRestrictionsTab.tsx
+++ b/src/pages/workspace/rules/tabs/RulesCardRestrictionsTab.tsx
@@ -109,7 +109,7 @@ function RulesCardRestrictionsTab({policyID, canWriteRules, selectedKeys, onSele
         headerContentStyles: shouldUseNarrowLayout ? styles.expensifyCardEmptyIllustration : styles.cardRulesEmptyStateIllustration,
         title: translate('workspace.rules.spendRules.cardRulesUpsell.title'),
         subtitle: translate('workspace.rules.spendRules.cardRulesUpsell.subtitle'),
-        subtitleStyles: [styles.textLabel, styles.textSupporting],
+        subtitleStyles: [styles.textSupporting],
         containerStyles: [styles.alignItemsCenter, styles.w100, styles.alignSelfCenter, StyleUtils.getMaximumWidth(variables.cardRulesEmptyStateMaxWidth)],
         buttons: [
             {

--- a/src/pages/workspace/rules/tabs/RulesFlagForReviewTab.tsx
+++ b/src/pages/workspace/rules/tabs/RulesFlagForReviewTab.tsx
@@ -67,7 +67,7 @@ function RulesFlagForReviewTab({policyID, canWriteRules, selectedKeys, onSelecti
         headerContentStyles: styles.sortingMachineRulesEmptyStateIllustration,
         title: translate('workspace.rules.flagForReviewEmptyState.title'),
         subtitle: translate('workspace.rules.flagForReviewEmptyState.subtitle'),
-        subtitleStyles: [styles.textLabel, styles.textSupporting],
+        subtitleStyles: [styles.textSupporting],
         containerStyles: [styles.alignItemsCenter, styles.w100, styles.alignSelfCenter, StyleUtils.getMaximumWidth(variables.cardRulesEmptyStateMaxWidth)],
         buttons: [
             {

--- a/src/pages/workspace/rules/tabs/RulesFlagForReviewTab.tsx
+++ b/src/pages/workspace/rules/tabs/RulesFlagForReviewTab.tsx
@@ -2,7 +2,7 @@ import type {TableEmptyStateProps} from '@components/Table/TableEmptyStates/Tabl
 import WorkspaceFlagForReviewTable from '@components/Tables/WorkspaceFlagForReviewTable';
 
 import {useCurrencyListActions} from '@hooks/useCurrencyList';
-import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -35,7 +35,8 @@ function RulesFlagForReviewTab({policyID, canWriteRules, selectedKeys, onSelecti
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
     const styles = useThemeStyles();
-    const illustrations = useMemoizedLazyIllustrations(['SortingMachine']);
+    // Its own illustration, so Flag for review doesn't repeat the sorting machine that Field requirements uses.
+    const icons = useMemoizedLazyExpensifyIcons(['EmptyStateSpyPigeon']);
     const policy = usePolicy(policyID);
     const policyData = usePolicyData(policyID);
     const StyleUtils = useStyleUtils();
@@ -63,8 +64,8 @@ function RulesFlagForReviewTab({policyID, canWriteRules, selectedKeys, onSelecti
     const flagForReviewEmptyState: TableEmptyStateProps = {
         minModalHeight: 0,
         cardContentStyles: styles.ph0,
-        headerMedia: illustrations.SortingMachine,
-        headerContentStyles: styles.sortingMachineRulesEmptyStateIllustration,
+        headerMedia: icons.EmptyStateSpyPigeon,
+        headerContentStyles: styles.spyPigeonRulesEmptyStateIllustration,
         title: translate('workspace.rules.flagForReviewEmptyState.title'),
         subtitle: translate('workspace.rules.flagForReviewEmptyState.subtitle'),
         subtitleStyles: [styles.textSupporting],

--- a/src/pages/workspace/rules/tabs/RulesRequireFieldsTab.tsx
+++ b/src/pages/workspace/rules/tabs/RulesRequireFieldsTab.tsx
@@ -69,7 +69,7 @@ function RulesRequireFieldsTab({policyID, canWriteRules, selectedKeys, onSelecti
         headerContentStyles: styles.sortingMachineRulesEmptyStateIllustration,
         title: translate('workspace.rules.requireFieldsEmptyState.title'),
         subtitle: translate('workspace.rules.requireFieldsEmptyState.subtitle'),
-        subtitleStyles: [styles.textLabel, styles.textSupporting],
+        subtitleStyles: [styles.textSupporting],
 
         containerStyles: [styles.alignItemsCenter, styles.w100, styles.alignSelfCenter, StyleUtils.getMaximumWidth(variables.cardRulesEmptyStateMaxWidth)],
         buttons: [

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5843,6 +5843,11 @@ const staticStyles = (theme: ThemeColors) =>
             height: variables.sortingMachineRulesEmptyStateIllustrationHeight,
         },
 
+        spyPigeonRulesEmptyStateIllustration: {
+            width: variables.spyPigeonRulesEmptyStateIllustrationWidth,
+            height: variables.spyPigeonRulesEmptyStateIllustrationHeight,
+        },
+
         agentsRulesEmptyStateIllustration: {
             width: variables.agentsRulesEmptyStateIllustrationWidth,
             height: variables.agentsRulesEmptyStateIllustrationHeight,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -342,9 +342,9 @@ export default {
     cardRulesEmptyStateIllustrationHeight: 196,
     sortingMachineRulesEmptyStateIllustrationWidth: 229,
     sortingMachineRulesEmptyStateIllustrationHeight: 240,
-    // Same height as the sorting machine so the tabs line up; width follows the artwork's 129:153 ratio.
-    spyPigeonRulesEmptyStateIllustrationWidth: 202,
-    spyPigeonRulesEmptyStateIllustrationHeight: 240,
+    // 20% down from the sorting machine's height per design; width follows the artwork's 129:153 ratio.
+    spyPigeonRulesEmptyStateIllustrationWidth: 162,
+    spyPigeonRulesEmptyStateIllustrationHeight: 192,
     agentsRulesEmptyStateIllustrationWidth: 268,
     agentsRulesEmptyStateIllustrationHeight: 194,
     cardRulesEmptyStateMaxWidth: 580,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -344,7 +344,7 @@ export default {
     sortingMachineRulesEmptyStateIllustrationHeight: 240,
     agentsRulesEmptyStateIllustrationWidth: 268,
     agentsRulesEmptyStateIllustrationHeight: 194,
-    cardRulesEmptyStateMaxWidth: 496,
+    cardRulesEmptyStateMaxWidth: 580,
     expensifyCardEmptyIllustrationWidth: 280,
     expensifyCardEmptyIllustrationHeight: 172,
     rulesNewMenuItemMinHeight: 84,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -342,6 +342,9 @@ export default {
     cardRulesEmptyStateIllustrationHeight: 196,
     sortingMachineRulesEmptyStateIllustrationWidth: 229,
     sortingMachineRulesEmptyStateIllustrationHeight: 240,
+    // Same height as the sorting machine so the tabs line up; width follows the artwork's 129:153 ratio.
+    spyPigeonRulesEmptyStateIllustrationWidth: 202,
+    spyPigeonRulesEmptyStateIllustrationHeight: 240,
     agentsRulesEmptyStateIllustrationWidth: 268,
     agentsRulesEmptyStateIllustrationHeight: 194,
     cardRulesEmptyStateMaxWidth: 580,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -342,7 +342,6 @@ export default {
     cardRulesEmptyStateIllustrationHeight: 196,
     sortingMachineRulesEmptyStateIllustrationWidth: 229,
     sortingMachineRulesEmptyStateIllustrationHeight: 240,
-    // 20% down from the sorting machine's height per design; width follows the artwork's 129:153 ratio.
     spyPigeonRulesEmptyStateIllustrationWidth: 162,
     spyPigeonRulesEmptyStateIllustrationHeight: 192,
     agentsRulesEmptyStateIllustrationWidth: 268,


### PR DESCRIPTION
### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/99432
PROPOSAL:


### Tests
**Card restrictions empty state (wide screen / web)**

1. Log in with an account that has the Rules revamp beta enabled.
2. Go to Workspace settings > More features and enable Rules.
3. Open Rules > Card restrictions.
4. Verify the empty state is wide enough that the supporting text has no orphaned line.
5. Verify the supporting text is 15px, matching other empty states (not the smaller 13px it used to be).
6. Repeat steps 3–5 for the Flag for review, Require fields, and Agents tabs — all four empty states should look consistent.

**List corner radius (narrow layout — mobile app, mWeb, or a narrow browser window)**

7. Go to the Spend tab > Reports.
8. Enter selection mode (long press a row, or use Select multiple).
9. Select the first row in the list and verify its top-left and top-right corners stay rounded.
10. Select the last row and verify its bottom-left and bottom-right corners stay rounded.
11. Verify rows in the middle of the list are still square on all corners, and the selected background is unchanged otherwise.
12. Repeat steps 8–11 on the Spend tab > Expenses.
13. Switch to a wide screen and verify the Reports and Expenses lists look unchanged from before.


- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as tests

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/71903051-98e2-4eba-a4ef-82003bec50d7

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/b877c326-44a3-455a-988f-e0886ec081ad

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/200db18d-f943-4c7e-8954-917bc4a3425c

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/b0acaac4-a2a6-4d6f-bf3d-28377b33140d

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/3529a4c9-60c0-4741-967e-c378392950a4

</details>
