### PR TITLE
[No QA] Fix import/no-cycle - part 1 - follow up

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,8 +1,9 @@
-import '@libs/Middleware/register';
 import EnvironmentProvider from '@components/EnvironmentContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import ScreenWrapperStatusContext from '@components/ScreenWrapper/ScreenWrapperStatusContext';
 import {SearchContextProvider} from '@components/Search/SearchContextProvider';
+
+import registerMiddlewares from '@libs/Middleware/register';
 
 import colors from '@styles/theme/colors';
 
@@ -22,6 +23,8 @@ import Onyx from 'react-native-onyx';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 import './fonts.css';
+
+registerMiddlewares();
 
 Onyx.init({
     keys: ONYXKEYS,

--- a/src/libs/Middleware/register.ts
+++ b/src/libs/Middleware/register.ts
@@ -23,44 +23,53 @@ import {
 // This lives here rather than in libs/API because six of the middlewares below import user actions, and every
 // user action imports libs/API. Registering from inside libs/API therefore closes an import cycle: libs/API
 // imports Middleware, Middleware imports an action, and that action imports libs/API again. Instead the
-// composition root imports this module for its side effect, before anything can call processWithMiddleware:
-// see src/setup/index.ts.
+// composition root calls this explicitly, before anything can call processWithMiddleware: see src/setup/index.ts.
+let hasRegistered = false;
 
-// Logging - Logs request details and errors.
-addMiddleware(Logging);
+function registerMiddlewares() {
+    if (hasRegistered) {
+        return;
+    }
+    hasRegistered = true;
 
-// Duplicates API calls (tagged with mockRequest=true) when the server sends load-test parameters via the X-Load-Test response header.
-addMiddleware(LoadTest);
+    // Logging - Logs request details and errors.
+    addMiddleware(Logging);
 
-// FailureTracking - Observes request outcomes and feeds them to FailureTracker for sustained failure detection.
-addMiddleware(FailureTracking);
+    // Duplicates API calls (tagged with mockRequest=true) when the server sends load-test parameters via the X-Load-Test response header.
+    addMiddleware(LoadTest);
 
-// Reauthentication - Handles jsonCode 407 which indicates an expired authToken. We need to reauthenticate and get a new authToken with our stored credentials.
-addMiddleware(Reauthentication);
+    // FailureTracking - Observes request outcomes and feeds them to FailureTracker for sustained failure detection.
+    addMiddleware(FailureTracking);
 
-// Handles the case when the copilot has been deleted. The response contains jsonCode 408 and a message indicating account deletion
-addMiddleware(handleDeletedAccount);
+    // Reauthentication - Handles jsonCode 407 which indicates an expired authToken. We need to reauthenticate and get a new authToken with our stored credentials.
+    addMiddleware(Reauthentication);
 
-// Handle supportal permission denial centrally
-addMiddleware(SupportalPermission);
+    // Handles the case when the copilot has been deleted. The response contains jsonCode 408 and a message indicating account deletion
+    addMiddleware(handleDeletedAccount);
 
-// If an optimistic ID is not used by the server, this will update the remaining serialized requests using that optimistic ID to use the correct ID instead.
-addMiddleware(HandleUnusedOptimisticID);
+    // Handle supportal permission denial centrally
+    addMiddleware(SupportalPermission);
 
-addMiddleware(Pagination);
+    // If an optimistic ID is not used by the server, this will update the remaining serialized requests using that optimistic ID to use the correct ID instead.
+    addMiddleware(HandleUnusedOptimisticID);
 
-// SentryServerTiming - Tracks server round-trip time for configured command groups via Sentry spans.
-addMiddleware(SentryServerTiming);
+    addMiddleware(Pagination);
 
-// RecordFullReconnectTime - Records the full-reconnect time into an OpenApp/full-ReconnectApp response. Must run before SaveResponseInOnyx applies the response.
-addMiddleware(RecordFullReconnectTime);
+    // SentryServerTiming - Tracks server round-trip time for configured command groups via Sentry spans.
+    addMiddleware(SentryServerTiming);
 
-// LoadPostDataForOpenOrReconnect - Sends the reads that OpenApp/ReconnectApp does not return, once per response that reaches the server.
-addMiddleware(LoadPostDataForOpenOrReconnect);
+    // RecordFullReconnectTime - Records the full-reconnect time into an OpenApp/full-ReconnectApp response. Must run before SaveResponseInOnyx applies the response.
+    addMiddleware(RecordFullReconnectTime);
 
-// SaveResponseInOnyx - Merges either the successData or failureData (or finallyData, if included in place of the former two values) into Onyx depending on if the call was successful or not. This must be the last middleware that applies Onyx data
-// (middlewares after it, like FraudMonitoring, must not write Onyx), because the SequentialQueue depends on the result of this middleware to pause the queue (if needed) to bring the app to an up-to-date state.
-addMiddleware(SaveResponseInOnyx);
+    // LoadPostDataForOpenOrReconnect - Sends the reads that OpenApp/ReconnectApp does not return, once per response that reaches the server.
+    addMiddleware(LoadPostDataForOpenOrReconnect);
 
-// FraudMonitoring - Tags the request with the appropriate Fraud Protection event.
-addMiddleware(FraudMonitoring);
+    // SaveResponseInOnyx - Merges either the successData or failureData (or finallyData, if included in place of the former two values) into Onyx depending on if the call was successful or not. This must be the last middleware that applies Onyx data
+    // (middlewares after it, like FraudMonitoring, must not write Onyx), because the SequentialQueue depends on the result of this middleware to pause the queue (if needed) to bring the app to an up-to-date state.
+    addMiddleware(SaveResponseInOnyx);
+
+    // FraudMonitoring - Tags the request with the appropriate Fraud Protection event.
+    addMiddleware(FraudMonitoring);
+}
+
+export default registerMiddlewares;

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -1,6 +1,6 @@
-import '@libs/Middleware/register';
 import {finishCloudflareSignInFromURL} from '@libs/CloudflareAccess/finishSignInFromURL';
 import intlPolyfill from '@libs/IntlPolyfill';
+import registerMiddlewares from '@libs/Middleware/register';
 import registerReportActionsPagination from '@libs/registerReportActionsPagination';
 
 import {setDeviceID} from '@userActions/Device';
@@ -21,6 +21,8 @@ import telemetry from './telemetry';
 const enableDevTools = Config?.USE_REDUX_DEVTOOLS === 'true';
 
 export default function () {
+    registerMiddlewares();
+
     telemetry();
 
     toSortedPolyfill.shim();

--- a/tests/ui/SearchPageTest.tsx
+++ b/tests/ui/SearchPageTest.tsx
@@ -1,4 +1,3 @@
-import '@libs/Middleware/register';
 import {act, render, screen} from '@testing-library/react-native';
 
 import ComposeProviders from '@components/ComposeProviders';
@@ -14,6 +13,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
 import {search} from '@libs/actions/Search';
 import type * as SearchActions from '@libs/actions/Search';
+import registerMiddlewares from '@libs/Middleware/register';
 import createRootStackNavigator from '@libs/Navigation/AppNavigator/createRootStackNavigator';
 import navigationRef from '@libs/Navigation/navigationRef';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
@@ -38,6 +38,8 @@ import {NavigationContainer} from '@react-navigation/native';
 import Onyx from 'react-native-onyx';
 
 import createMock from '../utils/createMock';
+
+registerMiddlewares();
 
 jest.mock('@hooks/useResponsiveLayout', () => jest.fn());
 jest.mock('@hooks/useNetwork', () => jest.fn());

--- a/tests/unit/MiddlewareEntryPointTest.ts
+++ b/tests/unit/MiddlewareEntryPointTest.ts
@@ -1,16 +1,26 @@
 import type * as RequestModule from '@libs/Request';
 import {addMiddleware} from '@libs/Request';
 
+import appSetup from '@src/setup';
+
 jest.mock('@libs/Request', () => ({
     ...jest.requireActual<typeof RequestModule>('@libs/Request'),
     addMiddleware: jest.fn(),
 }));
 
+jest.mock('@libs/registerReportActionsPagination', () => jest.fn());
+jest.mock('@libs/IntlPolyfill', () => jest.fn());
+jest.mock('@userActions/Device', () => ({setDeviceID: jest.fn()}));
+jest.mock('@userActions/OnyxDerived', () => jest.fn());
+jest.mock('@src/setup/addUtilsToWindow', () => jest.fn());
+jest.mock('@src/setup/platformSetup', () => jest.fn());
+jest.mock('@src/setup/telemetry', () => jest.fn());
+
 describe('src/setup attaches the API middlewares', () => {
-    it('registers all 13 middlewares at module scope when the composition root loads', () => {
+    it('registers all 13 middlewares when the composition root runs', () => {
         expect(jest.mocked(addMiddleware)).not.toHaveBeenCalled();
 
-        require('@src/setup');
+        appSetup();
 
         expect(jest.mocked(addMiddleware)).toHaveBeenCalledTimes(13);
     });

--- a/tests/unit/MiddlewareRegistrationTest.ts
+++ b/tests/unit/MiddlewareRegistrationTest.ts
@@ -13,6 +13,7 @@ import {
     SentryServerTiming,
     SupportalPermission,
 } from '@libs/Middleware';
+import registerMiddlewares from '@libs/Middleware/register';
 import type * as RequestModule from '@libs/Request';
 import {addMiddleware} from '@libs/Request';
 
@@ -41,9 +42,7 @@ describe('Middleware registration', () => {
     let registered: RequestModule.Middleware[] = [];
 
     beforeAll(() => {
-        // jest.isolateModules would give register.ts its own module registry, so the middlewares it resolves
-        // would be distinct function objects from the ones imported above and every identity check would fail.
-        require('@libs/Middleware/register');
+        registerMiddlewares();
         registered = jest.mocked(addMiddleware).mock.calls.map(([middleware]) => middleware);
     });
 

--- a/tests/unit/TransactionGroupListItemTest.tsx
+++ b/tests/unit/TransactionGroupListItemTest.tsx
@@ -1,4 +1,3 @@
-import '@libs/Middleware/register';
 import {fireEvent, render, screen} from '@testing-library/react-native';
 
 import ComposeProviders from '@components/ComposeProviders';
@@ -13,6 +12,7 @@ import type {
     TransactionReportGroupListItemType,
 } from '@components/Search/SearchList/ListItem/types';
 
+import registerMiddlewares from '@libs/Middleware/register';
 import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 
 import TransactionGroupListItem from '@src/components/Search/SearchList/ListItem/TransactionGroupListItem';
@@ -28,6 +28,8 @@ import Onyx from 'react-native-onyx';
 import type * as MockUsePaymentContextUtil from '../utils/mockUsePaymentContext';
 
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+registerMiddlewares();
 
 jest.mock('@libs/actions/Search', () => ({
     search: jest.fn(),

--- a/tests/utils/TestHelper.ts
+++ b/tests/utils/TestHelper.ts
@@ -4,6 +4,7 @@ import type {ApiCommand, ApiRequestCommandParameters} from '@libs/API/types';
 import {convertToFrontendAmountAsInteger, sanitizeCurrencyCode} from '@libs/CurrencyUtils';
 import {formatPhoneNumberWithCountryCode} from '@libs/LocalePhoneNumber';
 import {translate} from '@libs/Localize';
+import registerMiddlewares from '@libs/Middleware/register';
 import {format as formatNumber} from '@libs/NumberFormatUtils';
 import Pusher from '@libs/Pusher';
 import PusherConnectionManager from '@libs/PusherConnectionManager';
@@ -32,6 +33,10 @@ import createMock from './createMock';
 import {isObject} from './typeGuards';
 import waitForBatchedUpdates from './waitForBatchedUpdates';
 import waitForBatchedUpdatesWithAct from './waitForBatchedUpdatesWithAct';
+
+// Every test that imports this module can make an API call without first calling setupApp(), so middlewares
+// must be registered here too. Idempotent, so this doesn't conflict with the appSetup() call inside setupApp().
+registerMiddlewares();
 
 type MockFetch = jest.Mock<ReturnType<typeof fetch>, Parameters<typeof fetch>> & {
     pause: () => void;


### PR DESCRIPTION


<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Regarding https://github.com/Expensify/App/pull/99670#discussion_r3899027237

`src/libs/Middleware/register.ts` used to run its `addMiddleware` calls at module scope, so importing the module was the registration. It now exports a default `registerMiddlewares()` function that callers invoke, guarded by a module-level `hasRegistered` flag so repeated calls are no-ops.

Callers updated from `import '@libs/Middleware/register'` to importing and calling the function:

- `src/setup/index.ts` calls it first inside the default setup function
- `.storybook/preview.tsx` calls it before `Onyx.init`
- `tests/ui/SearchPageTest.tsx` and `tests/unit/TransactionGroupListItemTest.tsx` call it at module top level
- `tests/utils/TestHelper.ts` calls it on import, since tests that pull in this helper can issue API calls without going through `setupApp()`. The idempotency guard is what makes this safe alongside `setupApp()`'s own registration.
- `tests/unit/MiddlewareRegistrationTest.ts` calls the function instead of `require`-ing the module, which removes the note about `jest.isolateModules` breaking identity checks.

The middleware list and its ordering are unchanged, including the constraint that `SaveResponseInOnyx` runs last among Onyx-writing middlewares.

### Why

A bare side-effect import is easy to drop by accident: an import with no binding looks unused, and formatters or import-sorting tools can reorder it relative to code that depends on it having run. Making registration a call means the dependency is visible at the call site and the ordering inside `setup/index.ts` is explicit rather than implicit in import order.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99650
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


https://github.com/user-attachments/assets/7c4f6aa7-dcbd-480a-8c0a-1a650a902b39


