### PR TITLE
Fix - Android - Chat - Composer is no longer focused after backgrounding app

### DIFF
--- a/src/hooks/useBlurOnKeyboardHide/index.android.ts
+++ b/src/hooks/useBlurOnKeyboardHide/index.android.ts
@@ -24,13 +24,16 @@ const useBlurOnKeyboardHide: UseBlurOnKeyboardHide = (ref) => {
         });
 
         const hideSubscription = KeyboardEvents.addListener('keyboardDidHide', (event) => {
+            // keyboardDidHide can fire mid-gesture with the keyboard still partly on screen. Only the zero-height
+            // event means it is actually gone, so blurring on the earlier ones would break a cancelled swipe.
+            if (event.height !== 0) {
+                return;
+            }
+
             // Skipping blur if event was emitted because app was backgrounded.
             const shouldSkip = shouldSkipNextHide || AppState.currentState !== 'active';
             shouldSkipNextHide = false;
-
-            // keyboardDidHide can fire mid-gesture with the keyboard still partly on screen. Only the zero-height
-            // event means it is actually gone, so blurring on the earlier ones would break a cancelled swipe.
-            if (event.height !== 0 || shouldSkip) {
+            if (shouldSkip) {
                 return;
             }
             ref.current?.blur();

--- a/src/hooks/useBlurOnKeyboardHide/index.android.ts
+++ b/src/hooks/useBlurOnKeyboardHide/index.android.ts
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+import {AppState} from 'react-native';
 import {KeyboardEvents} from 'react-native-keyboard-controller';
 
 import type UseBlurOnKeyboardHide from './type';
@@ -9,15 +10,37 @@ import type UseBlurOnKeyboardHide from './type';
  */
 const useBlurOnKeyboardHide: UseBlurOnKeyboardHide = (ref) => {
     useEffect(() => {
-        const subscription = KeyboardEvents.addListener('keyboardDidHide', (event) => {
+        let shouldSkipNextHide = false;
+
+        const appStateSubscription = AppState.addEventListener('change', (state) => {
+            if (state === 'active') {
+                return;
+            }
+            shouldSkipNextHide = true;
+        });
+
+        const showSubscription = KeyboardEvents.addListener('keyboardDidShow', () => {
+            shouldSkipNextHide = false;
+        });
+
+        const hideSubscription = KeyboardEvents.addListener('keyboardDidHide', (event) => {
+            // Skipping blur if event was emitted because app was backgrounded.
+            const shouldSkip = shouldSkipNextHide || AppState.currentState !== 'active';
+            shouldSkipNextHide = false;
+
             // keyboardDidHide can fire mid-gesture with the keyboard still partly on screen. Only the zero-height
             // event means it is actually gone, so blurring on the earlier ones would break a cancelled swipe.
-            if (event.height !== 0) {
+            if (event.height !== 0 || shouldSkip) {
                 return;
             }
             ref.current?.blur();
         });
-        return () => subscription.remove();
+
+        return () => {
+            appStateSubscription.remove();
+            showSubscription.remove();
+            hideSubscription.remove();
+        };
     }, [ref]);
 };
 

--- a/tests/unit/hooks/useBlurOnKeyboardHide.test.ts
+++ b/tests/unit/hooks/useBlurOnKeyboardHide.test.ts
@@ -2,43 +2,90 @@ import {renderHook} from '@testing-library/react-native';
 
 import useBlurOnKeyboardHide from '@hooks/useBlurOnKeyboardHide/index.android';
 
+import type {AppStateStatus} from 'react-native';
 import type {KeyboardEventData} from 'react-native-keyboard-controller';
 
-const mockKeyboardDidHideListeners: Array<(e: KeyboardEventData) => void> = [];
+import {AppState} from 'react-native';
+
+const mockKeyboardListeners: Record<string, Array<(e: KeyboardEventData) => void>> = {};
 const mockRemove = jest.fn();
 
 jest.mock('react-native-keyboard-controller', () => ({
     KeyboardEvents: {
         addListener: jest.fn((event: string, handler: (e: KeyboardEventData) => void) => {
-            if (event === 'keyboardDidHide') {
-                mockKeyboardDidHideListeners.push(handler);
-            }
+            (mockKeyboardListeners[event] ??= []).push(handler);
             return {remove: mockRemove};
         }),
     },
 }));
 
-function emitKeyboardDidHide(height: number) {
-    const event: KeyboardEventData = {height, duration: 0, timestamp: 0, target: -1, type: 'default', appearance: 'light'};
-    for (const handler of mockKeyboardDidHideListeners) {
-        handler(event);
+const appStateListeners: Array<(state: AppStateStatus) => void> = [];
+
+function emitKeyboardEvent(event: 'keyboardDidShow' | 'keyboardDidHide', height: number) {
+    const eventData: KeyboardEventData = {height, duration: 0, timestamp: 0, target: -1, type: 'default', appearance: 'light'};
+    for (const handler of mockKeyboardListeners[event] ?? []) {
+        handler(eventData);
+    }
+}
+
+function setAppState(state: AppStateStatus) {
+    (AppState as {currentState: AppStateStatus}).currentState = state;
+    for (const handler of appStateListeners) {
+        handler(state);
+    }
+}
+
+type Step = {appState: AppStateStatus} | {show: true} | {hide: number};
+
+function runSteps(steps: Step[]) {
+    for (const step of steps) {
+        if ('appState' in step) {
+            setAppState(step.appState);
+        } else if ('show' in step) {
+            emitKeyboardEvent('keyboardDidShow', 300);
+        } else {
+            emitKeyboardEvent('keyboardDidHide', step.hide);
+        }
     }
 }
 
 describe('useBlurOnKeyboardHide', () => {
+    const appStateRemove = jest.fn();
+
     beforeEach(() => {
-        mockKeyboardDidHideListeners.length = 0;
+        for (const key of Object.keys(mockKeyboardListeners)) {
+            delete mockKeyboardListeners[key];
+        }
+        appStateListeners.length = 0;
         jest.clearAllMocks();
+        jest.spyOn(AppState, 'addEventListener').mockImplementation((type, handler) => {
+            appStateListeners.push(handler);
+            return {remove: appStateRemove} as ReturnType<typeof AppState.addEventListener>;
+        });
+        setAppState('active');
     });
 
-    it('blurs the ref only when keyboardDidHide reports zero height', () => {
+    it.each<[name: string, steps: Step[], expectedBlurCalls: number]>([
+        ['blurs only on a zero-height hide while the app is active', [{hide: 100}, {hide: 0}], 1],
+        ['does not blur when the keyboard hides because the app was backgrounded', [{appState: 'background'}, {hide: 0}], 0],
+        ['does not blur on the re-sync hide emitted after returning to the foreground', [{appState: 'background'}, {appState: 'active'}, {hide: 0}], 0],
+        ['blurs again once the keyboard reopens after a background trip', [{appState: 'background'}, {appState: 'active'}, {show: true}, {hide: 0}], 1],
+        ['skips only one hide per background trip', [{appState: 'background'}, {appState: 'active'}, {hide: 0}, {show: true}, {hide: 0}], 1],
+        ['clears a stale skip flag on keyboard show even without a foreground hide', [{appState: 'background'}, {appState: 'active'}, {show: true}, {hide: 100}, {hide: 0}], 1],
+    ])('%s', (_name, steps, expectedBlurCalls) => {
         const blur = jest.fn();
         renderHook(() => useBlurOnKeyboardHide({current: {blur}}));
 
-        emitKeyboardDidHide(100);
-        expect(blur).not.toHaveBeenCalled();
+        runSteps(steps);
 
-        emitKeyboardDidHide(0);
-        expect(blur).toHaveBeenCalledTimes(1);
+        expect(blur).toHaveBeenCalledTimes(expectedBlurCalls);
+    });
+
+    it('removes all subscriptions on unmount', () => {
+        const {unmount} = renderHook(() => useBlurOnKeyboardHide({current: {blur: jest.fn()}}));
+        unmount();
+
+        expect(appStateRemove).toHaveBeenCalledTimes(1);
+        expect(mockRemove).toHaveBeenCalledTimes(2);
     });
 });

--- a/tests/unit/hooks/useBlurOnKeyboardHide.test.ts
+++ b/tests/unit/hooks/useBlurOnKeyboardHide.test.ts
@@ -71,6 +71,7 @@ describe('useBlurOnKeyboardHide', () => {
         ['does not blur on the re-sync hide emitted after returning to the foreground', [{appState: 'background'}, {appState: 'active'}, {hide: 0}], 0],
         ['blurs again once the keyboard reopens after a background trip', [{appState: 'background'}, {appState: 'active'}, {show: true}, {hide: 0}], 1],
         ['skips only one hide per background trip', [{appState: 'background'}, {appState: 'active'}, {hide: 0}, {show: true}, {hide: 0}], 1],
+        ['does not consume the skip flag on a partial-height hide after a background trip', [{appState: 'background'}, {appState: 'active'}, {hide: 100}, {hide: 0}], 0],
         ['clears a stale skip flag on keyboard show even without a foreground hide', [{appState: 'background'}, {appState: 'active'}, {show: true}, {hide: 100}, {hide: 0}], 1],
     ])('%s', (_name, steps, expectedBlurCalls) => {
         const blur = jest.fn();


### PR DESCRIPTION

### Explanation of Change
Skip the composer blur when `keyboardDidHide` was caused by the app being backgrounded rather than by the user dismissing the keyboard.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99804
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open app
2. Open any chat.
3. Tap on the composer.
4. Background app.
5. Foreground app.
6. Verify that composer will remain focused after backgrounding app.


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/1bf0fffe-d710-4af5-8115-9384e052ff8d


</details>
