### PR TITLE
[No QA] Isolate Jest TypeScript project

### DIFF
--- a/config/eslint/eslint.config.mjs
+++ b/config/eslint/eslint.config.mjs
@@ -724,6 +724,17 @@ const config = defineConfig([
     },
 
     {
+        files: ['tests/**/*.{ts,tsx}', 'jest/**/*.{ts,tsx}', '__mocks__/**/*.{ts,tsx}', 'src/**/__mocks__/**/*.{ts,tsx}'],
+        ignores: ['tests/tooling/**'],
+        languageOptions: {
+            parserOptions: {
+                project: path.resolve(projectRoot, 'tsconfig.jest.json'),
+                projectService: false,
+            },
+        },
+    },
+
+    {
         files: ['scripts/**/*.ts', 'tests/tooling/**/*.ts', 'server/{libs,plugins,stubs}/**/*.{ts,tsx}', 'evals/**/*.ts'],
         languageOptions: {
             parserOptions: {

--- a/knip.json
+++ b/knip.json
@@ -12,6 +12,7 @@
                 ".github/scripts/**/*.ts",
                 "tests/tooling/**/*.ts",
                 ".github/actions/javascript/**/*.ts",
+                "tests/globals.d.ts",
                 ".storybook/**/*.{js,ts,tsx}",
                 "metro.config.js",
                 "eslint.changed.config.mjs",

--- a/scripts/typecheck.ts
+++ b/scripts/typecheck.ts
@@ -19,7 +19,7 @@ const projectRoot = `${import.meta.dir}/..`;
 const tsc = `${projectRoot}/node_modules/typescript/bin/tsc`;
 
 /** TypeScript projects, relative to the repo root, that `npm run typecheck` and CI check. */
-const DEFAULT_PROJECTS = ['tsconfig.json', 'tsconfig.bun.json', 'tsconfig.node.json', 'server/victory-chart-renderer/tsconfig.json'];
+const DEFAULT_PROJECTS = ['tsconfig.json', 'tsconfig.jest.json', 'tsconfig.bun.json', 'tsconfig.node.json', 'server/victory-chart-renderer/tsconfig.json'];
 
 const cli = new CLI({
     positionalArgs: [

--- a/tests/globals.d.ts
+++ b/tests/globals.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="jest" />
+
 declare global {
     namespace jest {
         // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -9,5 +11,4 @@ declare global {
     }
 }
 
-// We used the export {} line to mark this file as an external module
 export {};

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "types": ["react-native", "react-native-web"],
+        "lib": ["DOM", "ESNext"]
+    },
+    "include": ["src", "assets", "tests", "jest", "prompts", "__mocks__", "modules"],
+    "exclude": ["**/node_modules/*", "**/dist/*", "tests/tooling"]
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,10 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "./tsconfig.base.json",
-    "compilerOptions": {
-        "types": ["react-native", "react-native-web"],
-        "lib": ["DOM", "ESNext"]
-    },
+    "extends": "./tsconfig.json",
     "include": ["src", "assets", "tests", "jest", "prompts", "__mocks__", "modules"],
     "exclude": ["**/node_modules/*", "**/dist/*", "tests/tooling"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "types": ["react-native", "react-native-web", "jest", "node"],
+        "types": ["react-native", "react-native-web", "node"],
         "lib": ["DOM", "ESNext"],
         // Babel reads this config directly and does not resolve its `extends` chain.
         "paths": {
@@ -23,14 +23,12 @@
             "tests/*": ["./tests/*"]
         }
     },
-    "include": ["src", "website", "docs", "assets", "tests", "jest", "prompts", "__mocks__", ".storybook/**/*", ".claude/**/*", "modules", "**/*.nitro/*.ts", "**/*.nitro/*.tsx"],
+    "include": ["src", "assets", "prompts", ".storybook/**/*", "modules"],
     "exclude": [
         "**/node_modules/*",
         "**/dist/*",
         ".github/actions/**/index.js",
-        "**/docs/*",
-        ".claude/worktrees/**",
-        "tests/tooling",
+        "src/**/__mocks__/**",
         "server/libs",
         "server/plugins",
         "server/stubs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,14 @@
             "tests/*": ["./tests/*"]
         }
     },
-    "include": ["src", "assets", "prompts", ".storybook/**/*", "modules"],
+    "include": ["src", "website", "docs", "assets", "prompts", ".storybook/**/*", ".claude/**/*", "modules", "**/*.nitro/*.ts", "**/*.nitro/*.tsx"],
     "exclude": [
         "**/node_modules/*",
         "**/dist/*",
         ".github/actions/**/index.js",
+        "**/docs/*",
+        ".claude/worktrees/**",
+        "tests/tooling",
         "src/**/__mocks__/**",
         "server/libs",
         "server/plugins",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "types": ["react-native", "react-native-web", "node"],
+        "types": ["react-native", "react-native-web"],
         "lib": ["DOM", "ESNext"],
         // Babel reads this config directly and does not resolve its `extends` chain.
         "paths": {


### PR DESCRIPTION
### Explanation of Change

Create a dedicated `tsconfig.jest.json`, move the Jest type reference and matcher augmentation into `tests/globals.d.ts`, and point TypeScript/ESLint test paths at the new project. The root app project no longer loads Jest types or Jest test roots; its unrelated include paths remain unchanged.

This intentionally lands the project boundary before phase 2. Adding `moduleSuffixes: [".web", ""]` still exposes the same source resolution errors addressed by https://github.com/Expensify/App/pull/99495, so that option remains deferred rather than adding temporary ESLint restrictions or source backstops here.

### Fixed Issues

For https://github.com/Expensify/App/issues/99289
PROPOSAL: N/A

### Tests

1. Run `npm run typecheck`.
2. Verify `tsconfig.json`, `tsconfig.jest.json`, `tsconfig.bun.json`, `tsconfig.node.json`, and the Victory Chart Renderer project all pass.
3. Run `npm run lint-changed`.
4. Run `npm run spell-changed`.
5. Run `npm test -- --runInBand --silent tests/unit/parseAndCollectJSONsTest.ts tests/unit/retryWithBackoffTests.ts`.
6. Verify both Node-environment Jest suites pass.

- [x] Verify that no errors appear in the JS console (not applicable: tooling-only change)

### Offline tests

Not applicable: tooling-only change.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console (not applicable: tooling-only change)

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (not applicable: configuration-only change)
    - [x] I turned off my network connection and tested it while offline (not applicable: configuration-only change)
    - [x] I tested this PR with a High Traffic account (not applicable: configuration-only change)
- [x] I included screenshots or videos for tests on all platforms (not applicable: configuration-only change)
- [x] I ran the tests on all platforms & verified they passed on (not applicable: configuration-only change):
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (not applicable: configuration-only change)
- [x] I followed proper code patterns
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained why
    - [x] I verified any copy/text added to the app is grammatically correct (not applicable)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the Review Guidelines
- [x] I tested other components that can be impacted by my changes (not applicable)
- [x] If a new CSS style is added I verified it (not applicable)
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing StyleUtils function
- [x] If new assets were added or existing ones were modified (not applicable)
    - [x] The assets are optimized and compressed
    - [x] The assets load correctly across all supported platforms
- [x] If the PR modifies code that runs when editing or sending messages, I tested markdown behavior (not applicable)
- [x] If the PR modifies a generic component, I tested impacted usages (not applicable)
- [x] If the PR modifies a component related to Storybook stories, I verified stories (not applicable)
- [x] If the PR modifies a page accessible by deeplink, I verified deeplinks (not applicable)
- [x] If the PR modifies UI or form input styles, I verified alignment and design review (not applicable)
- [x] I added unit tests for any new feature or bug fix (not applicable: configuration-only change)
- [x] If main was merged after review, I tested again (not applicable)

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not applicable: tooling-only change.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not applicable: tooling-only change.

</details>

<details>
<summary>iOS: Native</summary>

Not applicable: tooling-only change.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not applicable: tooling-only change.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not applicable: tooling-only change.

</details>