### PR TITLE
[No QA] Add PERF-19 coding standard: collection selectors return only what the consumer uses

### DIFF
--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -37,6 +37,7 @@ Coding standards for the Expensify App. Each standard is a standalone file in `r
 - [PERF-16](rules/perf-16-guard-double-init.md) — Guard double initialization
 - [PERF-17](rules/perf-17-pass-raw-index-on-demand.md) — Pass raw source, index on demand (no pre-built digest)
 - [PERF-18](rules/perf-18-use-pre-mount-destination.md) — Use usePreMountDestination for RHP pre-mounting
+- [PERF-19](rules/perf-19-scalar-collection-selectors.md) — Collection selectors return only what the consumer uses
 
 ### Consistency
 - [CONSISTENCY-1](rules/consistency-1-no-platform-checks.md) — No platform-specific checks in components

--- a/.claude/skills/coding-standards/rules/perf-11-optimize-data-selection.md
+++ b/.claude/skills/coding-standards/rules/perf-11-optimize-data-selection.md
@@ -24,6 +24,8 @@ This means selectors are a double-edged sword. A well-written selector that retu
 - To filter/map entire collections into arrays — the output is still large, `deepEqual` still expensive
 - To return `Set` or `Map` — `deepEqual` is extremely slow on these types
 
+For the specific case where a collection selector returns an object graph but the consumer only reads scalars from it, see [PERF-19](perf-19-scalar-collection-selectors.md) — it applies when the reduction is provable from the call site.
+
 ### Incorrect
 
 ```tsx

--- a/.claude/skills/coding-standards/rules/perf-19-scalar-collection-selectors.md
+++ b/.claude/skills/coding-standards/rules/perf-19-scalar-collection-selectors.md
@@ -58,8 +58,7 @@ const [reportSelection] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {
     },
 });
 
-// The one record the component actually renders comes from a single-member subscription,
-// which compares by reference. Guard the key so an undefined ID doesn't subscribe to report_undefined.
+// The one record the component renders comes from a single-member subscription, which compares by reference.
 const [defaultReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportSelection?.defaultReportID)}`);
 ```
 
