### PR TITLE
fix Email - User is logged in and not redirected to User created room as the new user

### DIFF
--- a/src/libs/Navigation/linkingConfig/subscribe.ts
+++ b/src/libs/Navigation/linkingConfig/subscribe.ts
@@ -29,6 +29,13 @@ const skipRules: ReadonlyArray<{urlMatcher: RegExp; focusedScreens: readonly str
     },
 ];
 
+/**
+ * Returns the URL's path, without its query string or fragment.
+ */
+function getPathnameFromURL(url: string): string {
+    return url.split(/[?#]/).at(0) ?? '';
+}
+
 const subscribe: LinkingOptions<RootNavigatorParamList>['subscribe'] = (listener) => {
     const subscription = Linking.addEventListener('url', ({url}: {url: string}) => {
         // Skip deep links to screens where the user is already focused.
@@ -55,7 +62,7 @@ const subscribe: LinkingOptions<RootNavigatorParamList>['subscribe'] = (listener
         // which lives in AuthScreens and is not mounted while PublicScreens is showing. Dispatching it here
         // throws "NAVIGATE ... was not handled by any navigator". openReportFromDeepLink() already opens the
         // public room as an anonymous user and handles navigation, so defer to it instead. See #92672.
-        if (!hasAuthToken() && url.includes(`/${ROUTES.REPORT}/`)) {
+        if (!hasAuthToken() && getPathnameFromURL(url).includes(`/${ROUTES.REPORT}/`)) {
             return;
         }
         listener(url);

--- a/tests/unit/Navigation/linkingConfigSubscribeTest.ts
+++ b/tests/unit/Navigation/linkingConfigSubscribeTest.ts
@@ -1,0 +1,108 @@
+import {hasAuthToken} from '@libs/actions/Session';
+import subscribe from '@libs/Navigation/linkingConfig/subscribe';
+
+import {Linking} from 'react-native';
+
+jest.mock('@libs/actions/Session', () => ({
+    hasAuthToken: jest.fn(),
+}));
+
+// subscribe() only reads the ref to resolve the focused screen for its skip rules. None of the URLs
+// exercised here match a skip rule, so an empty ref keeps that branch out of the way.
+jest.mock('@libs/Navigation/navigationRef', () => ({
+    __esModule: true,
+    default: {current: null},
+}));
+
+const mockedHasAuthToken = jest.mocked(hasAuthToken);
+
+const REPORT_ID = '269886405016917';
+const ACCOUNT_ID = '22839920';
+const VALIDATE_CODE = 'ABC123';
+
+/**
+ * Delivers a single warm deep link (a React Native `Linking` `url` event) to subscribe()'s handler and
+ * returns the React Navigation listener it was given, so callers can assert whether (and with what)
+ * the link was forwarded.
+ */
+function deliverDeepLink(url: string): jest.Mock {
+    const listener = jest.fn();
+    // Capture the handler subscribe() registers, then hand it the URL directly. The teardown it returns
+    // is left alone on purpose: Linking is mocked here and hands back no subscription to remove.
+    const addEventListener = jest.spyOn(Linking, 'addEventListener').mockImplementation(jest.fn());
+
+    subscribe?.(listener);
+    const handleUrl = addEventListener.mock.calls.at(-1)?.[1];
+    handleUrl?.({url});
+    addEventListener.mockRestore();
+
+    return listener;
+}
+
+describe('linkingConfig subscribe', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('unauthenticated session', () => {
+        beforeEach(() => {
+            mockedHasAuthToken.mockReturnValue(false);
+        });
+
+        // The Report screen lives in AuthScreens and is not mounted while PublicScreens is showing, so
+        // forwarding these would throw "NAVIGATE ... was not handled by any navigator".
+        // openReportFromDeepLink() opens the public room anonymously instead. See #92672.
+        it.each([
+            'https://new.expensify.com/r/269886405016917',
+            'https://staging.new.expensify.com/r/269886405016917',
+            'new-expensify://r/269886405016917',
+            'app://-/r/269886405016917',
+            'https://new.expensify.com/r/269886405016917?secureKey=abc123',
+            'https://new.expensify.com/r/269886405016917#anchor',
+            'https://new.expensify.com/r/269886405016917/details',
+            'https://new.expensify.com/search/r/269886405016917',
+        ])('drops the report deep link %s', (url) => {
+            expect(deliverDeepLink(url)).not.toHaveBeenCalled();
+        });
+
+        // The guard matches on the path only, so a report route parked in a query string or fragment no
+        // longer swallows the link. Without this, the magic link below never reached ValidateLoginPage and
+        // the invited user was dropped into the app signed out. See #99156.
+        it.each([
+            `https://staging.new.expensify.com/v/${ACCOUNT_ID}/${VALIDATE_CODE}?exitTo=/r/${REPORT_ID}`,
+            `new-expensify://v/${ACCOUNT_ID}/${VALIDATE_CODE}?exitTo=/r/${REPORT_ID}`,
+            `https://new.expensify.com/transition?email=someone%40example.com&exitTo=/r/${REPORT_ID}`,
+            `https://new.expensify.com/settings/profile#/r/${REPORT_ID}`,
+        ])('forwards %s, where the report route is only in the query string or fragment', (url) => {
+            expect(deliverDeepLink(url)).toHaveBeenCalledWith(url);
+        });
+
+        it('forwards the magic link verbatim so exitTo survives for ValidateLoginPage', () => {
+            const url = `https://staging.new.expensify.com/v/${ACCOUNT_ID}/${VALIDATE_CODE}?exitTo=/r/${REPORT_ID}`;
+
+            const listener = deliverDeepLink(url);
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith(url);
+        });
+
+        it.each(['https://new.expensify.com/', `https://new.expensify.com/v/${ACCOUNT_ID}/${VALIDATE_CODE}`, 'https://new.expensify.com/settings/profile'])(
+            'forwards %s, which has no report route at all',
+            (url) => {
+                expect(deliverDeepLink(url)).toHaveBeenCalledWith(url);
+            },
+        );
+    });
+
+    describe('authenticated session', () => {
+        beforeEach(() => {
+            mockedHasAuthToken.mockReturnValue(true);
+        });
+
+        it('forwards a report deep link, because AuthScreens can handle it', () => {
+            const url = `https://new.expensify.com/r/${REPORT_ID}`;
+
+            expect(deliverDeepLink(url)).toHaveBeenCalledWith(url);
+        });
+    });
+});


### PR DESCRIPTION
### Explanation of Change


### Fixed Issues
$ https://github.com/Expensify/App/issues/99156
PROPOSAL: https://github.com/Expensify/App/issues/99156#issuecomment-5382783932

### Tests
**** Setup - Can be executed in a Secondary device or browser

1. Go to staging.new.expensify.com
2. Register as a new user to the app
3. Select “Manage my team’s expenses” and click Continue
4. Add a name for your business
5. Fill out a first & last name
6. Create a #room in the workspace
7. Click on the header of the room and navigate to Members
8. Click on the Invite button at the top
9. Invite an email address that does not have an expensify account (Should be a real account with an inbox that can receive the invite)

*****Steps - Main testing device (android)

1. Fresh install and open the app
2. Background the app
3. Go to Mailbox >> Click the link in “Reply to this message or respond at new.expensify.com”
4. Verify that user is logged in and redirected to to the User Created Room as the new user

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>



https://github.com/user-attachments/assets/4ce5fba8-6180-4747-9d59-9352536d5ae3


</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/66b7feba-8fb0-4bac-8c6f-e59e912dd96f



</details>
