### PR TITLE
fix: tag Control-tier upgrade features with requiredPlan for Submit workspaces

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -7913,12 +7913,14 @@ const CONST = {
                 title: 'workspace.upgrade.reportFields.title' as const,
                 description: 'workspace.upgrade.reportFields.description' as const,
                 icon: 'Pencil',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             policyPreventMemberChangingTitle: {
                 id: 'policyPreventMemberChangingTitle' as const,
                 alias: 'policy-prevent-member-changing-title',
                 name: undefined,
                 icon: undefined,
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             preventSelfApproval: {
                 id: 'preventSelfApproval' as const,
@@ -7962,6 +7964,7 @@ const CONST = {
                 title: 'workspace.upgrade.multiLevelTags.title' as const,
                 description: 'workspace.upgrade.multiLevelTags.description' as const,
                 icon: 'Tag',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
 
             [this.POLICY.CONNECTIONS.NAME.NETSUITE]: {
@@ -8028,6 +8031,7 @@ const CONST = {
                 title: `workspace.upgrade.approvals.title` as const,
                 description: `workspace.upgrade.approvals.description` as const,
                 icon: 'AdvancedApprovalsSquare',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             multiApprovalLevels: {
                 id: 'multiApprovalLevels' as const,
@@ -8036,6 +8040,7 @@ const CONST = {
                 title: `workspace.upgrade.multiApprovalLevels.title` as const,
                 description: `workspace.upgrade.multiApprovalLevels.description` as const,
                 icon: 'AdvancedApprovalsSquare',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             glCodes: {
                 id: 'glCodes' as const,
@@ -8044,6 +8049,7 @@ const CONST = {
                 title: 'workspace.upgrade.glCodes.title' as const,
                 description: 'workspace.upgrade.glCodes.description' as const,
                 icon: 'Tag',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             glAndPayrollCodes: {
                 id: 'glAndPayrollCodes' as const,
@@ -8052,6 +8058,7 @@ const CONST = {
                 title: 'workspace.upgrade.glAndPayrollCodes.title' as const,
                 description: 'workspace.upgrade.glAndPayrollCodes.description' as const,
                 icon: 'FolderOpen',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             taxCodes: {
                 id: 'taxCodes' as const,
@@ -8060,6 +8067,7 @@ const CONST = {
                 title: 'workspace.upgrade.taxCodes.title' as const,
                 description: 'workspace.upgrade.taxCodes.description' as const,
                 icon: 'Coins',
+                requiredPlan: this.POLICY.TYPE.CORPORATE,
             },
             companyCards: {
                 id: 'companyCards' as const,

--- a/src/pages/workspace/upgrade/GenericFeaturesView.tsx
+++ b/src/pages/workspace/upgrade/GenericFeaturesView.tsx
@@ -104,6 +104,7 @@ function GenericFeaturesView({onUpgrade, buttonDisabled, loading, formattedPrice
                     onPress={onUpgrade}
                     isDisabled={buttonDisabled}
                     size={CONST.BUTTON_SIZE.LARGE}
+                    testID="upgrade-button"
                 >
                     <Button.Text>{translate('common.upgrade')}</Button.Text>
                 </Button>

--- a/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
+++ b/src/pages/workspace/upgrade/WorkspaceUpgradePage.tsx
@@ -115,11 +115,9 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
         setUpgradingFromSubmit((previous) => (previous !== undefined ? previous : isUpgradingFromSubmitPolicy));
     }, [policyID, policy?.type, isUpgradingFromSubmitPolicy]);
 
-    const feature = featureNameAlias
-        ? Object.values(CONST.UPGRADE_FEATURE_INTRO_MAPPING)
-              .filter((value) => value.id !== CONST.UPGRADE_FEATURE_INTRO_MAPPING.policyPreventMemberChangingTitle.id)
-              .find((f) => f.alias === featureNameAlias)
-        : undefined;
+    const upgradeFeatureByAlias = featureNameAlias ? Object.values(CONST.UPGRADE_FEATURE_INTRO_MAPPING).find((mappingEntry) => mappingEntry.alias === featureNameAlias) : undefined;
+
+    const feature = upgradeFeatureByAlias?.id === CONST.UPGRADE_FEATURE_INTRO_MAPPING.policyPreventMemberChangingTitle.id ? undefined : upgradeFeatureByAlias;
 
     const isUpgraded = !!policy?.type && upgradingFromSubmit !== undefined && (isControlPolicy(policy) || !!(upgradingFromSubmit && isPaidGroupPolicy(policy)));
     const {translate} = useLocalize();
@@ -207,7 +205,8 @@ function WorkspaceUpgradePage({route}: WorkspaceUpgradePageProps) {
         }
 
         if (isUpgradingFromSubmitPolicy) {
-            const targetType = upgradePlanType ?? (feature && 'requiredPlan' in feature ? feature.requiredPlan : undefined) ?? CONST.POLICY.TYPE.TEAM;
+            const requiredPlan = upgradeFeatureByAlias && 'requiredPlan' in upgradeFeatureByAlias ? upgradeFeatureByAlias.requiredPlan : undefined;
+            const targetType = upgradePlanType ?? requiredPlan ?? CONST.POLICY.TYPE.TEAM;
             upgradeSubmit(policy, targetType, email, accountID, priorFirstDayFreeTrial, priorLastDayFreeTrial, reportID);
             return;
         }

--- a/tests/ui/WorkspaceUpgradeTest.tsx
+++ b/tests/ui/WorkspaceUpgradeTest.tsx
@@ -146,6 +146,48 @@ describe('WorkspaceUpgrade', () => {
         await waitForBatchedUpdates();
     });
 
+    it('should upgrade a Submit workspace to Corporate when unlocking Report fields', async () => {
+        const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+        });
+
+        const {unmount} = renderPage(SCREENS.WORKSPACE.UPGRADE, {
+            policyID: policy.id,
+            featureName: CONST.UPGRADE_FEATURE_INTRO_MAPPING.reportFields.alias,
+        });
+
+        fireEvent.press(screen.getByTestId('upgrade-button'));
+        await waitForBatchedUpdatesWithAct();
+
+        TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.UPGRADE_SUBMIT, 0, {policyID: policy.id, targetType: CONST.POLICY.TYPE.CORPORATE});
+
+        unmount();
+        await waitForBatchedUpdates();
+    });
+
+    it('should upgrade a Submit workspace to Corporate when unlocking GL codes', async () => {
+        const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+        });
+
+        const {unmount} = renderPage(SCREENS.WORKSPACE.UPGRADE, {
+            policyID: policy.id,
+            featureName: CONST.UPGRADE_FEATURE_INTRO_MAPPING.glCodes.alias,
+        });
+
+        fireEvent.press(screen.getByTestId('upgrade-button'));
+        await waitForBatchedUpdatesWithAct();
+
+        TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.UPGRADE_SUBMIT, 0, {policyID: policy.id, targetType: CONST.POLICY.TYPE.CORPORATE});
+
+        unmount();
+        await waitForBatchedUpdates();
+    });
+
     it('should show Collect pricing and upgrade a Submit workspace when unlocking a Collect-tier feature', async () => {
         const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
 

--- a/tests/ui/WorkspaceUpgradeTest.tsx
+++ b/tests/ui/WorkspaceUpgradeTest.tsx
@@ -188,6 +188,27 @@ describe('WorkspaceUpgrade', () => {
         await waitForBatchedUpdates();
     });
 
+    it('should upgrade a Submit workspace to Corporate when unlocking prevent-members-from-changing-custom-names via alias lookup', async () => {
+        const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+        });
+
+        const {unmount} = renderPage(SCREENS.WORKSPACE.UPGRADE, {
+            policyID: policy.id,
+            featureName: CONST.UPGRADE_FEATURE_INTRO_MAPPING.policyPreventMemberChangingTitle.alias,
+        });
+
+        fireEvent.press(screen.getByTestId('upgrade-button'));
+        await waitForBatchedUpdatesWithAct();
+
+        TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.UPGRADE_SUBMIT, 0, {policyID: policy.id, targetType: CONST.POLICY.TYPE.CORPORATE});
+
+        unmount();
+        await waitForBatchedUpdates();
+    });
+
     it('should show Collect pricing and upgrade a Submit workspace when unlocking a Collect-tier feature', async () => {
         const policy: Policy = {...LHNTestUtils.getFakePolicy(), type: CONST.POLICY.TYPE.SUBMIT};
 


### PR DESCRIPTION
Add requiredPlan: CORPORATE to Control-gated UPGRADE_FEATURE_INTRO_MAPPING entries that were still defaulting Submit upgrades to Collect (report fields, prevent-members-changing-title, GL/tax codes, multi-level tags, approvals).

Derive the Submit upgrade target from the raw mapping lookup by alias so filtered entries like policyPreventMemberChangingTitle upgrade correctly.

$ https://github.com/Expensify/App/issues/93096

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Control-tier toggles gate on `!isControlPolicy(policy)`, but Submit workspaces upgrading through `WorkspaceUpgradePage` defaulted to **Collect** (`TEAM`) whenever `UPGRADE_FEATURE_INTRO_MAPPING` had no `requiredPlan`. After the first upgrade the workspace was still not Control, so disable → re-enable re-opened the Upgrade RHP (issue #93096).

Product confirmed Submit → Report fields should upgrade to **Control**, stay Control after disable, and not re-prompt on re-enable.

This PR:
1. Adds `requiredPlan: this.POLICY.TYPE.CORPORATE` to all remaining Control-gated mapping entries (`reportFields`, `policyPreventMemberChangingTitle`, `multiApprovalLevels`, `glCodes`, `glAndPayrollCodes`, `taxCodes`, `multiLevelTags`, `approvals`).
2. Derives the Submit upgrade target from the **raw mapping lookup by alias** in `WorkspaceUpgradePage`, so filtered entries like `policyPreventMemberChangingTitle` (excluded from intro UI) still upgrade to Control.

Collect-tier Submit features (`travelSubmit`, `payments`, etc.) are unchanged and still default to `TEAM`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/93096
PROPOSAL: https://github.com/Expensify/App/issues/93096#issuecomment-5163602821

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

**Precondition:** Expensifail account with `submit2026` beta, **Submit** workspace.

1. Go to **Workspace settings → Reports**.
2. Enable **Report fields** → confirm Control upgrade RHP → tap **Upgrade** → workspace becomes **Control**.
3. Disable **Report fields** → workspace stays **Control**.
4. Re-enable **Report fields** → toggles on **without** Upgrade RHP.
5. On a fresh Submit workspace, enable **Prevent members from changing custom names** first → upgrade → disable → re-enable → **no** Upgrade loop.
6. On Submit workspace with tags, enable **GL codes** → upgrade → disable → re-enable → **no** Upgrade loop.
7. More Features → enable **Travel** on Submit workspace → still upgrades to **Collect** (regression check).

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Tests — the upgrade target is computed locally from the feature mapping, so the correct plan is chosen offline. The upgrade completes once back online.

### QA Steps

**Precondition:** Expensifail account, **Submit** workspace on staging.

1. Go to staging.new.expensify.com → **Workspace settings → Reports**.
2. Enable **Report fields** → tap **Upgrade** on Control upgrade RHP.
3. Verify workspace upgrades to **Control**.
4. Disable, then re-enable **Report fields** → verify Upgrade RHP does **not** reappear.
5. Repeat steps 2–4 for **Prevent members from changing custom names** on the same page.
6. On Submit workspace with tags enabled, repeat disable/re-enable for **GL codes**.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/d3514129-7d6e-426b-8b06-2a7d1af676a7



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/5c9034e8-354c-438a-a8a5-2d22435f6083



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/76656da6-631b-4660-9a1d-9c10a25ae897



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/414f8d8f-428a-4fa1-adca-a717ca7f90e0



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/1d9ef4a3-af1d-4d4d-985e-ff93804f090a

</details>