@@ -87,7 +86,9 @@ const [user] = useOnyx(`${ONYXKEYS.USER}${userId}`, {
 
 - The `useOnyx` call subscribes to a collection key (`ONYXKEYS.COLLECTION.*`, or a derived key whose value is a collection) **and** passes a `selector`. The selector may be inline or imported from `src/selectors/*`. If it is imported, read its definition before judging its return shape.
 - The selector returns an object graph: an array of Onyx records, a keyed object of records, or an object with nested records. A scalar or a flat record of primitives is already correct.
-- **Nothing derived from the selector output escapes as an object or array.** Trace each usage to what the component ultimately keeps, following intermediate calls. Passing the output whole into a util is not disqualifying if the component only reads a scalar off that util's result, because the entire chain can move into the selector. The output escapes when a branch of the data flow ends in JSX, a prop, `useState`, a context value, a ref, or the return value of an exported hook in the file. Enumerate every usage site, including aliases and re-destructuring, and name what each one finally yields before flagging.
+- **Nothing derived from the selector output escapes as an object or array.** For every usage site of the output, follow it through intermediate calls to what the component finally keeps, and flag only if all of them end in a scalar. Include aliases and re-destructuring.
+    - Escapes: the branch ends in JSX, a prop, `useState`, a context value, a ref, or the return value of an exported hook in the file.
+    - Does not escape: the output is passed whole into a util and the component only reads a scalar off that util's result, because the whole chain can move into the selector.
 - **Every function needed to compute the scalars is already reachable from the selector**: defined in the file, imported into it, or exported from a module the file already imports. Moving the chain into the selector must not require new branching, a new data source, or an Onyx value the selector does not already receive. A named wrapper that only calls those reachable functions and returns their scalar results counts as reachable; logic those functions do not already provide does not.
 
 Increase confidence (not required):
@@ -102,11 +103,8 @@ Increase confidence (not required):
 - The key is a single-item key rather than a collection. Picking a few fields from one record is already the correct pattern.
 - Computing the scalars needs logic that does not exist yet, a value the selector has no access to, or a new Onyx subscription to feed the selector itself.
 - The selector already returns scalars and the object graph comes from a separate single-member subscription.
-- [PERF-11](perf-11-optimize-data-selection.md) already covers the same line. PERF-19 is the narrower case; when both apply, report PERF-19 only.
 
-**When suggesting the fix:**
-
-- If the component still needs one full record, pair the scalar selector with a single-member subscription and guard the key with `getNonEmptyStringOnyxID`, or an undefined ID subscribes to a `<collection>undefined` key.
+**Overlap with PERF-11:** PERF-19 is the narrower case. When both match the same line, report PERF-19 only.
 
 **Search Patterns** (hints for reviewers):
 - `useOnyx\(ONYXKEYS\.COLLECTION`

--- a/.claude/skills/coding-standards/rules/perf-19-scalar-collection-selectors.md
+++ b/.claude/skills/coding-standards/rules/perf-19-scalar-collection-selectors.md
@@ -11,15 +11,15 @@ title: Collection selectors return only what the consumer uses
 
 A selector that returns an array or map of records when the consumer only reads an ID and a `length > 1` check pays that compare for nothing. On a large account the collection can hold thousands of records, so a single compare costs tens of milliseconds and a render cycle that triggers several of them costs hundreds. Returning the scalars removes the compare entirely.
 
-When the component also needs one full record, subscribe to that single member key separately. A single-key subscription without a selector compares by reference, which is free, so you get the scalars cheaply and the one object you actually render.
+When the component also needs one full record, subscribe to that single member key separately. A single-key subscription without a selector compares by reference, so the extra subscription costs nothing.
 
-This is a narrower case than [PERF-11](perf-11-optimize-data-selection.md), which covers selector sizing in general. PERF-19 applies only when the fix is provable from the code in front of you: nothing the component keeps from the selector output is an object, and every function needed to produce the scalars is already reachable from the selector. If either is untrue, this rule does not apply.
+This is a narrower case than [PERF-11](perf-11-optimize-data-selection.md), which covers selector sizing in general. PERF-19 applies only when the fix is provable from the code you can see: nothing the component keeps from the selector output is an object, and every function needed to produce the scalars is already reachable from the selector. If either is untrue, this rule does not apply.
 
 ### Incorrect
 
 ```tsx
-// BAD: the selector returns every matching report, so useOnyx deep-compares all of them on
-// each report_ update — and the component only asks whether there are any.
+// BAD: the selector returns every matching report, so useOnyx deep-compares all of them
+// on each report_ update. The component only asks whether there are any.
 const [reportsWithErrors] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {
     selector: (reports) => Object.values(reports ?? {}).filter((report) => !!report?.errors),
 });
@@ -85,9 +85,9 @@ const [user] = useOnyx(`${ONYXKEYS.USER}${userId}`, {
 
 **Flag when ALL of these are true:**
 
-- The `useOnyx` call subscribes to a collection key (`ONYXKEYS.COLLECTION.*`, or a derived key whose value is a collection) **and** passes a `selector`. The selector may be inline or imported from `src/selectors/*` — if it is imported, read its definition before judging its return shape.
+- The `useOnyx` call subscribes to a collection key (`ONYXKEYS.COLLECTION.*`, or a derived key whose value is a collection) **and** passes a `selector`. The selector may be inline or imported from `src/selectors/*`. If it is imported, read its definition before judging its return shape.
 - The selector returns an object graph: an array of Onyx records, a keyed object of records, or an object with nested records. A scalar or a flat record of primitives is already correct.
-- **Nothing derived from the selector output escapes as an object or array.** Trace each usage to what the component ultimately keeps, following intermediate calls: passing the output whole into a util is not disqualifying if the component only reads a scalar off that util's result — the entire chain can move into the selector. The output escapes when a branch of the data flow ends in JSX, a prop, `useState`, a context value, a ref, or the return value of an exported hook in the file. Enumerate every usage site, including aliases and re-destructuring, and name what each one finally yields before flagging.
+- **Nothing derived from the selector output escapes as an object or array.** Trace each usage to what the component ultimately keeps, following intermediate calls. Passing the output whole into a util is not disqualifying if the component only reads a scalar off that util's result, because the entire chain can move into the selector. The output escapes when a branch of the data flow ends in JSX, a prop, `useState`, a context value, a ref, or the return value of an exported hook in the file. Enumerate every usage site, including aliases and re-destructuring, and name what each one finally yields before flagging.
 - **Every function needed to compute the scalars is already reachable from the selector**: defined in the file, imported into it, or exported from a module the file already imports. Moving the chain into the selector must not require new branching, a new data source, or an Onyx value the selector does not already receive. A named wrapper that only calls those reachable functions and returns their scalar results counts as reachable; logic those functions do not already provide does not.
 
 Increase confidence (not required):
@@ -97,7 +97,7 @@ Increase confidence (not required):
 
 **DO NOT flag if:**
 
-- Any branch of the data flow ends with the objects themselves — rendered in a list, passed as a prop, stored in state, or returned from an exported hook.
+- Any branch of the data flow ends with the objects themselves: rendered in a list, passed as a prop, stored in state, or returned from an exported hook.
 - The chain cannot be traced. If the output goes into a callee whose body is not in the diff, search the callee; if what it yields still cannot be confirmed, do not flag.
 - The key is a single-item key rather than a collection. Picking a few fields from one record is already the correct pattern.
 - Computing the scalars needs logic that does not exist yet, a value the selector has no access to, or a new Onyx subscription to feed the selector itself.

--- a/.claude/skills/coding-standards/rules/perf-19-scalar-collection-selectors.md
+++ b/.claude/skills/coding-standards/rules/perf-19-scalar-collection-selectors.md
@@ -1,0 +1,116 @@
+---
+ruleId: PERF-19
+title: Collection selectors return only what the consumer uses
+---
+
+## [PERF-19] Collection selectors return only what the consumer uses
+
+### Reasoning
+
+`useOnyx` runs `deepEqual` on a selector's output whenever the input reference changes. For a collection key such as `policy_`, `report_` or `transaction_`, that reference changes on **every write to any member of the collection**, so the compare runs constantly and its cost scales with the size of whatever the selector returns.
+
+A selector that returns an array or map of records when the consumer only reads an ID and a `length > 1` check pays that compare for nothing. On a large account the collection can hold thousands of records, so a single compare costs tens of milliseconds and a render cycle that triggers several of them costs hundreds. Returning the scalars removes the compare entirely.
+
+When the component also needs one full record, subscribe to that single member key separately. A single-key subscription without a selector compares by reference, which is free, so you get the scalars cheaply and the one object you actually render.
+
+This is a narrower case than [PERF-11](perf-11-optimize-data-selection.md), which covers selector sizing in general. PERF-19 applies only when the fix is provable from the code in front of you: nothing the component keeps from the selector output is an object, and every function needed to produce the scalars is already reachable from the selector. If either is untrue, this rule does not apply.
+
+### Incorrect
+
+```tsx
+// BAD: the selector returns every matching report, so useOnyx deep-compares all of them on
+// each report_ update — and the component only asks whether there are any.
+const [reportsWithErrors] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {
+    selector: (reports) => Object.values(reports ?? {}).filter((report) => !!report?.errors),
+});
+const hasErrors = reportsWithErrors.length > 0;
+```
+
+```tsx
+// BAD: the array is passed whole into a util, but the component only keeps an ID off the result,
+// and the other usage is a length check. Nothing derived from the array escapes as an object,
+// so the whole chain can move into the selector.
+const [activeReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {
+    selector: (reports) => getActiveReports(reports),
+});
+const defaultReportID = pickDefaultReport(activeReports, activeWorkspaceID)?.reportID;
+const hasMultipleActiveReports = activeReports.length > 1;
+```
+
+### Correct
+
+```tsx
+// GOOD: the selector returns the boolean, so there is nothing expensive left to compare.
+const [hasErrors] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {
+    selector: (reports) => Object.values(reports ?? {}).some((report) => !!report?.errors),
+});
+```
+
+```tsx
+// GOOD: the whole chain moved into the selector, which now returns two scalars.
+const [reportSelection] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {
+    selector: (reports) => {
+        const activeReports = getActiveReports(reports);
+        return {
+            defaultReportID: pickDefaultReport(activeReports, activeWorkspaceID)?.reportID,
+            hasMultipleActiveReports: activeReports.length > 1,
+        };
+    },
+});
+
+// The one record the component actually renders comes from a single-member subscription,
+// which compares by reference. Guard the key so an undefined ID doesn't subscribe to report_undefined.
+const [defaultReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportSelection?.defaultReportID)}`);
+```
+
+### Not a violation
+
+```tsx
+// The report objects are rendered, so they have to escape the selector. Nothing to reduce.
+const [activeReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: getActiveReports});
+
+return <SelectionList sections={[{data: activeReports.map(toListItem)}]} />;
+```
+
+```tsx
+// Single-item key, not a collection. Picking a few fields here is already the right shape.
+const [user] = useOnyx(`${ONYXKEYS.USER}${userId}`, {
+    selector: (user) => ({name: user?.name, avatar: user?.avatar}),
+});
+```
+
+---
+
+### Review Metadata
+
+**Flag when ALL of these are true:**
+
+- The `useOnyx` call subscribes to a collection key (`ONYXKEYS.COLLECTION.*`, or a derived key whose value is a collection) **and** passes a `selector`. The selector may be inline or imported from `src/selectors/*` — if it is imported, read its definition before judging its return shape.
+- The selector returns an object graph: an array of Onyx records, a keyed object of records, or an object with nested records. A scalar or a flat record of primitives is already correct.
+- **Nothing derived from the selector output escapes as an object or array.** Trace each usage to what the component ultimately keeps, following intermediate calls: passing the output whole into a util is not disqualifying if the component only reads a scalar off that util's result — the entire chain can move into the selector. The output escapes when a branch of the data flow ends in JSX, a prop, `useState`, a context value, a ref, or the return value of an exported hook in the file. Enumerate every usage site, including aliases and re-destructuring, and name what each one finally yields before flagging.
+- **Every function needed to compute the scalars is already reachable from the selector**: defined in the file, imported into it, or exported from a module the file already imports. Moving the chain into the selector must not require new branching, a new data source, or an Onyx value the selector does not already receive. A named wrapper that only calls those reachable functions and returns their scalar results counts as reachable; logic those functions do not already provide does not.
+
+Increase confidence (not required):
+
+- The collection is a hot one (`policy_`, `report_`, `transaction_`, `transaction_draft_`), so the compare runs on a high-frequency write path.
+- The selector output feeds a `useMemo`/`useCallback` dependency array only through a scalar (`x.length`, `x?.id`), which makes the reduction mechanical.
+
+**DO NOT flag if:**
+
+- Any branch of the data flow ends with the objects themselves — rendered in a list, passed as a prop, stored in state, or returned from an exported hook.
+- The chain cannot be traced. If the output goes into a callee whose body is not in the diff, search the callee; if what it yields still cannot be confirmed, do not flag.
+- The key is a single-item key rather than a collection. Picking a few fields from one record is already the correct pattern.
+- Computing the scalars needs logic that does not exist yet, a value the selector has no access to, or a new Onyx subscription to feed the selector itself.
+- The selector already returns scalars and the object graph comes from a separate single-member subscription.
+- [PERF-11](perf-11-optimize-data-selection.md) already covers the same line. PERF-19 is the narrower case; when both apply, report PERF-19 only.
+
+**When suggesting the fix:**
+
+- If the component still needs one full record, pair the scalar selector with a single-member subscription and guard the key with `getNonEmptyStringOnyxID`, or an undefined ID subscribes to a `<collection>undefined` key.
+
+**Search Patterns** (hints for reviewers):
+- `useOnyx\(ONYXKEYS\.COLLECTION`
+- `selector: \(`
+- `selector: [a-z][A-Za-z]*Selector`
+- `Object\.(values|entries|keys)\(.*\)\.(filter|map)`
+- `OnyxCollection<`


### PR DESCRIPTION
### Explanation of Change

Adds `PERF-19` so the `useOnyx` collection-selector problem from #99168 gets caught in review. `useOnyx` deep-compares selector output whenever the input reference changes. On a collection key that happens on every write to any member, so a selector returning an array or map of records pays a compare that scales with collection size, even when the consumer only reads an ID or a boolean.

The rule fires only when the simplification is provable from the code the reviewer can see: nothing derived from the selector output escapes as an object, traced past intermediate util calls rather than direct reads alone, and every function needed to compute the scalars is already reachable from the selector. `PERF-11` gets a cross-reference, and PERF-19 wins when both match so reviewers don't get duplicate comments.

This is diff-scoped like every other rule. It stops new instances but won't surface the 191 existing call sites #99168 asks to audit, which needs a separate sweep.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99168
PROPOSAL:

### Tests
- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

N/A, no UI change.
