### PR TITLE
[CP Staging] Revert #98603: Copilot list search inputs

### DIFF
--- a/src/components/AccountSwitcher.tsx
+++ b/src/components/AccountSwitcher.tsx
@@ -7,7 +7,6 @@ import useOnyx from '@hooks/useOnyx';
 import {usePersonalDetailsByLogins} from '@hooks/usePersonalDetailByLogin';
 import usePopoverPosition from '@hooks/usePopoverPosition';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import useSearchResults from '@hooks/useSearchResults';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 
@@ -16,7 +15,6 @@ import {close} from '@libs/actions/Modal';
 import {getLatestError} from '@libs/ErrorUtils';
 import {getGpsPoints, stopGpsTrip} from '@libs/GPSDraftDetailsUtils';
 import {sortAlphabetically} from '@libs/OptionsListUtils';
-import tokenizedSearch from '@libs/tokenizedSearch';
 
 import TextWithEmojiFragment from '@pages/inbox/report/comment/TextWithEmojiFragment';
 
@@ -49,8 +47,6 @@ type AccountSwitcherProps = {
     /* Whether the screen is focused. Used to hide the product training tooltip */
     isScreenFocused: boolean;
 };
-
-const filterMenuItem = (item: PopoverMenuItem, searchInput: string) => tokenizedSearch([item], searchInput, (option) => [option.text, option.description ?? '']).length > 0;
 
 function AccountSwitcher({isScreenFocused}: AccountSwitcherProps) {
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
@@ -199,37 +195,9 @@ function AccountSwitcher({isScreenFocused}: AccountSwitcherProps) {
         };
     };
 
-    const currentUserMenuItem = createBaseMenuItem(currentUserPersonalDetails, undefined, {isSelected: true});
-    const delegatorMenuItems: PopoverMenuItem[] = sortAlphabetically(
-        delegators
-            .filter(({email}) => email !== currentUserPersonalDetails.login)
-            .map(({email, role}) => {
-                const errorFields = account?.delegatedAccess?.errorFields ?? {};
-                const error = getLatestError(errorFields?.connect?.[email]);
-                const personalDetails = personalDetailsByLogin[email];
-                return createBaseMenuItem(personalDetails, error, {
-                    badgeText: translate('delegate.role', role),
-                    onSelected: () => {
-                        if (isOffline) {
-                            close(showOfflineModal);
-                            return;
-                        }
-                        if (isTrackingGPS) {
-                            close(() => showGpsInProgressModal(() => connect({email, delegatedAccess: account?.delegatedAccess, credentials, session, activePolicyID})));
-                            return;
-                        }
-                        connect({email, delegatedAccess: account?.delegatedAccess, credentials, session, activePolicyID});
-                    },
-                });
-            }),
-        'text',
-        localeCompare,
-    );
-    const allMenuItems = [currentUserMenuItem, ...delegatorMenuItems];
-    const [searchInput, setSearchInput, filteredMenuItems] = useSearchResults(allMenuItems, filterMenuItem);
-    const shouldShowSearchInput = !isActingAsDelegate && delegatorMenuItems.length >= CONST.STANDARD_LIST_ITEM_LIMIT;
-
     const menuItems = (): PopoverMenuItem[] => {
+        const currentUserMenuItem = createBaseMenuItem(currentUserPersonalDetails, undefined, {isSelected: true});
+
         if (isActingAsDelegate) {
             // Avoid duplicating the current user in the list when switching accounts
             if (delegate === currentUserPersonalDetails.login) {
@@ -258,12 +226,37 @@ function AccountSwitcher({isScreenFocused}: AccountSwitcherProps) {
             ];
         }
 
-        return shouldShowSearchInput ? filteredMenuItems : allMenuItems;
+        const delegatorMenuItems: PopoverMenuItem[] = sortAlphabetically(
+            delegators
+                .filter(({email}) => email !== currentUserPersonalDetails.login)
+                .map(({email, role}) => {
+                    const errorFields = account?.delegatedAccess?.errorFields ?? {};
+                    const error = getLatestError(errorFields?.connect?.[email]);
+                    const personalDetails = personalDetailsByLogin[email];
+                    return createBaseMenuItem(personalDetails, error, {
+                        badgeText: translate('delegate.role', role),
+                        onSelected: () => {
+                            if (isOffline) {
+                                close(showOfflineModal);
+                                return;
+                            }
+                            if (isTrackingGPS) {
+                                close(() => showGpsInProgressModal(() => connect({email, delegatedAccess: account?.delegatedAccess, credentials, session, activePolicyID})));
+                                return;
+                            }
+                            connect({email, delegatedAccess: account?.delegatedAccess, credentials, session, activePolicyID});
+                        },
+                    });
+                }),
+            'text',
+            localeCompare,
+        );
+
+        return [currentUserMenuItem, ...delegatorMenuItems];
     };
 
     const hideDelegatorMenu = () => {
         setShouldShowDelegatorMenu(false);
-        setSearchInput('');
         clearDelegatorErrors({delegatedAccess: account?.delegatedAccess});
     };
 
@@ -340,17 +333,10 @@ function AccountSwitcher({isScreenFocused}: AccountSwitcherProps) {
                     }}
                     menuItems={menuItems()}
                     headerText={translate('delegate.switchAccount')}
