### PR TITLE
[No QA] Fix WorkspaceCompanyCardPageEmptyState delegate test failing on main

### DIFF
--- a/tests/ui/WorkspaceCompanyCardPageEmptyStateTest.tsx
+++ b/tests/ui/WorkspaceCompanyCardPageEmptyStateTest.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 const POLICY_ID = 'policy123';
 
 let mockIsUserValidated = false;
-let mockIsActingAsDelegate = false;
+let mockIsDelegateAccessRestricted = false;
 let mockOtherFeeds: Array<{value: string}> = [];
 let mockCapturedOnResume: ((payload?: () => void) => void) | undefined;
 const mockVerifyAccountAndResume = jest.fn<void, [payload?: () => void]>();
@@ -28,7 +28,7 @@ jest.mock('@hooks/useVerifyAccountAndResume', () => ({
 }));
 
 jest.mock('@components/DelegateNoAccessModalProvider', () => ({
-    useDelegateNoAccessState: () => ({isActingAsDelegate: mockIsActingAsDelegate}),
+    useDelegateNoAccessState: () => ({isDelegateAccessRestricted: mockIsDelegateAccessRestricted}),
     useDelegateNoAccessActions: () => ({showDelegateNoAccessModal: mockShowDelegateNoAccessModal}),
 }));
 
@@ -108,7 +108,7 @@ describe('WorkspaceCompanyCardPageEmptyState', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockIsUserValidated = false;
-        mockIsActingAsDelegate = false;
+        mockIsDelegateAccessRestricted = false;
         mockOtherFeeds = [];
         mockCapturedOnResume = undefined;
     });
@@ -155,8 +155,8 @@ describe('WorkspaceCompanyCardPageEmptyState', () => {
         expect(mockNavigate).toHaveBeenCalledWith(expectedRoute());
     });
 
-    it('shows the delegate no access modal instead of any navigation for a delegate', () => {
-        mockIsActingAsDelegate = true;
+    it('shows the delegate no access modal instead of any navigation for a submitter only delegate', () => {
+        mockIsDelegateAccessRestricted = true;
         renderEmptyState();
 
         pressAddCards();


### PR DESCRIPTION
### Explanation of Change

The `test / test (job 2)` job started failing on `main` after [Allow full-access copilots to add new company card feeds](https://github.com/Expensify/App/pull/98600) merged. The failure is in `tests/ui/WorkspaceCompanyCardPageEmptyStateTest.tsx`:

```
● WorkspaceCompanyCardPageEmptyState › shows the delegate no access modal instead of any navigation for a delegate

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 1
    Received number of calls: 0

      at Object.toHaveBeenCalledTimes (tests/ui/WorkspaceCompanyCardPageEmptyStateTest.tsx:164:47)
```

That PR changed `WorkspaceCompanyCardPageEmptyState` to read `isDelegateAccessRestricted` from `useDelegateNoAccessState` instead of `isActingAsDelegate`, so that a full-access copilot can add a card feed and only a submitter only delegate is blocked. The test's mock of `useDelegateNoAccessState` still returned only `isActingAsDelegate`, so the component read `isDelegateAccessRestricted` as `undefined`, took the normal navigation path, and never called `showDelegateNoAccessModal`.

This change updates the mock to return `isDelegateAccessRestricted`, renames the mock variable to match, and renames the test case to say "submitter only delegate", which is what `isDelegateAccessRestricted` now means (`isActingAsDelegate && isDelegateOnlySubmitter`). No production code is touched.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99996
PROPOSAL:

### Tests

1. Check out this branch.
2. Run `npx jest tests/ui/WorkspaceCompanyCardPageEmptyStateTest.tsx`.
3. Verify all 5 tests in the suite pass, including `shows the delegate no access modal instead of any navigation for a submitter only delegate`.
4. Check out `main` and run the same command.
5. Verify the delegate test fails there with `Expected number of calls: 1, Received number of calls: 0`, which confirms this branch is what fixes it.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not applicable. This change only touches a Jest test file and has no runtime or network behavior.

### QA Steps

Not applicable, the title includes "[No QA]". This change only touches a Jest test file, so there is no user-facing behavior to verify on staging.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Not applicable, this change only touches a Jest test file.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not applicable, this change only touches a Jest test file.

</details>

<details>
<summary>iOS: Native</summary>

Not applicable, this change only touches a Jest test file.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not applicable, this change only touches a Jest test file.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not applicable, this change only touches a Jest test file.

</details>
