### PR TITLE
[No QA] Bump oxc-transform-react 0.145 → 0.148

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,7 +266,7 @@
         "nitrogen": "0.36.3",
         "onchange": "^7.1.0",
         "openai": "^7.0.0",
-        "oxc-transform-react": "0.145.0",
+        "oxc-transform-react": "0.148.0",
         "oxfmt": "^0.55.0",
         "patch-package": "^8.1.0-canary.1",
         "peggy": "^4.0.3",
@@ -12638,9 +12638,9 @@
       ]
     },
     "node_modules/@oxc-transform-react/binding-android-arm-eabi": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm-eabi/-/binding-android-arm-eabi-0.145.0.tgz",
-      "integrity": "sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm-eabi/-/binding-android-arm-eabi-0.148.0.tgz",
+      "integrity": "sha512-W+elZaL7gMDaRC6OtkYO2gOelNNcCDBO7EAZYGSkPW2WXoCTkILVibnpDkiMFlwBnKQRwqdq7SPk/KwwFyMtPQ==",
       "cpu": [
         "arm"
       ],
@@ -12655,9 +12655,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-android-arm64": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm64/-/binding-android-arm64-0.145.0.tgz",
-      "integrity": "sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm64/-/binding-android-arm64-0.148.0.tgz",
+      "integrity": "sha512-qHDAUwJOfsIAL6s3smScVtCVbkrKYAF2GhNSb2jB3fYvdbaIk96W0BSXvBoye7eee8sIVTjznrb0fSYZxmmdGQ==",
       "cpu": [
         "arm64"
       ],
@@ -12672,9 +12672,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-darwin-arm64": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-arm64/-/binding-darwin-arm64-0.145.0.tgz",
-      "integrity": "sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-arm64/-/binding-darwin-arm64-0.148.0.tgz",
+      "integrity": "sha512-vkhY+l8u8A3+hfsxQMK+xP7ejiKWR5hbRsnDbg5fNa4tCNNzpeJ8xqmlZ6+MKGhXMP03ZtjXlXGyRaGgCFoAgQ==",
       "cpu": [
         "arm64"
       ],
@@ -12689,9 +12689,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-darwin-x64": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-x64/-/binding-darwin-x64-0.145.0.tgz",
-      "integrity": "sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-x64/-/binding-darwin-x64-0.148.0.tgz",
+      "integrity": "sha512-Ehu33kg2NocBwrVxtlLkGpOzWhzFXRwo7CYxpLFIgmQT24iMYzjgsDjRUW9tHgC1q12UF1A7mUGhZV0wO2sUQQ==",
       "cpu": [
         "x64"
       ],
@@ -12706,9 +12706,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-freebsd-x64": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-freebsd-x64/-/binding-freebsd-x64-0.145.0.tgz",
-      "integrity": "sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-freebsd-x64/-/binding-freebsd-x64-0.148.0.tgz",
+      "integrity": "sha512-5xxrqOGqO+gX6a+kyRtgIQsTByDcQayclyBKlgjyEiz2CXvvQ5SZn9/kGw6rbL7E+gwQQFzpVYLdYUM7zJlcXA==",
       "cpu": [
         "x64"
       ],
@@ -12723,9 +12723,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-arm-gnueabihf": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.145.0.tgz",
-      "integrity": "sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.148.0.tgz",
+      "integrity": "sha512-2wDoBJ0aOo3ygoTu6TAV6UCIzlCTO8eEMWYVpLbX0iq/29WA6M3tjrRItWrE0suLP0uXcBDmWrsUu4NeqsM5og==",
       "cpu": [
         "arm"
       ],
@@ -12740,9 +12740,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-arm-musleabihf": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.145.0.tgz",
-      "integrity": "sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.148.0.tgz",
+      "integrity": "sha512-Lh73KZTuC2rh4Pff1XpGh4WkQCkWdtM04adrvDGZbxGTYWXaF6uWih5WdO5Pr+ZbkceBbHgKgEQL8Lp3M1TbxQ==",
       "cpu": [
         "arm"
       ],
@@ -12757,9 +12757,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-arm64-gnu": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.145.0.tgz",
-      "integrity": "sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.148.0.tgz",
+      "integrity": "sha512-HglSrS/bA2pKL20xCPgVlHvhhVycUC7QsSmBWJH5NqWVLPA2RdcvGyEtCWDKKTH0jbYJoHGrnz/aTq3KabwrnQ==",
       "cpu": [
         "arm64"
       ],
