### PR TITLE
[NO QA] Fix currency helper references in BulkEdit tests

### DIFF
--- a/src/components/HeaderWithBackButtonComposed/HeaderWithBackButton.tsx
+++ b/src/components/HeaderWithBackButtonComposed/HeaderWithBackButton.tsx
@@ -1,4 +1,4 @@
-import WorkspaceAvatar from '@components/Avatar/WorkspaceAvatar';
+import AvatarFromIcon from '@components/Avatar/AvatarFromIcon';
 import AvatarWithDisplayName from '@components/AvatarWithDisplayName';
 import type HeaderWithBackButtonProps from '@components/HeaderWithBackButton/types';
 import SearchButton from '@components/Search/SearchRouter/SearchButton';
@@ -156,11 +156,9 @@ function HeaderWithBackButton({
                     />
                 )}
                 {!!policyAvatar && (
-                    <WorkspaceAvatar
+                    <AvatarFromIcon
+                        icon={policyAvatar}
                         containerStyles={[StyleUtils.getWidthAndHeightStyle(StyleUtils.getAvatarSize(policyAvatarSize)), styles.mr3]}
-                        source={policyAvatar.source}
-                        name={policyAvatar.name ?? ''}
-                        avatarID={policyAvatar.id ?? CONST.DEFAULT_NUMBER_ID}
                         size={policyAvatarSize}
                     />
                 )}

--- a/src/components/HeaderWithBackButtonComposed/HeaderWithBackButton.tsx
+++ b/src/components/HeaderWithBackButtonComposed/HeaderWithBackButton.tsx
@@ -1,4 +1,4 @@
-import Avatar from '@components/Avatar';
+import WorkspaceAvatar from '@components/Avatar/WorkspaceAvatar';
 import AvatarWithDisplayName from '@components/AvatarWithDisplayName';
 import type HeaderWithBackButtonProps from '@components/HeaderWithBackButton/types';
 import SearchButton from '@components/Search/SearchRouter/SearchButton';
@@ -156,12 +156,11 @@ function HeaderWithBackButton({
                     />
                 )}
                 {!!policyAvatar && (
-                    <Avatar
+                    <WorkspaceAvatar
                         containerStyles={[StyleUtils.getWidthAndHeightStyle(StyleUtils.getAvatarSize(policyAvatarSize)), styles.mr3]}
                         source={policyAvatar.source}
-                        name={policyAvatar.name}
-                        avatarID={policyAvatar.id}
-                        type={policyAvatar.type}
+                        name={policyAvatar.name ?? ''}
+                        avatarID={policyAvatar.id ?? CONST.DEFAULT_NUMBER_ID}
                         size={policyAvatarSize}
                     />
                 )}

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -2458,7 +2458,7 @@ function hasNoticeTypeViolation(
             violation.type === CONST.VIOLATION_TYPES.NOTICE &&
             (showInReview === undefined || showInReview === (violation.showInReview ?? false)) &&
             !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, iouReport, iouReportOwnerLogin, policy) &&
-            shouldShowViolation(iouReport, policy, violation.name, currentUserEmail, true, transaction),
+            shouldShowViolation(iouReport, policy, violation.name, currentUserEmail, currentUserAccountID, true, transaction),
     );
 }
 

--- a/tests/actions/IOUTest/BulkEditTest.ts
+++ b/tests/actions/IOUTest/BulkEditTest.ts
@@ -2382,8 +2382,8 @@ describe('actions/IOU/BulkEdit', () => {
                 hash: undefined,
                 currentUserAccountID: RORY_ACCOUNT_ID,
                 delegateAccountID: undefined,
-                getCurrencyDecimals,
-                getCurrencySymbol,
+                getCurrencyDecimals: getCurrencyDecimalsLocal,
+                getCurrencySymbol: getCurrencySymbolLocal,
                 allPolicies: {
                     [`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`]: policy,
                 },
@@ -2472,8 +2472,8 @@ describe('actions/IOU/BulkEdit', () => {
                 hash: undefined,
                 currentUserAccountID: RORY_ACCOUNT_ID,
                 delegateAccountID: undefined,
-                getCurrencyDecimals,
-                getCurrencySymbol,
+                getCurrencyDecimals: getCurrencyDecimalsLocal,
+                getCurrencySymbol: getCurrencySymbolLocal,
                 allPolicies: {
                     [`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`]: policy,
                 },
@@ -2554,8 +2554,8 @@ describe('actions/IOU/BulkEdit', () => {
                 hash: undefined,
                 currentUserAccountID: RORY_ACCOUNT_ID,
                 delegateAccountID: undefined,
-                getCurrencyDecimals,
-                getCurrencySymbol,
+                getCurrencyDecimals: getCurrencyDecimalsLocal,
+                getCurrencySymbol: getCurrencySymbolLocal,
                 allPolicies: {
                     [`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`]: policy,
                 },

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -16968,7 +16968,6 @@ describe('ReportUtils', () => {
                     },
                 },
                 owner: currentUserEmail,
-                isPolicyExpenseChatEnabled: true,
             };
 
             const chatReport: Report = {


### PR DESCRIPTION
Fixes the CI failures reported in:
- https://github.com/Expensify/App/issues/99942
- https://github.com/Expensify/App/issues/99943
- https://github.com/Expensify/App/issues/99944

The three original failures shared one cause: BulkEditTest.ts had three missed references after migrating from production currency helpers to test helpers. Those call sites now use getCurrencyDecimalsLocal and getCurrencySymbolLocal.

The PR also fixes three unrelated TypeScript errors already present on main:
- Replace the stale @components/Avatar import with AvatarFromIcon, preserving user/workspace avatar rendering.
- Add the missed currentUserAccountID argument after shouldShowViolation changed signatures.
- Remove the stale isPolicyExpenseChatEnabled field from a test fixture after it was removed from the Policy type.

Validation: TypeScript CI passes; focused Jest tests, ESLint, spelling, and React Compiler checks pass.