### PR TITLE
[HOLD Onyx#832] Pin react-native-onyx: classify WebKit 'without an in-progress transaction' IDB errors as transient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "react-native-nitro-fetch": "1.5.4",
         "react-native-nitro-modules": "0.36.3",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.101",
+        "react-native-onyx": "github:callstack-internal/react-native-onyx#d56ec42a6748ec4105306fd6feea4964c2366839",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -35907,9 +35907,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.101",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.101.tgz",
-      "integrity": "sha512-bSz9K8x8/2za4ouyiHssiK5AytGX6nG0ujIMe3fyOoAUj9Ddx7yDfYBLifb0N84rkByf4Qm0r/kRuNzNSFey+A==",
+      "version": "3.0.90",
+      "resolved": "git+ssh://git@github.com/callstack-internal/react-native-onyx.git#d56ec42a6748ec4105306fd6feea4964c2366839",
+      "integrity": "sha512-bI8nB3nnpkG6umQWBc6qfYCphMwdFDHdppc3bzbdi40cn3bDTavqwzJnjhGUi5mZhRAJiFUwCtDFXlU5komNqA==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-nitro-fetch": "1.5.4",
     "react-native-nitro-modules": "0.36.3",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.101",
+    "react-native-onyx": "github:callstack-internal/react-native-onyx#d56ec42a6748ec4105306fd6feea4964c2366839",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Pins `react-native-onyx` to the HEAD of https://github.com/Expensify/react-native-onyx/pull/832 so the full E/App test suite runs against it, per the Onyx PR process. After the Onyx PR is merged and published to npm, this PR will be swapped to the pinned version and become the bump PR.

The Onyx change classifies WebKit's `UnknownError: Attempt to ... without an in-progress transaction` IndexedDB error family as `TRANSIENT`, so the storage connection layer drops the stale cached connection and retries once with a fresh one instead of propagating. Today this family is classified `UNKNOWN`; when WebKit tears transactions down under a live connection (page reload, foregrounding after process suspension), the boot-time `getAll` fails and Onyx starts with default key states only ("Failed to load data from storage during init"), discarding the intact local cache for that session. Only WebKit browsers are affected (iOS Safari, iOS Chrome/Edge/Google shells, macOS Safari).

Context: https://expensify.sentry.io/issues/APP-KG and the storage-error cluster in https://github.com/Expensify/App/issues/87844.

### Fixed Issues

$ https://github.com/Expensify/App/issues/87844
PROPOSAL:

### Tests

Web (any browser, simulating the WebKit failure):

1. Run the web app and sign in.
2. In the browser DevTools console, force the next IndexedDB transaction to fail with the WebKit error:
    ```js
    const original = IDBDatabase.prototype.transaction;
    let thrown = false;
    IDBDatabase.prototype.transaction = function (...args) {
        if (!thrown) {
            thrown = true;
            throw new DOMException('Attempt to get a record from database without an in-progress transaction', 'UnknownError');
        }
        return original.apply(this, args);
    };
    ```
3. Open any report and send a message.
4. Verify the console shows `[Onyx] IDB transient error — dropping cached connection and retrying once` and does NOT show `[Onyx] IDB error not recoverable at the connection layer, propagating`.
5. Reload the page and verify the sent message is still there (the write was persisted by the retried transaction).

Regression pass:

1. Sign in, browse reports, send messages, reload — verify app boots with data as usual on all platforms (the change only affects the IndexedDB web provider; native uses SQLite and is untouched).

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline, send a message, go back online, reload — verify the message persisted and synced (offline writes go through the same IndexedDB provider on web).

### QA Steps

// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests (the console-injection test requires DevTools; the regression pass applies to staging).

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
