### PR TITLE
Fix unread marker disappears after revealing Concierge history in side panel

### DIFF
--- a/src/hooks/useConciergeSessionStartTime.ts
+++ b/src/hooks/useConciergeSessionStartTime.ts
@@ -1,0 +1,18 @@
+import {useConciergeSessionState} from '@pages/inbox/ConciergeSessionContext';
+
+import useIsInSidePanel from './useIsInSidePanel';
+import useSidePanelState from './useSidePanelState';
+
+/**
+ * Returns the Concierge session start time from the context that actually tracks it: SidePanelStateContext in the
+ * side panel, ConciergeSessionContext in the main DM. Each is null on the other surface, so always read via this
+ * hook. Only meaningful in a Concierge chat - callers gate with e.g. isConciergeHiddenHistory.
+ */
+function useConciergeSessionStartTime(): string | null {
+    const isInSidePanel = useIsInSidePanel();
+    const {sessionStartTime: mainDMSessionStartTime} = useConciergeSessionState();
+    const {sessionStartTime: sidePanelSessionStartTime} = useSidePanelState();
+    return isInSidePanel ? sidePanelSessionStartTime : mainDMSessionStartTime;
+}
+
+export default useConciergeSessionStartTime;

--- a/src/hooks/useUnreadMarker.ts
+++ b/src/hooks/useUnreadMarker.ts
@@ -139,15 +139,12 @@ function useUnreadMarker({
         setPrevUnreadMarkerReportActionID(unreadMarkerReportActionID);
     }
 
-    // When the user reads a new message as it is received, push unreadMarkerTime down to the
-    // latest action's timestamp so new incoming actions display over those new messages instead of
-    // sticking to the initial lastReadTime. A null marker alone is not enough to push: revealing
-    // existing history at once (Concierge "Show history") also scans to null because those actions
-    // are new to the list, and pushing then would advance the watermark past the unread message and
-    // permanently hide the New divider. So only push when a genuinely newer action arrived, i.e. the
-    // newest visible `created` advanced past the previous render's. The synthetic Concierge greeting
-    // is excluded as a push target: its `created` tracks report.lastReadTime, so it would drag the
-    // watermark to "now".
+    // When the user reads a new message as it arrives, advance the watermark so that only actions
+    // arriving after it count as unread. Only push when the newest visible `created` has advanced:
+    // a bulk history reveal (Concierge "Show history") also scans to a null marker, and pushing then
+    // would move the watermark past the unread message and permanently hide the New divider. The
+    // synthetic greeting is not a valid push target either, because its `created` tracks
+    // report.lastReadTime and would drag the watermark to "now".
     const newestVisibleReportActionCreated = sortedVisibleReportActions.at(0)?.created ?? '';
     const prevNewestVisibleReportActionCreated = usePrevious(newestVisibleReportActionCreated);
     const mostRecentReportActionCreated = sortedVisibleReportActions.find((action) => action.reportActionID !== CONST.CONCIERGE_GREETING_ACTION_ID)?.created ?? '';

--- a/src/hooks/useUnreadMarker.ts
+++ b/src/hooks/useUnreadMarker.ts
@@ -3,6 +3,7 @@ import Visibility from '@libs/Visibility';
 
 import {getUnreadMarkerReportAction} from '@pages/inbox/report/shouldDisplayNewMarkerOnReportAction';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
 
@@ -134,9 +135,17 @@ function useUnreadMarker({
 
     // When the user reads a new message as it is received, push unreadMarkerTime down to the
     // latest action's timestamp so new incoming actions display over those new messages instead of
-    // sticking to the initial lastReadTime.
-    const mostRecentReportActionCreated = sortedVisibleReportActions.at(0)?.created ?? '';
-    if (!isAnonymousUser && !unreadMarkerReportActionID && mostRecentReportActionCreated > unreadMarkerTime) {
+    // sticking to the initial lastReadTime. A null marker alone is not enough to push: revealing
+    // existing history at once (Concierge "Show history") also scans to null because those actions
+    // are new to the list, and pushing then would advance the watermark past the unread message and
+    // permanently hide the New divider. So only push when a genuinely newer action arrived, i.e. the
+    // newest visible `created` advanced past the previous render's. The synthetic Concierge greeting
+    // is excluded as a push target: its `created` tracks report.lastReadTime, so it would drag the
+    // watermark to "now".
+    const newestVisibleReportActionCreated = sortedVisibleReportActions.at(0)?.created ?? '';
+    const prevNewestVisibleReportActionCreated = usePrevious(newestVisibleReportActionCreated);
+    const mostRecentReportActionCreated = sortedVisibleReportActions.find((action) => action.reportActionID !== CONST.CONCIERGE_GREETING_ACTION_ID)?.created ?? '';
+    if (!isAnonymousUser && !unreadMarkerReportActionID && mostRecentReportActionCreated > unreadMarkerTime && newestVisibleReportActionCreated > prevNewestVisibleReportActionCreated) {
         setUnreadMarkerTime(mostRecentReportActionCreated);
     }
 

--- a/src/hooks/useUnreadMarker.ts
+++ b/src/hooks/useUnreadMarker.ts
@@ -35,6 +35,10 @@ type UseUnreadMarkerParams = {
 
     /** Whether report actions have loaded at least once; once true, the pagination anchor is ignored in favor of the scan */
     hasOnceLoadedReportActions: boolean;
+
+    /** Concierge hidden-history boundary: actions created before this were revealed/loaded from history,
+     * not received live, so they are never treated as read-on-arrival */
+    newMessageBoundaryTime?: string | null;
 };
 
 type UseUnreadMarkerResult = {
@@ -54,6 +58,7 @@ function useUnreadMarker({
     oldestUnreadReportActionID,
     isScrolledOverThreshold,
     hasOnceLoadedReportActions,
+    newMessageBoundaryTime,
 }: UseUnreadMarkerParams): UseUnreadMarkerResult {
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
     const isAnonymousUser = useIsAnonymousUser();
@@ -123,6 +128,7 @@ function useUnreadMarker({
         isAnonymousUser,
         prevUnreadMarkerReportActionID,
         hasWindowFocus: Visibility.hasFocus(),
+        newMessageBoundaryTime,
     });
     // Pagination is anchored to the oldest unread on first open; that anchor does not change when the user
     // marks read or unread, or when messages are deleted. Prefer the scan when it does not match that stale id.

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -191,6 +191,7 @@ function ReportActionsListContent({reportID, conciergeChat, onLayout}: ReportAct
         oldestUnreadReportActionID: oldestUnreadReportAction?.reportActionID,
         isScrolledOverThreshold: hasScrolledOverThreshold,
         hasOnceLoadedReportActions: !!hasOnceLoadedReportActions,
+        newMessageBoundaryTime: isConciergeHiddenHistory ? sessionStartTime : undefined,
     });
 
     const {markNewestActionAsRead, completeSkippedMarkAsRead} = useMarkAsRead({

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -2,6 +2,7 @@ import {renderScrollComponent as renderActionSheetAwareScrollView} from '@compon
 import InvertedFlashList from '@components/FlashList/InvertedFlashList';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
+import useConciergeSessionStartTime from '@hooks/useConciergeSessionStartTime';
 import useEnvironment from '@hooks/useEnvironment';
 import useLinkedMessageOfflineLoading from '@hooks/useLinkedMessageOfflineLoading';
 import useLocalize from '@hooks/useLocalize';
@@ -47,7 +48,6 @@ import type {ReportsSplitNavigatorParamList} from '@navigation/types';
 
 import {useActionListContext, useActionListRef} from '@pages/inbox/ActionListContext';
 import {useConciergeDraft, useConciergeDraftActions} from '@pages/inbox/ConciergeDraftContext';
-import {useConciergeSessionState} from '@pages/inbox/ConciergeSessionContext';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -134,7 +134,7 @@ function ReportActionsListContent({reportID, conciergeChat, onLayout}: ReportAct
     const {isOffline} = useNetwork();
     const route = useRoute<PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>>();
     const reportActionIDFromRoute = route?.params?.reportActionID;
-    const {sessionStartTime} = useConciergeSessionState();
+    const sessionStartTime = useConciergeSessionStartTime();
 
     const didLayout = useRef(false);
 

--- a/src/pages/inbox/report/shouldDisplayNewMarkerOnReportAction.ts
+++ b/src/pages/inbox/report/shouldDisplayNewMarkerOnReportAction.ts
@@ -32,6 +32,10 @@ type ShouldDisplayNewMarkerOnReportActionParams = {
     prevUnreadMarkerReportActionID?: string | null;
     /** Whether the app window is focused */
     hasWindowFocus?: boolean;
+
+    /** Actions created before this time cannot have "just arrived" (e.g. Concierge history revealed via "Show history"),
+     * so the live auto-read suppression for new-to-list messages does not apply to them */
+    newMessageBoundaryTime?: string | null;
 };
 
 /**
@@ -49,6 +53,7 @@ const shouldDisplayNewMarkerOnReportAction = ({
     isOffline,
     prevUnreadMarkerReportActionID,
     hasWindowFocus = true,
+    newMessageBoundaryTime,
 }: ShouldDisplayNewMarkerOnReportActionParams): boolean => {
     const isNextMessageUnread = !!nextMessage && isReportActionUnread(nextMessage, unreadMarkerTime);
 
@@ -96,7 +101,12 @@ const shouldDisplayNewMarkerOnReportAction = ({
         return false;
     }
 
-    return !isNewMessage || isScrolledOverThreshold || !hasWindowFocus;
+    // An action created before the session boundary was revealed or loaded from history, not received live,
+    // so it is never treated as read-on-arrival.
+    const isRevealedHistoryMessage = !!newMessageBoundaryTime && message.created < newMessageBoundaryTime;
+
+    const result = !isNewMessage || isRevealedHistoryMessage || isScrolledOverThreshold || !hasWindowFocus;
+    return result;
 };
 
 export default shouldDisplayNewMarkerOnReportAction;
@@ -133,6 +143,10 @@ type GetUnreadMarkerReportActionParams = {
     prevUnreadMarkerReportActionID?: string | null;
     /** Whether the app window is focused */
     hasWindowFocus?: boolean;
+
+    /** Actions created before this time cannot have "just arrived" (e.g. Concierge history revealed via "Show history"),
+     * so the live auto-read suppression for new-to-list messages does not apply to them */
+    newMessageBoundaryTime?: string | null;
 };
 
 /**
@@ -151,6 +165,7 @@ const getUnreadMarkerReportAction = ({
     isAnonymousUser = false,
     prevUnreadMarkerReportActionID,
     hasWindowFocus = true,
+    newMessageBoundaryTime,
 }: GetUnreadMarkerReportActionParams): [string | null, number] => {
     if (isAnonymousUser) {
         return [null, -1];
@@ -192,6 +207,7 @@ const getUnreadMarkerReportAction = ({
                 isOffline,
                 prevUnreadMarkerReportActionID,
                 hasWindowFocus,
+                newMessageBoundaryTime,
             });
 
         if (shouldShowMarker) {

--- a/tests/unit/useUnreadMarkerTest.ts
+++ b/tests/unit/useUnreadMarkerTest.ts
@@ -125,7 +125,6 @@ describe('useUnreadMarker', () => {
     });
 
     it('keeps the unread marker when Concierge hidden history is revealed at once (side panel "Show history")', () => {
-        // Welcome mode: the visible list is only [synthetic greeting, CREATED]; the unread message is filtered out.
         const greeting = makeAction(CONST.CONCIERGE_GREETING_ACTION_ID, {created: LAST_READ_TIME});
         const createdAction = makeAction('created', {created: '2023-01-01 08:00:00.000', actionName: CONST.REPORT.ACTIONS.TYPE.CREATED});
         const welcomeActions = [greeting, createdAction];
@@ -144,23 +143,72 @@ describe('useUnreadMarker', () => {
         );
         expect(result.current.unreadMarkerReportActionID).toBeNull();
 
-        // Opening the panel marks the report read, which bumps report.lastReadTime and re-stamps the
-        // greeting's `created` to "now". The synthetic greeting must not drive the watermark forward.
         const bumpedGreeting = makeAction(CONST.CONCIERGE_GREETING_ACTION_ID, {created: '2023-01-01 12:00:00.000'});
         rerender([bumpedGreeting, createdAction]);
         expect(result.current.unreadMarkerReportActionID).toBeNull();
 
-        // "Show history" reveals the real history in one render. All of it is new to the list, so the
-        // scan is suppressed this render — but the watermark must not be pushed past the unread message.
         const unreadMessage = makeAction('unread', {created: '2023-01-01 11:00:00.000'});
         const readMessage = makeAction('read', {created: '2023-01-01 09:00:00.000'});
         const fullHistory = [unreadMessage, readMessage, createdAction];
         rerender(fullHistory);
 
-        // On the next render the actions are no longer "new" and the marker lands on the unread message.
         rerender(fullHistory);
         expect(result.current.unreadMarkerReportActionID).toBe('unread');
         expect(result.current.unreadMarkerReportActionIndex).toBe(0);
+    });
+
+    it('shows the marker immediately on the reveal render when a session boundary is provided ("Show history")', () => {
+        const sessionStartTime = '2023-01-01 11:30:00.000';
+        const greeting = makeAction(CONST.CONCIERGE_GREETING_ACTION_ID, {created: LAST_READ_TIME});
+        const createdAction = makeAction('created', {created: '2023-01-01 08:00:00.000', actionName: CONST.REPORT.ACTIONS.TYPE.CREATED});
+
+        const {result, rerender} = renderHook(
+            (sortedVisibleReportActions: OnyxTypes.ReportAction[]) =>
+                useUnreadMarker({
+                    reportID: REPORT_ID,
+                    sortedVisibleReportActions,
+                    sortedReportActions: sortedVisibleReportActions,
+                    oldestUnreadReportActionID: undefined,
+                    isScrolledOverThreshold: false,
+                    hasOnceLoadedReportActions: true,
+                    newMessageBoundaryTime: sessionStartTime,
+                }),
+            {initialProps: [greeting, createdAction]},
+        );
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+
+        const unreadMessage = makeAction('unread', {created: '2023-01-01 11:00:00.000'});
+        const readMessage = makeAction('read', {created: '2023-01-01 09:00:00.000'});
+        rerender([unreadMessage, readMessage, createdAction]);
+
+        expect(result.current.unreadMarkerReportActionID).toBe('unread');
+        expect(result.current.unreadMarkerReportActionIndex).toBe(0);
+    });
+
+    it('still auto-reads a live message received while caught up when a session boundary is provided', () => {
+        const sessionStartTime = '2023-01-01 10:30:00.000';
+        const oldMessage = makeAction('old', {created: '2023-01-01 09:00:00.000'});
+
+        const {result, rerender} = renderHook(
+            (sortedVisibleReportActions: OnyxTypes.ReportAction[]) =>
+                useUnreadMarker({
+                    reportID: REPORT_ID,
+                    sortedVisibleReportActions,
+                    sortedReportActions: sortedVisibleReportActions,
+                    oldestUnreadReportActionID: undefined,
+                    isScrolledOverThreshold: false,
+                    hasOnceLoadedReportActions: true,
+                    newMessageBoundaryTime: sessionStartTime,
+                }),
+            {initialProps: [oldMessage]},
+        );
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+
+        const incoming = makeAction('incoming', {created: '2023-01-01 11:00:00.000'});
+        rerender([incoming, oldMessage]);
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+        rerender([incoming, oldMessage]);
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
     });
 
     it('still pushes the watermark past a new message received while caught up', () => {
@@ -180,8 +228,6 @@ describe('useUnreadMarker', () => {
         );
         expect(result.current.unreadMarkerReportActionID).toBeNull();
 
-        // A new message arrives while the user is at the bottom with the window focused: the marker is
-        // suppressed and the watermark advances past it, so it stays suppressed on later renders too.
         const incoming = makeAction('incoming', {created: '2023-01-01 11:00:00.000'});
         rerender([incoming, oldMessage]);
         expect(result.current.unreadMarkerReportActionID).toBeNull();

--- a/tests/unit/useUnreadMarkerTest.ts
+++ b/tests/unit/useUnreadMarkerTest.ts
@@ -2,6 +2,7 @@ import {act, renderHook} from '@testing-library/react-native';
 
 import useUnreadMarker from '@hooks/useUnreadMarker';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
 
@@ -121,6 +122,71 @@ describe('useUnreadMarker', () => {
 
         expect(result.current.unreadMarkerReportActionID).toBeNull();
         expect(result.current.unreadMarkerReportActionIndex).toBe(-1);
+    });
+
+    it('keeps the unread marker when Concierge hidden history is revealed at once (side panel "Show history")', () => {
+        // Welcome mode: the visible list is only [synthetic greeting, CREATED]; the unread message is filtered out.
+        const greeting = makeAction(CONST.CONCIERGE_GREETING_ACTION_ID, {created: LAST_READ_TIME});
+        const createdAction = makeAction('created', {created: '2023-01-01 08:00:00.000', actionName: CONST.REPORT.ACTIONS.TYPE.CREATED});
+        const welcomeActions = [greeting, createdAction];
+
+        const {result, rerender} = renderHook(
+            (sortedVisibleReportActions: OnyxTypes.ReportAction[]) =>
+                useUnreadMarker({
+                    reportID: REPORT_ID,
+                    sortedVisibleReportActions,
+                    sortedReportActions: sortedVisibleReportActions,
+                    oldestUnreadReportActionID: undefined,
+                    isScrolledOverThreshold: false,
+                    hasOnceLoadedReportActions: true,
+                }),
+            {initialProps: welcomeActions},
+        );
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+
+        // Opening the panel marks the report read, which bumps report.lastReadTime and re-stamps the
+        // greeting's `created` to "now". The synthetic greeting must not drive the watermark forward.
+        const bumpedGreeting = makeAction(CONST.CONCIERGE_GREETING_ACTION_ID, {created: '2023-01-01 12:00:00.000'});
+        rerender([bumpedGreeting, createdAction]);
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+
+        // "Show history" reveals the real history in one render. All of it is new to the list, so the
+        // scan is suppressed this render — but the watermark must not be pushed past the unread message.
+        const unreadMessage = makeAction('unread', {created: '2023-01-01 11:00:00.000'});
+        const readMessage = makeAction('read', {created: '2023-01-01 09:00:00.000'});
+        const fullHistory = [unreadMessage, readMessage, createdAction];
+        rerender(fullHistory);
+
+        // On the next render the actions are no longer "new" and the marker lands on the unread message.
+        rerender(fullHistory);
+        expect(result.current.unreadMarkerReportActionID).toBe('unread');
+        expect(result.current.unreadMarkerReportActionIndex).toBe(0);
+    });
+
+    it('still pushes the watermark past a new message received while caught up', () => {
+        const oldMessage = makeAction('old', {created: '2023-01-01 09:00:00.000'});
+
+        const {result, rerender} = renderHook(
+            (sortedVisibleReportActions: OnyxTypes.ReportAction[]) =>
+                useUnreadMarker({
+                    reportID: REPORT_ID,
+                    sortedVisibleReportActions,
+                    sortedReportActions: sortedVisibleReportActions,
+                    oldestUnreadReportActionID: undefined,
+                    isScrolledOverThreshold: false,
+                    hasOnceLoadedReportActions: true,
+                }),
+            {initialProps: [oldMessage]},
+        );
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+
+        // A new message arrives while the user is at the bottom with the window focused: the marker is
+        // suppressed and the watermark advances past it, so it stays suppressed on later renders too.
+        const incoming = makeAction('incoming', {created: '2023-01-01 11:00:00.000'});
+        rerender([incoming, oldMessage]);
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
+        rerender([incoming, oldMessage]);
+        expect(result.current.unreadMarkerReportActionID).toBeNull();
     });
 
     it('seeds the marker from the switched-to report lastReadTime (one mount per report)', () => {

--- a/tests/unit/useUnreadMarkerTest.ts
+++ b/tests/unit/useUnreadMarkerTest.ts
@@ -124,7 +124,7 @@ describe('useUnreadMarker', () => {
         expect(result.current.unreadMarkerReportActionIndex).toBe(-1);
     });
 
-    it('keeps the unread marker when Concierge hidden history is revealed at once (side panel "Show history")', () => {
+    it('does not push the read watermark on a bulk history reveal without a session boundary (marker appears on the next render)', () => {
         const greeting = makeAction(CONST.CONCIERGE_GREETING_ACTION_ID, {created: LAST_READ_TIME});
         const createdAction = makeAction('created', {created: '2023-01-01 08:00:00.000', actionName: CONST.REPORT.ACTIONS.TYPE.CREATED});
         const welcomeActions = [greeting, createdAction];


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Fixes the "New" unread marker disappearing when Concierge hidden history is revealed via "Show history". `useUnreadMarker` now only advances the read watermark when the newest visible action actually advances (a bulk history reveal no longer pushes it past unread messages), ignores the synthetic Concierge greeting as a push target, and a new `newMessageBoundaryTime` param prevents revealed history actions from being treated as read-on-arrival.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/100006


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Send a message to Concierge so the chat has a few messages.
2. Long-press (or right-click) one of the earlier Concierge messages and mark it as unread.
3. Navigate to any other chat.
4. Open the Concierge chat in the side panel.
5. Click "Show history".
6. Verify that the green "New" unread marker appears right above the message you marked as unread.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Mark an earlier Concierge message as unread while online, then go offline.
2. Open another chat, open Concierge in the side panel, and click "Show history".
3. Verify that the "New" unread marker appears above the marked message and remains stable while offline.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/c89a234c-f8d3-4602-9dc5-2b2791d2f61a

</details>