@@ -12777,9 +12777,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-arm64-musl": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.145.0.tgz",
-      "integrity": "sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.148.0.tgz",
+      "integrity": "sha512-kM0JCd+Mym4QIILv9a2CxqnriNozIz8KQjlw3kRrCdbEVEc2fIop4tvlcwYTRa+vKCWecZx627DsHTL7Ad9pzA==",
       "cpu": [
         "arm64"
       ],
@@ -12797,9 +12797,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-ppc64-gnu": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.145.0.tgz",
-      "integrity": "sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.148.0.tgz",
+      "integrity": "sha512-7C8iUK/nw1wos9IJvW/RxROOz4TIj6g22a1B8ydPA5rBz8qMFNJNOPy3/UwhAd01F1h28LZlSeu6gewthGSL2A==",
       "cpu": [
         "ppc64"
       ],
@@ -12817,9 +12817,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-riscv64-gnu": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.145.0.tgz",
-      "integrity": "sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.148.0.tgz",
+      "integrity": "sha512-0ZN6WTRcLxhPns7MYYKy7MQGTGf0jpEDACmdXEUquhPOizQ+7AsOcTnYR9Uss1dgG9G+2XAAd759i7jQXh0+2A==",
       "cpu": [
         "riscv64"
       ],
@@ -12837,9 +12837,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-riscv64-musl": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.145.0.tgz",
-      "integrity": "sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.148.0.tgz",
+      "integrity": "sha512-dcd2RAANPoKmHIKJlFCnvRlYJ7s268fswMgO7kmY6m5g35XMRlv71jZ/easkMW/RPr9vUPZyUZPHq0pTyMgXUg==",
       "cpu": [
         "riscv64"
       ],
@@ -12857,9 +12857,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-s390x-gnu": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.145.0.tgz",
-      "integrity": "sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.148.0.tgz",
+      "integrity": "sha512-JdyMRM7bjODyVsDkyyJQfRCeM4MXmOzEu25RuPdz9dvPPKNb4gT9BrcnrDQiceQ2MLeLo9z7jawuCs4kjCALzw==",
       "cpu": [
         "s390x"
       ],
@@ -12877,9 +12877,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-x64-gnu": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.145.0.tgz",
-      "integrity": "sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.148.0.tgz",
+      "integrity": "sha512-UlpQs3EHU9p6oVJe/UifVer7L3OnNJULFaAmPBVz8p9wsFBHA2cBzOuD4cBTo5i+QmQMbSsrJ8qsGtPg+OCO2Q==",
       "cpu": [
         "x64"
       ],
@@ -12897,9 +12897,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-linux-x64-musl": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-musl/-/binding-linux-x64-musl-0.145.0.tgz",
-      "integrity": "sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-musl/-/binding-linux-x64-musl-0.148.0.tgz",
+      "integrity": "sha512-+ZTnNcXOeUazfT1KNAmkmYayS82c/Z06AuZUaITbZKn+Hbp99SAI5HVE+HZXumwKGF89r0JOSQviIXfuyOLpSw==",
       "cpu": [
         "x64"
       ],
@@ -12917,9 +12917,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-openharmony-arm64": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-openharmony-arm64/-/binding-openharmony-arm64-0.145.0.tgz",
-      "integrity": "sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-openharmony-arm64/-/binding-openharmony-arm64-0.148.0.tgz",
+      "integrity": "sha512-QsbwZEBvJhAvdgUDekEi5B5m0H7aZE5f32M0OLmpUd2o94mA1gm2vIHP0YgaJ96SMHlBJwvCA+lvLzEiq7nyjQ==",
       "cpu": [
         "arm64"
       ],
@@ -12934,9 +12934,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-win32-arm64-msvc": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.145.0.tgz",
-      "integrity": "sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.148.0.tgz",
+      "integrity": "sha512-OxXPOxtEn05uPpVjozZDaRq9jLWNLjldTZtYwuphGEx7F+c0s49Sj+NfB3TXBa2siDIcWHNnXK4crg1RiG5W7Q==",
       "cpu": [
         "arm64"
       ],
