### PR TITLE
Fix: rebuild report transactions index on a full compute

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/reportTransactionsAndViolations.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportTransactionsAndViolations.ts
@@ -37,7 +37,14 @@ export default createOnyxDerivedValueConfig({
             transactionsToProcess = Array.from(transactionKeys);
         }
 
-        const reportTransactionsAndViolations = currentValue ? {...currentValue} : {};
+        // A full compute visits every transaction, so rebuild from scratch instead of merging into the
+        // value restored from disk. After a reload transactionReportIDMapping is empty, so the removal
+        // below never runs and an expense stays listed under a report it has already left.
+        const isFullCompute = !transactionsUpdates && !transactionViolationsUpdates;
+        if (isFullCompute) {
+            transactionReportIDMapping = {};
+        }
+        const reportTransactionsAndViolations = !isFullCompute && currentValue ? {...currentValue} : {};
 
         // Track which reportID entries have been cloned so we only clone once per reportID.
         // This avoids mutating nested objects that are still referenced by the cached value.

--- a/tests/unit/OnyxDerived/reportTransactionsAndViolationsTest.ts
+++ b/tests/unit/OnyxDerived/reportTransactionsAndViolationsTest.ts
@@ -85,4 +85,31 @@ describe('reportTransactionsAndViolations compute', () => {
         expect(result.reportE?.transactions?.[txKey('5')]).toBeTruthy();
         expect(result.reportE?.transactions?.[txKey('6')]).toBeTruthy();
     });
+
+    it('drops an entry whose transaction moved to another report while the cross-compute state was empty', () => {
+        // Given a derived value restored from disk that still files the transaction under its old report,
+        // and no primed cross-compute state (a fresh app load leaves the module-level mapping empty)
+        const currentValue: ReportTransactionsAndViolationsDerivedValue = {reportOld: {transactions: {[txKey('7')]: makeTx('7', 'reportOld')}, violations: {}}};
+
+        // When a full compute runs (no delta) and the collection already places it on the new report
+        const transactions: OnyxCollection<Transaction> = {[txKey('7')]: makeTx('7', 'reportNew')};
+        const result = reportTransactionsAndViolationsConfig.compute([transactions, undefined], {sourceValues: undefined, currentValue});
+
+        // Then it is listed only under the new report
+        expect(result.reportNew?.transactions?.[txKey('7')]).toBeTruthy();
+        expect(result.reportOld?.transactions?.[txKey('7')]).toBeUndefined();
+    });
+
+    it('drops an entry whose transaction is absent from the collection on a full compute', () => {
+        // Given a derived value restored from disk listing a transaction that no longer exists
+        const currentValue: ReportTransactionsAndViolationsDerivedValue = {reportF: {transactions: {[txKey('8')]: makeTx('8', 'reportF')}, violations: {}}};
+
+        // When a full compute runs (no delta) over a collection that no longer contains it
+        const transactions: OnyxCollection<Transaction> = {[txKey('9')]: makeTx('9', 'reportF')};
+        const result = reportTransactionsAndViolationsConfig.compute([transactions, undefined], {sourceValues: undefined, currentValue});
+
+        // Then the missing transaction is dropped and the surviving one is kept
+        expect(result.reportF?.transactions?.[txKey('8')]).toBeUndefined();
+        expect(result.reportF?.transactions?.[txKey('9')]).toBeTruthy();
+    });
 });


### PR DESCRIPTION
### Explanation of Change

A report's expense list is read straight from `reportTransactionsAndViolations`, a map of report to expenses with no `reportID` filter at render time. That index is persisted and restored from disk on every load, but `transactionReportIDMapping` — which the code needs in order to know which report an expense was previously filed under, so it can remove the old entry — lives at module scope and starts empty after every reload.

A full compute then started from `{...currentValue}`, the copy from disk, and only added to it. With the mapping empty the old entry was never removed, so the index could gain entries but never lose them. An expense moved between reports stayed filed under both: the list showed the old report while opening the expense showed the new one, since the detail view reads the transaction thread rather than the index. Nothing cleared it short of a full Onyx clear, and because the index is per browser profile, the same account could look right in one browser and wrong in another.

The fix starts a full compute from an empty object instead, clearing `transactionReportIDMapping` alongside it so both rebuild in step. A full compute already visits every transaction, so nothing is lost by dropping the disk copy. The delta path is unchanged.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98667
PROPOSAL:

### Tests

The stale index state is not reproducible on demand — it needs a specific boot timing window — so it is covered by unit tests in `tests/unit/OnyxDerived/reportTransactionsAndViolationsTest.ts`, which fail without this change. The steps below verify the paths this change touches still behave correctly.

1. Open an expense report containing several expenses.
2. Move one expense to a different report using the expense's `Report` field.
3. Verify it is removed from the source report's list and appears in the destination report's list, without a reload.
4. Reload the page and verify both reports still show the correct expenses.
5. Open the moved expense and verify its `Report` field matches the report whose list it appears in.
6. Delete an expense and verify it is removed from its report's list.
7. Reload and verify it is still gone.
8. Verify report totals and any category groupings match the expenses actually listed.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Move an expense between two reports.
3. Verify the source list drops it and the destination list shows it optimistically.
4. Go back online and verify both lists settle to the same state with no duplicate row in the source report.

### QA Steps

1. Open an expense report containing several expenses.
2. Move one expense to a different report using the expense's `Report` field.
3. Verify it is removed from the original report's list and appears in the destination report's list.
4. Reload the page and verify both reports still show the correct expenses.
5. Open the moved expense and verify its `Report` field matches the report whose list it appears in.
6. Verify report totals and any category groupings match the expenses actually listed.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/8e4a0b46-c0a6-4fa6-b9df-8d6a31d652ea



</details>
