### PR TITLE
Extend the stale `hasOutstandingChildRequest` GBR guard to workspace chats

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4678,7 +4678,12 @@ function getReasonAndReportActionThatRequiresAttention(
     // Has a child report that is awaiting action (e.g. approve, pay, add bank account) from current user.
     // A report whose only expenses are pending Expensify Card transactions can't be actioned until they post, so it
     // shouldn't demand attention even when the chat still carries an outstanding-child flag.
-    const hasStaleChildRequest = isTripRoom(optionOrReport) && (optionOrReport.transactionCount ?? 0) === 0;
+    // A workspace chat can keep the flag set after its expense report is gone, leaving a GBR with nothing behind it.
+    // Trust the flag again as soon as either side reports an expense, so a chat whose child report has not loaded into
+    // Onyx yet keeps its GBR.
+    const hasStaleChildRequest =
+        (isTripRoom(optionOrReport) && (optionOrReport.transactionCount ?? 0) === 0) ||
+        (isPolicyExpenseChat(optionOrReport) && optionOrReport.transactionCount === 0 && transactions.length === 0);
     const hasValidIOUAction =
         ((optionOrReport.hasOutstandingChildRequest === true && !hasStaleChildRequest) || iouReportActionToApproveOrPay?.reportActionID) &&
         !hasOnlyPendingTransactions &&

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -3881,6 +3881,81 @@ describe('ReportUtils', () => {
             expect(requiresAttentionFromCurrentUser(report, currentUserEmail, currentUserAccountID)).toBe(true);
         });
 
+        it('returns false when a workspace chat carries a stale outstanding child request', () => {
+            // Given a workspace chat still flagged as having an outstanding child request, whose expense report is gone
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                ownerAccountID: 99,
+                hasOutstandingChildRequest: true,
+                isWaitingOnBankAccount: false,
+                transactionCount: 0,
+            };
+
+            // When we check whether it requires attention
+            // Then the stale flag is ignored, because there is no expense left to act on
+            expect(requiresAttentionFromCurrentUser(report, currentUserEmail, currentUserAccountID)).toBe(false);
+        });
+
+        it('returns true when a workspace chat with an outstanding child request still has expenses', () => {
+            // Given a workspace chat flagged as having an outstanding child request that still counts an expense
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                ownerAccountID: 99,
+                hasOutstandingChildRequest: true,
+                isWaitingOnBankAccount: false,
+                transactionCount: 1,
+            };
+
+            // When we check whether it requires attention
+            // Then the flag is trusted
+            expect(requiresAttentionFromCurrentUser(report, currentUserEmail, currentUserAccountID)).toBe(true);
+        });
+
+        it('returns false for the reported workspace chat whose expense report is long gone', () => {
+            // Given the exact shape of the reported chat: flag still set, zero expenses, last activity in Jan 2025
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                isOwnPolicyExpenseChat: true,
+                ownerAccountID: 623727,
+                managerID: 0,
+                hasOutstandingChildRequest: true,
+                hasOutstandingChildTask: false,
+                isWaitingOnBankAccount: false,
+                transactionCount: 0,
+                total: 0,
+                unheldTotal: 0,
+                reimbursableTotal: 0,
+                nonReimbursableTotal: 0,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+                lastMentionedTime: '2025-01-22 15:16:43.872',
+                lastReadTime: '2026-08-25 01:13:11.118',
+                lastVisibleActionCreated: '2025-01-22 15:16:59.865',
+            };
+
+            // When we check whether it requires attention
+            // Then no reason is found, so the GBR clears
+            expect(requiresAttentionFromCurrentUser(report, currentUserEmail, currentUserAccountID)).toBe(false);
+        });
+
+        it('returns true when a workspace chat with an outstanding child request has no expense count yet', () => {
+            // Given a workspace chat flagged as having an outstanding child request and no transactionCount at all
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                ownerAccountID: 99,
+                hasOutstandingChildRequest: true,
+                isWaitingOnBankAccount: false,
+            };
+
+            // When we check whether it requires attention
+            // Then the flag is trusted, since a missing count is not proof the child report is gone
+            expect(requiresAttentionFromCurrentUser(report, currentUserEmail, currentUserAccountID)).toBe(true);
+        });
+
         it('returns false if the user is not on free trial', async () => {
             await Onyx.multiSet({
                 [ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL]: null, // not on free trial


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

A workspace chat (`policyExpenseChat`) showed a green dot (GBR) in the LHN, but opening it offered no action. The reported chat has `hasOutstandingChildRequest: true` with `transactionCount: 0`, all totals `0`, and no activity since January 2025.

`getReasonAndReportActionThatRequiresAttention()` treats `hasOutstandingChildRequest === true` as reason enough on its own. Once the child expense report is gone and the flag stays set, the dot has nothing to point at. #86744 added a guard for this, but it checks `isTripRoom()`, so workspace chats never reach it.

This change extends `hasStaleChildRequest` to workspace chats, with two conditions the trip-room arm does not have.

The count must be an explicit `0`, not `?? 0`. A workspace chat with no `transactionCount` is not the same as one reporting zero expenses, and this branch runs for every row in the LHN, so a defaulted zero would suppress too much. The reported report sends `0`, so it still matches.

`transactions.length` must also be `0`. Those transactions come from the outstanding child, resolved through the report preview action or the chat's own `iouReportID`, so a chat whose child still holds expenses keeps its dot even when the chat-side count is wrong.

Both conditions cover the loading race the issue asks about. A chat whose child report has not reached Onyx yet reports either a positive count or none at all, and both keep the dot.

`hasStaleChildRequest` gates only the flag arm of the `||`, so a chat with a real `iouReportActionToApproveOrPay` still shows its dot whatever the count says.

Tests are in this PR, in the `requiresAttentionFromCurrentUser` block of `tests/unit/ReportUtilsTest.ts`, including one built from the reported report's fields.

One thing this does not do. The server keeps sending the flag, so this only hides the dot; someone needs to find the flow that removes the expense report without clearing `hasOutstandingChildRequest`, and clear it on the reports already affected.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/99846
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

The stale flag comes from the backend, so the state has to be set by hand. Note that a Debug mode edit does **not** hold — the next `OpenReport` pushes the server value straight back over it — so set it from the JS console instead and do not navigate afterwards.

1. Sign in, create a workspace, and open its expense chat from the Inbox. Note the report ID from the URL (`/r/<reportID>`).
2. In the JS console, put the chat into the reported state:
   ```js
   Onyx.merge('report_<reportID>', {hasOutstandingChildRequest: true, transactionCount: 0})
   ```
3. Verify the workspace chat shows **no** green dot in the LHN, no `To-dos` count, and no "There's a report awaiting action" banner.
4. Trust the flag again when there is an expense:
   ```js
   Onyx.merge('report_<reportID>', {hasOutstandingChildRequest: true, transactionCount: 1})
   ```
5. Verify the green dot, the `To-dos` count and the banner all come back.
6. Verify a missing count does not hide the dot either:
   ```js
   Onyx.merge('report_<reportID>', {hasOutstandingChildRequest: true, transactionCount: null})
   ```
7. Verify the green dot is still shown.
8. Reload the app so the server data comes back, then as an employee on a workspace with approvals enabled, submit an expense in the workspace chat.
9. As the approver, verify the workspace chat shows a green dot in the LHN and the expense can be approved.
10. Approve the expense and verify the green dot clears.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

The change is a pure computation over report data already in Onyx, with no new network dependency.

1. With an expense awaiting your approval, go offline.
2. Verify the workspace chat still shows its green dot, and that reloading the app while offline keeps it.
3. Verify a workspace chat with no outstanding expenses still shows no green dot while offline.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

The reported state is stale server data, so QA cannot create it on demand. These steps confirm the green dot on workspace chats still appears and clears in the normal flows — no Debug mode or flags needed.

1. Sign in as an employee of a workspace that has approvals enabled.
2. Submit an expense from the workspace chat.
3. Sign in as the approver of that workspace and verify the workspace chat shows a green dot in the LHN.
4. Open the chat and verify the expense can be approved, then approve it.
5. Verify the green dot on the workspace chat clears.
6. Open a workspace chat that has no expenses at all and verify it shows no green dot.
7. Send a message mentioning the approver in that same empty workspace chat, and as the approver verify the chat still gets its unread mention indicator.
8. Open a trip room with no expenses and verify it shows no green dot.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