@@ -12951,9 +12951,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-win32-ia32-msvc": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.145.0.tgz",
-      "integrity": "sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.148.0.tgz",
+      "integrity": "sha512-I7hP5FSEuUD+8Qle97YqC9BtvS69ERDu5afbGVpL0Wy9WtO5LtUnwwVj/u+75gEFMBYyh/eCyuah1J8eCYjWWg==",
       "cpu": [
         "ia32"
       ],
@@ -12968,9 +12968,9 @@
       }
     },
     "node_modules/@oxc-transform-react/binding-win32-x64-msvc": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.145.0.tgz",
-      "integrity": "sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.148.0.tgz",
+      "integrity": "sha512-nUv3W/fIaMuyQN479OZcJAA4uuuL/YzdQI490OgrBrzP69vXyMYnIVivptDNJF/gu37AmT2vW2+8ZWx33ghjdQ==",
       "cpu": [
         "x64"
       ],
@@ -34016,37 +34016,37 @@
       }
     },
     "node_modules/oxc-transform-react": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform-react/-/oxc-transform-react-0.145.0.tgz",
-      "integrity": "sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform-react/-/oxc-transform-react-0.148.0.tgz",
+      "integrity": "sha512-0EreEjngNalcw26tFo2UPiD3tZm8KqumYFZRDb5weWdz3ENLea7+GV0kzLaSCdaq3uF4rQ0jw1GAgW41HLn90g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       },
       "optionalDependencies": {
-        "@oxc-transform-react/binding-android-arm-eabi": "0.145.0",
-        "@oxc-transform-react/binding-android-arm64": "0.145.0",
-        "@oxc-transform-react/binding-darwin-arm64": "0.145.0",
-        "@oxc-transform-react/binding-darwin-x64": "0.145.0",
-        "@oxc-transform-react/binding-freebsd-x64": "0.145.0",
-        "@oxc-transform-react/binding-linux-arm-gnueabihf": "0.145.0",
-        "@oxc-transform-react/binding-linux-arm-musleabihf": "0.145.0",
-        "@oxc-transform-react/binding-linux-arm64-gnu": "0.145.0",
-        "@oxc-transform-react/binding-linux-arm64-musl": "0.145.0",
-        "@oxc-transform-react/binding-linux-ppc64-gnu": "0.145.0",
-        "@oxc-transform-react/binding-linux-riscv64-gnu": "0.145.0",
-        "@oxc-transform-react/binding-linux-riscv64-musl": "0.145.0",
-        "@oxc-transform-react/binding-linux-s390x-gnu": "0.145.0",
-        "@oxc-transform-react/binding-linux-x64-gnu": "0.145.0",
-        "@oxc-transform-react/binding-linux-x64-musl": "0.145.0",
-        "@oxc-transform-react/binding-openharmony-arm64": "0.145.0",
-        "@oxc-transform-react/binding-win32-arm64-msvc": "0.145.0",
-        "@oxc-transform-react/binding-win32-ia32-msvc": "0.145.0",
-        "@oxc-transform-react/binding-win32-x64-msvc": "0.145.0"
+        "@oxc-transform-react/binding-android-arm-eabi": "0.148.0",
+        "@oxc-transform-react/binding-android-arm64": "0.148.0",
+        "@oxc-transform-react/binding-darwin-arm64": "0.148.0",
+        "@oxc-transform-react/binding-darwin-x64": "0.148.0",
+        "@oxc-transform-react/binding-freebsd-x64": "0.148.0",
+        "@oxc-transform-react/binding-linux-arm-gnueabihf": "0.148.0",
+        "@oxc-transform-react/binding-linux-arm-musleabihf": "0.148.0",
+        "@oxc-transform-react/binding-linux-arm64-gnu": "0.148.0",
+        "@oxc-transform-react/binding-linux-arm64-musl": "0.148.0",
+        "@oxc-transform-react/binding-linux-ppc64-gnu": "0.148.0",
+        "@oxc-transform-react/binding-linux-riscv64-gnu": "0.148.0",
+        "@oxc-transform-react/binding-linux-riscv64-musl": "0.148.0",
+        "@oxc-transform-react/binding-linux-s390x-gnu": "0.148.0",
+        "@oxc-transform-react/binding-linux-x64-gnu": "0.148.0",
+        "@oxc-transform-react/binding-linux-x64-musl": "0.148.0",
+        "@oxc-transform-react/binding-openharmony-arm64": "0.148.0",
+        "@oxc-transform-react/binding-win32-arm64-msvc": "0.148.0",
+        "@oxc-transform-react/binding-win32-ia32-msvc": "0.148.0",
+        "@oxc-transform-react/binding-win32-x64-msvc": "0.148.0"
       }
     },
     "node_modules/oxfmt": {

--- a/package.json
+++ b/package.json
@@ -340,7 +340,7 @@
     "nitrogen": "0.36.3",
     "onchange": "^7.1.0",
     "openai": "^7.0.0",
-    "oxc-transform-react": "0.145.0",
+    "oxc-transform-react": "0.148.0",
     "oxfmt": "^0.55.0",
     "patch-package": "^8.1.0-canary.1",
     "peggy": "^4.0.3",


### PR DESCRIPTION
### Explanation of Change
Bump `oxc-transform-react` from `0.145.0` to `0.148.0` (latest on npm as of 2026-09-01). 0.148 includes `transform-react: Match Babel diagnostic reporting`, which may shrink Babel-vs-OXC status gaps over time. This PR does not fix remaining Rules-of-React / ref-during-render files; it is a measured compiler bump.

`transformSync` / `transform` options are unchanged, so no checker or loader updates were required.

#### Compile-status inventory
Full `src/` inventory (7,036 files, excluding tests/stories), Babel + OXC, before vs after:

| | Babel 0.145 era | Babel after | OXC 0.145.0 | OXC 0.148.0 |
|---|---:|---:|---:|---:|
| compiled | 3646 | 3646 | 3586 | 3586 |
| failed | 112 | 112 | 77 | 77 |
| no-components | 3278 | 3278 | 3373 | 3373 |

| | before | after |
|---|---:|---:|
| compiledBoth | 3581 | 3581 |
| failedEither | 112 | 112 |
| memoizedBoth | 3568 | 3568 |
| divergent (memoization) | 5 | 5 |

Per-file oxc status, errors, and memoization flags are identical. No files newly compiled on OXC; no files newly failed on OXC.

Top OXC error classes (unchanged): ref-during-render 70, "This value cannot be modified" 4, plus 3 singleton compiler-limitation errors.

#### Wall-clock benchmark
Same 7,036 files, `transformSync` only (sources preloaded so I/O is out of the clock), options matching the web loader (`target: '19'`, `panicThreshold: 'none'`, `eslintSuppressionRules: []`). 1 warmup + 3 timed runs, macOS arm64, bun.

| | OXC 0.145.0 | OXC 0.148.0 | delta |
|---|---:|---:|---:|
| min | 7.27s | 5.91s | −18.6% |
| median | 7.27s | 6.00s | −17.4% |
| mean | 7.28s | 5.99s | −17.7% |
| max | 7.31s | 6.06s | −17.1% |
| files/sec (mean) | 966 | 1,174 | +21.5% |

Raw timed runs: 0.145.0 = 7266 / 7267 / 7310 ms; 0.148.0 = 5911 / 6003 / 6058 ms.

Compile-status is a wash; the bump is still a ~18% faster React Compiler transform over `src/`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/68765
PROPOSAL: https://github.com/Expensify/App/issues/68765#issuecomment-5497738000

### Tests
1. Confirm `oxc-transform-react` is `0.148.0` in `package.json` and `package-lock.json`.
2. Run a dual-compiler inventory over `src/` (exclude tests/stories) and confirm OXC compiled/failed/no-components counts match 0.145.0 (3586 / 77 / 3373) with zero newly compiling or newly failing files.
3. Time `oxc-transform-react` `transformSync` over the same 7,036 files (1 warmup + 3 runs) and confirm 0.148.0 is faster than 0.145.0 (~18% lower mean wall clock).
4. Run `npm run react-compiler-compliance-check check-changed` and confirm it passes (no React source files changed).
5. Run `npm test -- --testPathPattern=CheckReactCompilerWithOxcTest --no-coverage` and confirm all 6 tests pass.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A — compiler dependency bump only; no runtime/offline behavior change.

### QA Steps
N/A — title includes `[No QA]`.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
None.