### PR TITLE
Part 3 - Audit usage of Str.removeSMSDomain

### DIFF
--- a/src/components/ApprovalWorkflowSection.tsx
+++ b/src/components/ApprovalWorkflowSection.tsx
@@ -62,7 +62,7 @@ function ApprovalWorkflowSection({
     const icons = useMemoizedLazyExpensifyIcons(['ArrowRight', 'Lightbulb', 'Pencil', 'Users', 'UserCheck']);
     const styles = useThemeStyles();
     const theme = useTheme();
-    const {translate, toLocaleOrdinalWithWords, localeCompare} = useLocalize();
+    const {translate, toLocaleOrdinalWithWords, localeCompare, formatPhoneNumber} = useLocalize();
     const {convertToDisplayString} = useCurrencyListActions();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const approverTitle = (index: number) => {
@@ -88,7 +88,9 @@ function ApprovalWorkflowSection({
     // the workflow (e.g. a member invited offline) is still pending server confirmation.
     const membersPendingAction = sortedMembers.find((member) => !!member.pendingFields?.submitsTo)?.pendingFields?.submitsTo;
 
-    const members = approvalWorkflow.isDefault ? translate('workspace.common.everyone') : sortedMembers.map((m) => Str.removeSMSDomain(m.displayName)).join(', ');
+    const members = approvalWorkflow.isDefault
+        ? translate('workspace.common.everyone')
+        : sortedMembers.map((m) => (Str.isSMSLogin(m.displayName) ? formatPhoneNumber(m.displayName) : m.displayName)).join(', ');
 
     const memberPills = sortedMembers.map((m) => ({
         avatar: m.avatar,
@@ -98,7 +100,9 @@ function ApprovalWorkflowSection({
     const pressAction = isDisabled ? undefined : onPress;
     const accessibilityLabel = translate('workflowsPage.accessibilityLabel', {
         members,
-        approvers: approvalWorkflow?.approvers.map((approver) => Str.removeSMSDomain(approver?.displayName ?? '')).join(', '),
+        approvers: approvalWorkflow?.approvers
+            .map((approver) => (Str.isSMSLogin(approver?.displayName ?? '') ? formatPhoneNumber(approver?.displayName ?? '') : (approver?.displayName ?? '')))
+            .join(', '),
     });
 
     return (
@@ -191,7 +195,7 @@ function ApprovalWorkflowSection({
                                         />
                                     </View>
                                 }
-                                helperText={getApprovalLimitDescription({approver, currency, translate, convertToDisplayString})}
+                                helperText={getApprovalLimitDescription({approver, currency, translate, formatPhoneNumber, convertToDisplayString})}
                                 helperTextStyle={styles.workflowApprovalLimitText}
                                 sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKFLOWS.APPROVAL_SECTION_APPROVER}
                             />

--- a/src/libs/WorkflowUtils.ts
+++ b/src/libs/WorkflowUtils.ts
@@ -687,19 +687,21 @@ type GetApprovalLimitDescriptionParams = {
     approver: Approver | undefined;
     currency: string;
     translate: LocaleContextProps['translate'];
+    formatPhoneNumber: LocaleContextProps['formatPhoneNumber'];
     convertToDisplayString: CurrencyListActionsContextType['convertToDisplayString'];
 };
 
 /**
  * Get the approval limit description for an approver (e.g., "Reports above $1,000 forward to John Doe")
  */
-function getApprovalLimitDescription({approver, currency, translate, convertToDisplayString}: GetApprovalLimitDescriptionParams): string | undefined {
+function getApprovalLimitDescription({approver, currency, translate, formatPhoneNumber, convertToDisplayString}: GetApprovalLimitDescriptionParams): string | undefined {
     if (approver?.approvalLimit == null || !approver?.overLimitForwardsTo) {
         return undefined;
     }
 
     const formattedAmount = convertToDisplayString(approver.approvalLimit, currency);
-    const approverDisplayName = Str.removeSMSDomain(approver.overLimitForwardsToDisplayName ?? approver.overLimitForwardsTo);
+    const approverName = approver.overLimitForwardsToDisplayName ?? approver.overLimitForwardsTo;
+    const approverDisplayName = Str.isSMSLogin(approverName) ? formatPhoneNumber(approverName) : approverName;
 
     return translate('workflowsApprovalLimitPage.forwardLimitDescription', {
         approvalLimit: formattedAmount,

--- a/src/pages/workspace/workflows/approvals/ApprovalWorkflowEditor.tsx
+++ b/src/pages/workspace/workflows/approvals/ApprovalWorkflowEditor.tsx
@@ -53,7 +53,7 @@ type ApprovalWorkflowEditorProps = {
 function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, policy, policyID, ref}: ApprovalWorkflowEditorProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Trashcan']);
     const styles = useThemeStyles();
-    const {translate, toLocaleOrdinalWithWords, localeCompare} = useLocalize();
+    const {translate, toLocaleOrdinalWithWords, localeCompare, formatPhoneNumber} = useLocalize();
     const {convertToDisplayString} = useCurrencyListActions();
     const approverCount = approvalWorkflow.approvers.length;
     const currency = policy?.outputCurrency ?? CONST.CURRENCY.USD;
@@ -94,7 +94,9 @@ function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, polic
         [approvalWorkflow.isDefault, approvalWorkflow.members, localeCompare],
     );
 
-    const members = approvalWorkflow.isDefault ? translate('workspace.common.everyone') : sortedMembers.map((m) => Str.removeSMSDomain(m.displayName)).join(', ');
+    const members = approvalWorkflow.isDefault
+        ? translate('workspace.common.everyone')
+        : sortedMembers.map((m) => (Str.isSMSLogin(m.displayName) ? formatPhoneNumber(m.displayName) : m.displayName)).join(', ');
 
     const memberPills = useMemo(
         () =>
@@ -121,12 +123,16 @@ function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, polic
                 if (!previousApprover || !approver) {
                     return;
                 }
-                return translate('workflowsPage.approverCircularReference', Str.removeSMSDomain(approver.displayName), Str.removeSMSDomain(previousApprover.displayName));
+                return translate(
+                    'workflowsPage.approverCircularReference',
+                    Str.isSMSLogin(approver.displayName) ? formatPhoneNumber(approver.displayName) : approver.displayName,
+                    Str.isSMSLogin(previousApprover.displayName) ? formatPhoneNumber(previousApprover.displayName) : previousApprover.displayName,
+                );
             }
 
             return translate(error);
         },
-        [approvalWorkflow.approvers, approvalWorkflow.errors, translate],
+        [approvalWorkflow.approvers, approvalWorkflow.errors, translate, formatPhoneNumber],
     );
 
     const editApprover = useCallback(
@@ -208,6 +214,7 @@ function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, polic
                         approver,
                         currency,
                         translate,
+                        formatPhoneNumber,
                         convertToDisplayString,
                     });
                     const hintText = [isApproverInMultipleWorkflows ? translate('workflowsPage.approverInMultipleWorkflows') : undefined, limitDescription].filter(Boolean).join('\n');
@@ -219,7 +226,7 @@ function ApprovalWorkflowEditor({approvalWorkflow, removeApprovalWorkflow, polic
                             pendingAction={getApprovalPendingAction(approverIndex)}
                         >
                             <MenuItemWithTopDescription
-                                accessibilityLabel={Str.removeSMSDomain(approver?.displayName ?? '')}
+                                accessibilityLabel={formatPhoneNumber(approver?.displayName ?? '')}
                                 titleStyle={styles.textNormalThemeText}
                                 wrapperStyle={styles.sectionMenuItemTopDescription}
                                 description={approverDescription(approverIndex)}

--- a/src/pages/workspace/workflows/approvals/DynamicWorkspaceWorkflowsApprovalsExpensesFromPage.tsx
+++ b/src/pages/workspace/workflows/approvals/DynamicWorkspaceWorkflowsApprovalsExpensesFromPage.tsx
@@ -58,7 +58,7 @@ function normalizeLogin(login: string | null | undefined): string {
 
 function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingReportData = true, route}: DynamicWorkspaceWorkflowsApprovalsExpensesFromPageProps) {
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
+    const {translate, formatPhoneNumber} = useLocalize();
     const backPath = useDynamicBackPath(DYNAMIC_ROUTES.WORKSPACE_WORKFLOWS_APPROVALS_EXPENSES_FROM.path);
     const [approvalWorkflow, approvalWorkflowResults] = useOnyx(ONYXKEYS.APPROVAL_WORKFLOW);
     const [rulesCollection] = useOnyx(ONYXKEYS.COLLECTION.RULE);
@@ -181,9 +181,10 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
                 const login = personalDetails?.[accountID]?.login ?? member.email;
                 const displayName = member.displayName ?? personalDetail?.displayName ?? member.email;
                 const avatar = member.avatar ?? personalDetail?.avatar;
+                const formattedDisplayName = Str.isSMSLogin(displayName) ? formatPhoneNumber(displayName) : displayName;
 
                 return {
-                    text: Str.removeSMSDomain(displayName),
+                    text: formattedDisplayName,
                     alternateText: member.email,
                     keyForList: member.email,
                     isSelected: true,
@@ -193,7 +194,7 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
                         {
                             source: avatar ?? icons.FallbackAvatar,
                             type: CONST.ICON_TYPE_AVATAR,
-                            name: Str.removeSMSDomain(displayName),
+                            name: formattedDisplayName,
                             id: accountID,
                         },
                     ],
@@ -236,8 +237,10 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
             .map((member) => {
                 const accountID = Number(policyMemberEmailsToAccountIDs[member.email] ?? '');
 
+                const formattedDisplayName = Str.isSMSLogin(member.displayName) ? formatPhoneNumber(member.displayName) : member.displayName;
+
                 return {
-                    text: Str.removeSMSDomain(member.displayName),
+                    text: formattedDisplayName,
                     alternateText: member.email,
                     keyForList: member.email,
                     isSelected: false,
@@ -247,7 +250,7 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
                         {
                             source: member.avatar ?? icons.FallbackAvatar,
                             type: CONST.ICON_TYPE_AVATAR,
-                            name: Str.removeSMSDomain(member.displayName),
+                            name: formattedDisplayName,
                             id: accountID,
                         },
                     ],
@@ -317,6 +320,7 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
         availableOptions.personalDetails,
         icons.FallbackAvatar,
         policyMemberEmailsToAccountIDs,
+        formatPhoneNumber,
     ]);
 
     // Drop any selected members who never made it into the workspace. They were staged for invite but
@@ -524,9 +528,11 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
                     : !!existingApproverEmail && existingApproverEmail !== firstApprover;
 
                 if (newMember && existingApproverEmail && belongsToDifferentWorkflow) {
-                    const memberName = Str.removeSMSDomain(newMember.text ?? newMember.login ?? '');
+                    const rawMemberName = newMember.text ?? newMember.login ?? '';
+                    const memberName = Str.isSMSLogin(rawMemberName) ? formatPhoneNumber(rawMemberName) : rawMemberName;
                     const approverDetails = employeeAndApprovalMembersPersonalDetails[existingApproverEmail];
-                    const approverName = Str.removeSMSDomain(approverDetails?.displayName ?? existingApproverEmail);
+                    const rawApproverName = approverDetails?.displayName ?? existingApproverEmail;
+                    const approverName = Str.isSMSLogin(rawApproverName) ? formatPhoneNumber(rawApproverName) : rawApproverName;
 
                     showConfirmModal({
                         title: translate('workflowsExpensesFromPage.memberAlreadyInWorkflowTitle'),
@@ -559,6 +565,7 @@ function DynamicWorkspaceWorkflowsApprovalsExpensesFromPage({policy, isLoadingRe
             currentWorkflowKey,
             showConfirmModal,
             translate,
+            formatPhoneNumber,
         ],
     );
 

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsApprovalLimitPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsApprovalLimitPage.tsx
@@ -48,7 +48,7 @@ type WorkspaceWorkflowsApprovalsApprovalLimitPageProps = WithPolicyAndFullscreen
 
 function WorkspaceWorkflowsApprovalsApprovalLimitPage({policy, isLoadingReportData = true, route}: WorkspaceWorkflowsApprovalsApprovalLimitPageProps) {
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
+    const {translate, formatPhoneNumber} = useLocalize();
     const icons = useMemoizedLazyExpensifyIcons(['Trashcan']);
     const [approvalWorkflow] = useOnyx(ONYXKEYS.APPROVAL_WORKFLOW);
     const personalDetailsByEmail = usePersonalDetailsByEmail();
@@ -72,12 +72,14 @@ function WorkspaceWorkflowsApprovalsApprovalLimitPage({policy, isLoadingReportDa
     const approvalLimit = editedApprovalLimit?.approverEmail === approverEmail ? editedApprovalLimit.value : defaultApprovalLimit;
 
     const selectedApproverPersonalDetails = selectedApproverEmail ? personalDetailsByEmail?.[selectedApproverEmail] : undefined;
-    const selectedApproverDisplayName = selectedApproverEmail ? Str.removeSMSDomain(selectedApproverPersonalDetails?.displayName ?? selectedApproverEmail) : '';
+    const selectedApproverName = selectedApproverPersonalDetails?.displayName ?? selectedApproverEmail;
+    const formattedApproverName = Str.isSMSLogin(selectedApproverName) ? formatPhoneNumber(selectedApproverName) : selectedApproverName;
+    const selectedApproverDisplayName = selectedApproverEmail ? formattedApproverName : '';
     const canWriteApprovals = canMemberWrite(policy, currentUserLogin, CONST.POLICY.POLICY_FEATURE.WORKFLOWS_APPROVALS);
 
     const shouldShowNotFoundView = (isEmptyObject(policy) && !isLoadingReportData) || !canWriteApprovals || isPendingDeletePolicy(policy) || isAnyHRReadOnlyWorkflowMode(policy);
 
-    const approverDisplayName = currentApprover ? Str.removeSMSDomain(currentApprover.displayName) : '';
+    const approverDisplayName = Str.isSMSLogin(currentApprover?.displayName ?? '') ? formatPhoneNumber(currentApprover?.displayName ?? '') : (currentApprover?.displayName ?? '');
     const isApproverSelected = isEditFlow ? approverDisplayName.length > 0 : true;
     const areLimitFieldsDisabled = isEditFlow && !isApproverSelected;
 

--- a/src/pages/workspace/workflows/tabs/WorkflowsApprovalsTab.tsx
+++ b/src/pages/workspace/workflows/tabs/WorkflowsApprovalsTab.tsx
@@ -111,7 +111,7 @@ function WorkflowsLoadMoreCard({count, onPress}: {count: number; onPress: () => 
 }
 
 function WorkflowsApprovalsTab({policyID}: WorkflowsApprovalsTabProps) {
-    const {translate, localeCompare} = useLocalize();
+    const {translate, localeCompare, formatPhoneNumber} = useLocalize();
     const styles = useThemeStyles();
     const theme = useTheme();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -243,22 +243,26 @@ function WorkflowsApprovalsTab({policyID}: WorkflowsApprovalsTabProps) {
     const filterWorkflow = (workflow: ApprovalWorkflow, searchInput: string) => {
         const searchableTexts: string[] = [];
 
+        const pushSearchableName = (value: string) => {
+            searchableTexts.push(value);
+            if (Str.isSMSLogin(value)) {
+                searchableTexts.push(Str.removeSMSDomain(value));
+                searchableTexts.push(formatPhoneNumber(value));
+            }
+        };
+
         if (workflow.isDefault) {
             searchableTexts.push(everyoneText);
         } else {
             for (const member of workflow.members) {
-                searchableTexts.push(member.displayName);
-                searchableTexts.push(Str.removeSMSDomain(member.displayName));
-                searchableTexts.push(member.email);
-                searchableTexts.push(Str.removeSMSDomain(member.email));
+                pushSearchableName(member.displayName);
+                pushSearchableName(member.email);
             }
         }
 
         for (const approver of workflow.approvers) {
-            searchableTexts.push(approver.displayName);
-            searchableTexts.push(Str.removeSMSDomain(approver.displayName));
-            searchableTexts.push(approver.email);
-            searchableTexts.push(Str.removeSMSDomain(approver.email));
+            pushSearchableName(approver.displayName);
+            pushSearchableName(approver.email);
         }
 
         return tokenizedSearch([workflow], searchInput, () => searchableTexts).length > 0;

--- a/tests/unit/WorkflowUtilsTest.ts
+++ b/tests/unit/WorkflowUtilsTest.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
-
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import {
@@ -37,7 +35,7 @@ import type Rule from '@src/types/onyx/Rule';
 
 import createRandomPolicy from '../utils/collections/policies';
 import createMock from '../utils/createMock';
-import {buildPersonalDetails, convertToDisplayString, localeCompare, translateLocal} from '../utils/TestHelper';
+import {buildPersonalDetails, convertToDisplayString, formatPhoneNumber, localeCompare, translateLocal} from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
 const personalDetails: PersonalDetailsList = {};

--- a/tests/unit/WorkflowUtilsTest.ts
+++ b/tests/unit/WorkflowUtilsTest.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
+import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
+
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import {
@@ -1434,6 +1436,7 @@ describe('WorkflowUtils', () => {
                 approver: undefined,
                 currency: 'USD',
                 translate: translateLocal,
+                formatPhoneNumber,
                 convertToDisplayString,
             });
 
@@ -1447,6 +1450,7 @@ describe('WorkflowUtils', () => {
                 approver,
                 currency: 'USD',
                 translate: translateLocal,
+                formatPhoneNumber,
                 convertToDisplayString,
             });
 
@@ -1460,6 +1464,7 @@ describe('WorkflowUtils', () => {
                 approver,
                 currency: 'USD',
                 translate: translateLocal,
+                formatPhoneNumber,
                 convertToDisplayString,
             });
 
@@ -1473,6 +1478,7 @@ describe('WorkflowUtils', () => {
                 approver,
                 currency: 'USD',
                 translate: translateLocal,
+                formatPhoneNumber,
                 convertToDisplayString,
             });
 
@@ -1486,6 +1492,7 @@ describe('WorkflowUtils', () => {
                 approver,
                 currency: 'USD',
                 translate: translateLocal,
+                formatPhoneNumber,
                 convertToDisplayString,
             });
 
@@ -1503,6 +1510,7 @@ describe('WorkflowUtils', () => {
                 approver,
                 currency: 'USD',
                 translate: translateLocal,
+                formatPhoneNumber,
                 convertToDisplayString,
             });
 


### PR DESCRIPTION
### Explanation of Change

The approval workflow surfaces displayed member and approver names through `Str.removeSMSDomain`, which only strips the `@expensify.sms` suffix. A phone-login user with no display name therefore rendered as a raw `+15551234567` in the workflows list, the workflow editor, the approval limit page, and the "Expenses from" member selector, instead of the national format for the viewer's country.

This replaces those calls with `formatPhoneNumber` from `useLocalize()`, so the values react to the viewer's country code. Display names are guarded with `Str.isSMSLogin` first, because `formatPhoneNumber` substitutes non-breaking spaces and would break wrapping on ordinary names; logins are formatted directly, since it leaves non-phone strings unchanged. `getApprovalLimitDescription` takes `formatPhoneNumber` as an injected parameter, matching how it already receives `translate` and `convertToDisplayString`. The workflow search is left additive rather than swapped, so typing raw digits still matches alongside the newly displayed format.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97957
PROPOSAL: N/A — issue owner

### Tests

**Setup:** a workspace on a Control policy with **at least four approval workflows** (the search field only appears above three), at least two members whose login is a phone number and who have **no display name set**, so the login is what renders, plus one member with an ordinary display name.

1. Go to **Workspace settings > Workflows** and enable **Add approvals**.
2. Verify each workflow row shows the phone member formatted for your region rather than as a raw `+15551234567`, on both the "Expenses from" line and the approver line.
3. Verify the member with an ordinary display name still shows that name unchanged.
4. Tap a workflow to open the editor. Verify the members line and each approver row show the same formatted number.
5. On an approver row, set an **approval limit** and an over-limit forward-to approver.
6. Verify the helper text reads "Reports above $1,000 forward to ..." with the approver's number formatted rather than raw.
7. Open the **approval limit** page for that approver and verify the selected approver's name is formatted there too.
8. Go back to the workflows list. With more than three workflows present, verify the search field is shown, and use it.
9. Search the raw digits of the phone member's login and verify the workflow still matches.
10. Search the number exactly as it now appears in the row and verify the workflow matches.
11. Search the email/login form and verify the workflow matches.
12. Search part of the ordinary display name and verify that workflow still matches.
13. Open a workflow and tap **Expenses from** to open the member selection list.
14. Verify each selected and unselected member row shows a formatted number, and that the avatar tooltip/name matches.
15. Verify the row's secondary line still shows the raw email/login.
16. Select a member who already belongs to another workflow, so the "member already in workflow" confirmation appears.
17. Verify the prompt names both the member and the existing approver with formatted numbers.

[x] Verify that no errors appear in the JS console

### Offline tests

Same as tests

### QA Steps

Same as tests
- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests

### QA Steps

Same as tests
- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests

### QA Steps

Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/b363016f-13d9-431b-8768-6c5e3c08db6f


</details>