-                    searchInputLabel={shouldShowSearchInput ? translate('workspace.people.findMember') : undefined}
-                    searchInputValue={searchInput}
-                    onSearchInputChange={setSearchInput}
-                    shouldShowSearchEmptyState={shouldShowSearchInput && filteredMenuItems.length === 0 && searchInput.length > 0}
-                    searchInputContainerStyle={styles.mb2}
-                    containerStyles={[{maxHeight: windowHeight / 2}, styles.mw100, shouldUseNarrowLayout ? {} : styles.accountSwitcherPopover]}
+                    containerStyles={[{maxHeight: windowHeight / 2}, styles.mw100, shouldUseNarrowLayout ? {} : styles.wFitContent]}
                     headerStyles={styles.pt0}
                     innerContainerStyle={styles.pb0}
-                    scrollContainerStyle={shouldShowSearchInput ? styles.pt0 : undefined}
                     shouldUseScrollView
-                    shouldAddScrollViewTopItemSpacing={!shouldShowSearchInput}
                     shouldUpdateFocusedIndex={false}
                     enableEdgeToEdgeBottomSafeAreaPadding
                     shouldShowRadioButton

--- a/src/components/Modal/ReanimatedModal/Backdrop/index.web.tsx
+++ b/src/components/Modal/ReanimatedModal/Backdrop/index.web.tsx
@@ -50,18 +50,17 @@ function Backdrop({
 
     if (!customBackdrop) {
         return (
-            // Keep the interactive wrapper full-screen so Safari does not size the overlay from its narrower reported window dimensions.
             <PressableWithoutFeedback
                 accessible
                 accessibilityLabel={translate('modal.backdropLabel')}
                 onPress={onBackdropPress}
-                style={[styles.fullScreen, styles.userSelectNone, styles.cursorAuto]}
+                style={[styles.userSelectNone, styles.cursorAuto]}
                 dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: true}}
                 sentryLabel={CONST.SENTRY_LABEL.REANIMATED_MODAL.BACKDROP}
             >
                 {isBackdropVisible && (
                     <Animated.View
-                        style={[styles.flex1, backdropStyle, style]}
+                        style={[styles.modalBackdrop, backdropStyle, style]}
                         entering={Entering}
                         exiting={Exiting}
                     />
@@ -72,13 +71,13 @@ function Backdrop({
     return (
         isBackdropVisible && (
             <View
-                style={[styles.fullScreen, styles.userSelectNone]}
+                style={[styles.userSelectNone]}
                 dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: true}}
             >
                 <Animated.View
                     entering={Entering}
                     exiting={Exiting}
-                    style={[styles.flex1, backdropStyle, style]}
+                    style={[styles.modalBackdrop, backdropStyle, style]}
                 >
                     {!!customBackdrop && customBackdrop}
                 </Animated.View>

--- a/src/components/Modal/ReanimatedModal/getBackdropStyle.ts
+++ b/src/components/Modal/ReanimatedModal/getBackdropStyle.ts
@@ -1,9 +1,0 @@
-import type {GetBackdropStyle} from './types';
-
-const getBackdropStyle: GetBackdropStyle = (backdropColor, windowWidth, windowHeight) => ({
-    width: windowWidth,
-    height: windowHeight,
-    backgroundColor: backdropColor,
-});
-
-export default getBackdropStyle;

--- a/src/components/Modal/ReanimatedModal/getBackdropStyle.web.ts
+++ b/src/components/Modal/ReanimatedModal/getBackdropStyle.web.ts
@@ -1,5 +1,0 @@
-import type {GetBackdropStyle} from './types';
-
-const getBackdropStyle: GetBackdropStyle = (backdropColor) => ({backgroundColor: backdropColor});
-
-export default getBackdropStyle;

--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -13,7 +13,7 @@ import variables from '@styles/variables';
 
 import CONST from '@src/CONST';
 
-import type {NativeEventSubscription} from 'react-native';
+import type {NativeEventSubscription, ViewStyle} from 'react-native';
 
 import noop from 'lodash/noop';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -24,7 +24,6 @@ import type ReanimatedModalProps from './types';
 
 import Backdrop from './Backdrop';
 import Container from './Container';
-import getBackdropStyle from './getBackdropStyle';
 
 function ReanimatedModal({
     testID,
@@ -148,7 +147,9 @@ function ReanimatedModal({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isVisible, isContainerOpen, isTransitioning]);
 
-    const backdropStyle = useMemo(() => getBackdropStyle(backdropColor, windowWidth, windowHeight), [windowWidth, windowHeight, backdropColor]);
+    const backdropStyle: ViewStyle = useMemo(() => {
+        return {width: windowWidth, height: windowHeight, backgroundColor: backdropColor};
+    }, [windowWidth, windowHeight, backdropColor]);
 
     const onOpenCallBack = useCallback(() => {
         setIsTransitioning(false);

--- a/src/components/Modal/ReanimatedModal/types.ts
+++ b/src/components/Modal/ReanimatedModal/types.ts
@@ -187,8 +187,6 @@ type BackdropProps = {
     isBackdropVisible: boolean;
 };
 
-type GetBackdropStyle = (backdropColor: string, windowWidth: number, windowHeight: number) => ViewStyle;
-
 type ContainerProps = {
     /** Host node of the modal's content, used to tell whether focus is still inside this modal. */
     ref?: Ref<View>;
@@ -210,4 +208,4 @@ type ContainerProps = {
 };
 
 export default ReanimatedModalProps;
-export type {BackdropProps, ContainerProps, GestureHandlerProps, GetBackdropStyle, AnimationIn, AnimationOut, SwipeDirection};
+export type {BackdropProps, ContainerProps, GestureHandlerProps, AnimationIn, AnimationOut, SwipeDirection};

--- a/src/components/PopoverMenu/index.tsx
+++ b/src/components/PopoverMenu/index.tsx
@@ -8,7 +8,6 @@ import type BaseModalProps from '@components/Modal/types';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import PopoverWithMeasuredContent from '@components/PopoverWithMeasuredContent';
 import ScrollView from '@components/ScrollView';
-import SearchBar from '@components/SearchBar';
 import Text from '@components/Text';
 
 import useArrowKeyFocusManager from '@hooks/useArrowKeyFocusManager';
@@ -132,21 +131,6 @@ type PopoverMenuProps = Partial<ModalAnimationProps> & {
     /** Optional non-interactive text to display as a header for any create menu */
     headerText?: string;
 
-    /** Label for the optional controlled search input */
-    searchInputLabel?: string;
-
-    /** Value of the optional controlled search input */
-    searchInputValue?: string;
-
-    /** Callback fired when the controlled search input changes */
-    onSearchInputChange?: (value: string) => void;
-
-    /** Whether to display the standard empty state below the search input */
-    shouldShowSearchEmptyState?: boolean;
-
-    /** Styles applied to the optional controlled search input container */
-    searchInputContainerStyle?: StyleProp<ViewStyle>;
-
     /** Whether disable the animations */
     disableAnimation?: boolean;
 
@@ -203,9 +187,6 @@ type PopoverMenuProps = Partial<ModalAnimationProps> & {
 
     /** Whether we should wrap the list item in a scroll view */
     shouldUseScrollView?: boolean;
-
-    /** Whether to add spacing to the first item when using a scroll view */
-    shouldAddScrollViewTopItemSpacing?: boolean;
 
     /**
      * Whether we should set a max height to the popover content.
@@ -347,11 +328,6 @@ function BasePopoverMenu({
     onModalShow,
     onModalHide,
     headerText,
-    searchInputLabel,
-    searchInputValue = '',
-    onSearchInputChange,
-    shouldShowSearchEmptyState,
-    searchInputContainerStyle,
     fromSidebarMediumScreen,
     shouldHandleNavigationBack,
     anchorAlignment = {
@@ -376,7 +352,6 @@ function BasePopoverMenu({
     innerContainerStyle,
     scrollContainerStyle,
     shouldUseScrollView = false,
-    shouldAddScrollViewTopItemSpacing = true,
     shouldEnableMaxHeight = true,
     shouldUpdateFocusedIndex = true,
     shouldUseModalPaddingStyle,
@@ -397,12 +372,10 @@ function BasePopoverMenu({
     const currentMenuItemsFocusedIndex = getSelectedItemIndex(currentMenuItems);
     const [enteredSubMenuIndexes, setEnteredSubMenuIndexes] = useState<readonly number[]>(CONST.EMPTY_ARRAY);
     const isWeb = getPlatform() === CONST.PLATFORM.WEB;
-    const isSearchEnabled = !!searchInputLabel;
     const [focusedIndex, setFocusedIndex] = useArrowKeyFocusManager({
         initialFocusedIndex: currentMenuItemsFocusedIndex,
         maxIndex: currentMenuItems.length - 1,
         isActive: isVisible,
-        captureOnInputs: !isSearchEnabled,
     });
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['BackArrow', 'ReceiptScan', 'MoneyCircle']);
     const prevMenuItems = usePrevious(menuItems);
@@ -436,9 +409,6 @@ function BasePopoverMenu({
             return;
         }
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (isSearchEnabled && e.target instanceof HTMLInputElement) {
-                return;
-            }
             const isNavigationKey = [
                 CONST.KEYBOARD_SHORTCUTS.ARROW_UP,
                 CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN,
@@ -453,7 +423,7 @@ function BasePopoverMenu({
         };
         addKeyDownPressListener(handleKeyDown);
         return () => removeKeyDownPressListener(handleKeyDown);
-    }, [isVisible, isRadioButtonMode, isSearchEnabled]);
+    }, [isVisible, isRadioButtonMode]);
 
     const selectItem = (index: number, event?: GestureResponderEvent | KeyboardEvent) => {
         const selectedItem = currentMenuItems.at(index);
@@ -570,10 +540,7 @@ function BasePopoverMenu({
                                 theme.activeComponentBG,
                                 theme.hoverComponentBG,
                             ),
-                            shouldUseScrollView &&
-                                (shouldAddScrollViewTopItemSpacing || menuIndex !== 0) &&
-                                !shouldUseModalPaddingStyle &&
-                                StyleUtils.getOptionMargin(menuIndex, currentMenuItems.length - 1),
+                            shouldUseScrollView && !shouldUseModalPaddingStyle && StyleUtils.getOptionMargin(menuIndex, currentMenuItems.length - 1),
                         ]}
                         shouldRemoveHoverBackground={item.isSelected}
                         titleStyle={StyleSheet.flatten([styles.flex1, item.titleStyle])}
@@ -613,7 +580,7 @@ function BasePopoverMenu({
             selectItem(focusedIndex);
             setFocusedIndex(-1); // Reset the focusedIndex on selecting any menu
         },
-        {isActive: isVisible, captureOnInputs: !isSearchEnabled},
+        {isActive: isVisible},
     );
 
     const keyboardShortcutSpaceCallback = useCallback(
@@ -649,7 +616,7 @@ function BasePopoverMenu({
     // we are not accessing the wrong sub-menu parent or possibly undefined when rendering the back button.
     // We use useLayoutEffect so the reset happens before the repaint
     useLayoutEffect(() => {
-        if ((!isSearchEnabled && menuItems.length === 0) || deepEqual(menuItems, prevMenuItems)) {
+        if (menuItems.length === 0 || deepEqual(menuItems, prevMenuItems)) {
             return;
         }
 
@@ -661,7 +628,7 @@ function BasePopoverMenu({
         if (keyPath.length === 0) {
             setEnteredSubMenuIndexes(CONST.EMPTY_ARRAY);
             setCurrentMenuItems(menuItems);
-            if (!isVisible || isSearchEnabled) {
+            if (!isVisible) {
                 setFocusedIndex(getSelectedItemIndex(menuItems));
             }
             return;
@@ -685,7 +652,7 @@ function BasePopoverMenu({
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [menuItems, setFocusedIndex, isSearchEnabled]);
+    }, [menuItems, setFocusedIndex]);
 
     const menuContainerStyle = useMemo(() => {
         if (isSmallScreenWidth) {
@@ -736,9 +703,6 @@ function BasePopoverMenu({
         ],
     );
 
-    // The native KeyboardAvoidingView can shrink-wrap a bottom-docked modal, so keep its outer wrapper full-width while search is active.
-    const keyboardAvoidingOuterStyle = isSearchEnabled && isSmallScreenWidth ? styles.w100 : undefined;
-
     return (
         <PopoverWithMeasuredContent
             anchorPosition={anchorPosition}
@@ -752,8 +716,6 @@ function BasePopoverMenu({
             isVisible={isVisible}
             onModalHide={handleModalHide}
             onModalShow={onModalShow}
-            avoidKeyboard={isSearchEnabled}
-            outerStyle={keyboardAvoidingOuterStyle}
             animationIn={animationIn}
             animationOut={animationOut}
             animationInDelay={animationInDelay}
@@ -783,25 +745,12 @@ function BasePopoverMenu({
                         onLayout={onLayout}
                         style={[restMenuContainerStyle, restContainerStyles, isWeb ? styles.flex1 : styles.flexGrow1]}
                     >
-                        {isSearchEnabled && enteredSubMenuIndexes.length === 0 && (
-                            <View style={isSmallScreenWidth ? styles.pt4 : styles.pt2}>
-                                {renderHeaderText()}
-                                <SearchBar
-                                    label={searchInputLabel ?? ''}
-                                    inputValue={searchInputValue}
-                                    onChangeText={onSearchInputChange}
-                                    shouldShowEmptyState={shouldShowSearchEmptyState}
-                                    shouldShowIcon={false}
-                                    style={searchInputContainerStyle}
-                                />
-                            </View>
-                        )}
                         <PopoverMenuContent
                             shouldUseScrollView={shouldUseScrollView}
                             contentContainerStyle={[scrollViewPaddingStyles, restScrollContainerStyle]}
                             addBottomSafeAreaPadding={enableEdgeToEdgeBottomSafeAreaPadding}
                         >
-                            {!isSearchEnabled && renderHeaderText()}
+                            {renderHeaderText()}
                             {enteredSubMenuIndexes.length > 0 && renderBackButtonItem()}
                             {renderedMenuItems}
                         </PopoverMenuContent>
@@ -822,12 +771,6 @@ export default React.memo(
         deepEqual(prevProps.anchorPosition, nextProps.anchorPosition) &&
         prevProps.anchorRef === nextProps.anchorRef &&
         prevProps.headerText === nextProps.headerText &&
-        prevProps.searchInputLabel === nextProps.searchInputLabel &&
-        prevProps.searchInputValue === nextProps.searchInputValue &&
-        prevProps.onSearchInputChange === nextProps.onSearchInputChange &&
-        prevProps.shouldShowSearchEmptyState === nextProps.shouldShowSearchEmptyState &&
-        prevProps.searchInputContainerStyle === nextProps.searchInputContainerStyle &&
-        prevProps.shouldAddScrollViewTopItemSpacing === nextProps.shouldAddScrollViewTopItemSpacing &&
         prevProps.fromSidebarMediumScreen === nextProps.fromSidebarMediumScreen &&
         // eslint-disable-next-line rulesdir/no-deep-equal-in-memo -- anchorAlignment object is created inline in most usages
         deepEqual(prevProps.anchorAlignment, nextProps.anchorAlignment) &&

--- a/src/components/PopoverMenu/index.tsx
+++ b/src/components/PopoverMenu/index.tsx
@@ -792,7 +792,7 @@ function BasePopoverMenu({
                                     onChangeText={onSearchInputChange}
                                     shouldShowEmptyState={shouldShowSearchEmptyState}
                                     shouldShowIcon={false}
-                                    style={[styles.mw100, searchInputContainerStyle]}
+                                    style={searchInputContainerStyle}
                                 />
                             </View>
                         )}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -12,12 +12,9 @@ import BaseSearchBar from './BaseSearchBar';
 type SearchBarProps = SharedSearchBarProps & {
     /** Icon shown inside the input while it is empty. Defaults to the magnifying glass. */
     icon?: IconAsset;
-
-    /** Whether to show the icon while the input is empty */
-    shouldShowIcon?: boolean;
 };
 
-function SearchBar({ref, label, style, icon, shouldShowIcon = true, inputValue, onChangeText, onSubmitEditing, shouldShowEmptyState, emptyStateContainerStyle}: SearchBarProps) {
+function SearchBar({ref, label, style, icon, inputValue, onChangeText, onSubmitEditing, shouldShowEmptyState, emptyStateContainerStyle}: SearchBarProps) {
     const styles = useThemeStyles();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['MagnifyingGlass']);
 
@@ -33,7 +30,7 @@ function SearchBar({ref, label, style, icon, shouldShowIcon = true, inputValue, 
             emptyStateContainerStyle={emptyStateContainerStyle}
             textInputProps={{
                 label,
-                icon: inputValue?.length || !shouldShowIcon ? undefined : (icon ?? expensifyIcons.MagnifyingGlass),
+                icon: inputValue?.length ? undefined : (icon ?? expensifyIcons.MagnifyingGlass),
                 iconContainerStyle: styles.p0,
             }}
         />

--- a/src/pages/settings/Copilot/CopilotPage.tsx
+++ b/src/pages/settings/Copilot/CopilotPage.tsx
@@ -11,7 +11,6 @@ import PopoverMenu from '@components/PopoverMenu';
 import type {PopoverMenuItem} from '@components/PopoverMenu';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
-import SearchBar from '@components/SearchBar';
 import Section from '@components/Section';
 import Text from '@components/Text';
 import TextLink from '@components/TextLink';
@@ -24,7 +23,6 @@ import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePersonalDetailsByLogin from '@hooks/usePersonalDetailsByLogin';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import useSearchResults from '@hooks/useSearchResults';
 import useSwitchToDelegator from '@hooks/useSwitchToDelegator';
 import useThemeStyles from '@hooks/useThemeStyles';
 
@@ -33,7 +31,6 @@ import {getLatestError} from '@libs/ErrorUtils';
 import getClickedTargetLocation from '@libs/getClickedTargetLocation';
 import Navigation from '@libs/Navigation/Navigation';
 import {sortAlphabetically} from '@libs/OptionsListUtils';
-import tokenizedSearch from '@libs/tokenizedSearch';
 import {getDefaultAvatarURL} from '@libs/UserAvatarUtils';
 
 import type {AnchorPosition} from '@styles/index';
@@ -59,13 +56,6 @@ const accountDelegationSelector = (accountValue: Account | undefined) => ({
     delegatedAccess: accountValue?.delegatedAccess,
     validated: accountValue?.validated,
 });
-
-type SearchableCopilot = Delegate & {
-    sortKey: string;
-    type: 'delegate' | 'delegator';
-};
-
-const filterCopilot = (copilot: SearchableCopilot, searchInput: string) => tokenizedSearch([copilot], searchInput, (option) => [option.sortKey, option.email]).length > 0;
 
 /**
  * Resolves the title and description a copilot row shows for one account.
@@ -140,6 +130,9 @@ function CopilotPage() {
     const {showDelegateNoAccessModal} = useDelegateNoAccessActions();
     const delegates = account?.delegatedAccess?.delegates ?? [];
     const delegators = account?.delegatedAccess?.delegators ?? [];
+
+    const hasDelegators = delegators.length > 0;
+    const hasDelegates = delegates.length > 0;
 
     const setMenuPosition = useCallback(() => {
         if (!delegateButtonRef.current) {
@@ -220,29 +213,13 @@ function CopilotPage() {
         [styles, translate],
     );
 
-    const sortedDelegates = sortAlphabetically(
-        delegates.filter((d) => !d.optimisticAccountID).map((d) => ({...d, sortKey: formatPhoneNumber(personalDetailsByLogin[d.email.toLowerCase()]?.displayName ?? d.email)})),
-        'sortKey',
-        localeCompare,
-    );
-    const sortedDelegators = sortAlphabetically(
-        delegators.map((d) => ({...d, sortKey: formatPhoneNumber(personalDetailsByLogin[d.email.toLowerCase()]?.displayName ?? d.email)})),
-        'sortKey',
-        localeCompare,
-    );
-    const searchableCopilots: SearchableCopilot[] = [
-        ...sortedDelegators.map((delegator) => ({...delegator, type: 'delegator' as const})),
-        ...sortedDelegates.map((delegateItem) => ({...delegateItem, type: 'delegate' as const})),
-    ];
-    const [searchInput, setSearchInput, filteredCopilots] = useSearchResults(searchableCopilots, filterCopilot);
-    const filteredDelegators = filteredCopilots.filter((copilot) => copilot.type === 'delegator');
-    const filteredDelegates = filteredCopilots.filter((copilot) => copilot.type === 'delegate');
-    const shouldShowSearchInput = searchableCopilots.length >= CONST.STANDARD_LIST_ITEM_LIMIT;
-    const hasDelegators = filteredDelegators.length > 0;
-    const hasDelegates = filteredDelegates.length > 0;
-
     const delegateMenuItems: MenuItemProps[] = useMemo(() => {
-        return filteredDelegates.map(({email, role, pendingAction, pendingFields}) => {
+        const sortedDelegates = sortAlphabetically(
+            delegates.filter((d) => !d.optimisticAccountID).map((d) => ({...d, sortKey: formatPhoneNumber(personalDetailsByLogin[d.email.toLowerCase()]?.displayName ?? d.email)})),
+            'sortKey',
+            localeCompare,
+        );
+        return sortedDelegates.map(({email, role, pendingAction, pendingFields}) => {
             const personalDetail = personalDetailsByLogin[email.toLowerCase()];
             const addDelegateErrors = errorFields?.addDelegate?.[email];
             const error = getLatestError(addDelegateErrors);
@@ -286,7 +263,7 @@ function CopilotPage() {
             };
         });
     }, [
-        filteredDelegates,
+        delegates,
         errorFields,
         account?.delegatedAccess,
         formatPhoneNumber,
@@ -294,13 +271,19 @@ function CopilotPage() {
         styles,
         selectedEmail,
         icons.ThreeDots,
+        localeCompare,
         showPopoverMenu,
         renderTitleWithRole,
         isAgentAccount,
         actingDelegateEmail,
     ]);
 
-    const delegatorMenuItems: MenuItemProps[] = filteredDelegators.map(({email, role, pendingAction}) => {
+    const sortedDelegators = sortAlphabetically(
+        delegators.map((d) => ({...d, sortKey: formatPhoneNumber(personalDetailsByLogin[d.email.toLowerCase()]?.displayName ?? d.email)})),
+        'sortKey',
+        localeCompare,
+    );
+    const delegatorMenuItems: MenuItemProps[] = sortedDelegators.map(({email, role, pendingAction}) => {
         const personalDetail = personalDetailsByLogin[email.toLowerCase()];
         const connectError = getLatestError(errorFields?.connect?.[email]);
         const removeDelegatorError = getLatestError(errorFields?.removeDelegator?.[email]);
@@ -468,16 +451,6 @@ function CopilotPage() {
                                 titleStyles={styles.accountSettingsSectionTitle}
                                 childrenStyles={styles.pt5}
                             >
-                                {shouldShowSearchInput && (
-                                    <SearchBar
-                                        label={translate('workspace.people.findMember')}
-                                        inputValue={searchInput}
-                                        onChangeText={setSearchInput}
-                                        shouldShowEmptyState={filteredCopilots.length === 0 && searchInput.length > 0}
-                                        shouldShowIcon={false}
-                                        style={styles.mh0}
-                                    />
-                                )}
                                 {hasDelegators && (
                                     <>
                                         <Text style={[styles.textLabelSupporting, styles.pv1]}>{translate('delegate.youCanAccessTheseAccounts')}</Text>


### PR DESCRIPTION
### Explanation of Change
Reverts https://github.com/Expensify/App/pull/98603, which added search inputs to the Copilot list and the account switcher copilot list. That feature produced four deploy blockers on the 9.4.65-1 checklist, so it is being pulled from staging rather than patched under deploy pressure.

This also reverts https://github.com/Expensify/App/pull/99970, which fixed the padding on the search field that #98603 introduced. It only exists to patch the reverted feature, so it goes with it.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99961
$ https://github.com/Expensify/App/issues/99964
$ https://github.com/Expensify/App/issues/99972
$ https://github.com/Expensify/App/issues/99974


### Tests
Same as QA

- [x] Verify that no errors appear in the JS console


### QA Steps

Verify that all the blockers linked in "Fixed issues" are no longer reproducible

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
