### PR TITLE
Remove unsafe type assertions from Search chart group-by config

### DIFF
--- a/src/components/Search/chartGroupByConfig.ts
+++ b/src/components/Search/chartGroupByConfig.ts
@@ -2,18 +2,6 @@ import DateUtils from '@libs/DateUtils';
 
 import CONST from '@src/CONST';
 
-import type {
-    TransactionCardGroupListItemType,
-    TransactionCategoryGroupListItemType,
-    TransactionMemberGroupListItemType,
-    TransactionMerchantGroupListItemType,
-    TransactionMonthGroupListItemType,
-    TransactionQuarterGroupListItemType,
-    TransactionTagGroupListItemType,
-    TransactionWeekGroupListItemType,
-    TransactionWithdrawalIDGroupListItemType,
-    TransactionYearGroupListItemType,
-} from './SearchList/ListItem/types';
 import type {GroupedItem, SearchGroupBy} from './types';
 
 type ChartGroupByConfig = {
@@ -37,71 +25,79 @@ type ChartGroupByConfig = {
 const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     [CONST.SEARCH.GROUP_BY.FROM]: {
         titleIconName: 'Users',
-        getLabel: (item: GroupedItem) => (item as TransactionMemberGroupListItemType).formattedFrom ?? '',
-        getFilterQuery: (item: GroupedItem) => `from:${(item as TransactionMemberGroupListItemType).accountID}`,
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.FROM ? (item.formattedFrom ?? '') : ''),
+        getFilterQuery: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.FROM ? `from:${item.accountID}` : ''),
     },
     [CONST.SEARCH.GROUP_BY.CARD]: {
         titleIconName: 'CreditCard',
-        getLabel: (item: GroupedItem) => (item as TransactionCardGroupListItemType).formattedCardName ?? '',
-        getFilterQuery: (item: GroupedItem) => `cardID:${(item as TransactionCardGroupListItemType).cardID}`,
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.CARD ? (item.formattedCardName ?? '') : ''),
+        getFilterQuery: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.CARD ? `cardID:${item.cardID}` : ''),
     },
     [CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID]: {
         titleIconName: 'Send',
         // eslint-disable-next-line rulesdir/no-default-id-values -- formattedWithdrawalID is a display label, not an Onyx ID
-        getLabel: (item: GroupedItem) => (item as TransactionWithdrawalIDGroupListItemType).formattedWithdrawalID ?? '',
-        getFilterQuery: (item: GroupedItem) => `withdrawalID:${(item as TransactionWithdrawalIDGroupListItemType).entryID}`,
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID ? (item.formattedWithdrawalID ?? '') : ''),
+        getFilterQuery: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID ? `withdrawalID:${item.entryID}` : ''),
     },
     [CONST.SEARCH.GROUP_BY.CATEGORY]: {
         titleIconName: 'Folder',
-        getLabel: (item: GroupedItem) => (item as TransactionCategoryGroupListItemType).formattedCategory ?? '',
-        getFilterQuery: (item: GroupedItem) => `category:"${(item as TransactionCategoryGroupListItemType).category}"`,
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.CATEGORY ? (item.formattedCategory ?? '') : ''),
+        getFilterQuery: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.CATEGORY ? `category:"${item.category}"` : ''),
     },
     [CONST.SEARCH.GROUP_BY.MERCHANT]: {
         titleIconName: 'Basket',
-        getLabel: (item: GroupedItem) => (item as TransactionMerchantGroupListItemType).formattedMerchant ?? '',
-        getFilterQuery: (item: GroupedItem) => `merchant:"${(item as TransactionMerchantGroupListItemType).merchant}"`,
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.MERCHANT ? (item.formattedMerchant ?? '') : ''),
+        getFilterQuery: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.MERCHANT ? `merchant:"${item.merchant}"` : ''),
     },
     [CONST.SEARCH.GROUP_BY.TAG]: {
         titleIconName: 'Tag',
-        getLabel: (item: GroupedItem) => (item as TransactionTagGroupListItemType).formattedTag ?? '',
-        getFilterQuery: (item: GroupedItem) => `tag:"${(item as TransactionTagGroupListItemType).tag}"`,
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.TAG ? (item.formattedTag ?? '') : ''),
+        getFilterQuery: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.TAG ? `tag:"${item.tag}"` : ''),
     },
     [CONST.SEARCH.GROUP_BY.MONTH]: {
         titleIconName: 'Calendar',
-        getLabel: (item: GroupedItem) => (item as TransactionMonthGroupListItemType).formattedMonth ?? '',
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.MONTH ? (item.formattedMonth ?? '') : ''),
         getShortLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.MONTH ? item.shortFormattedMonth : undefined),
         getFilterQuery: (item: GroupedItem) => {
-            const monthItem = item as TransactionMonthGroupListItemType;
-            const {start, end} = DateUtils.getMonthDateRange(monthItem.year, monthItem.month);
+            if (item.groupedBy !== CONST.SEARCH.GROUP_BY.MONTH) {
+                return '';
+            }
+            const {start, end} = DateUtils.getMonthDateRange(item.year, item.month);
             return `date>=${start} date<=${end}`;
         },
     },
     [CONST.SEARCH.GROUP_BY.WEEK]: {
         titleIconName: 'Calendar',
-        getLabel: (item: GroupedItem) => (item as TransactionWeekGroupListItemType).formattedWeek ?? '',
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.WEEK ? (item.formattedWeek ?? '') : ''),
         getShortLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.WEEK ? item.shortFormattedWeek : undefined),
         getFilterQuery: (item: GroupedItem) => {
-            const weekItem = item as TransactionWeekGroupListItemType;
-            const {start, end} = DateUtils.getWeekDateRange(weekItem.week);
+            if (item.groupedBy !== CONST.SEARCH.GROUP_BY.WEEK) {
+                return '';
+            }
+            const {start, end} = DateUtils.getWeekDateRange(item.week);
             return `date>=${start} date<=${end}`;
         },
     },
     [CONST.SEARCH.GROUP_BY.YEAR]: {
         titleIconName: 'Calendar',
-        getLabel: (item: GroupedItem) => (item as TransactionYearGroupListItemType).formattedYear ?? '',
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.YEAR ? (item.formattedYear ?? '') : ''),
         getFilterQuery: (item: GroupedItem) => {
-            const yearItem = item as TransactionYearGroupListItemType;
-            const {start, end} = DateUtils.getYearDateRange(yearItem.year);
+            if (item.groupedBy !== CONST.SEARCH.GROUP_BY.YEAR) {
+                return '';
+            }
+            const {start, end} = DateUtils.getYearDateRange(item.year);
             return `date>=${start} date<=${end}`;
         },
     },
     [CONST.SEARCH.GROUP_BY.QUARTER]: {
         titleIconName: 'Calendar',
-        getLabel: (item: GroupedItem) => (item as TransactionQuarterGroupListItemType).formattedQuarter ?? '',
+        getLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.QUARTER ? (item.formattedQuarter ?? '') : ''),
         getShortLabel: (item: GroupedItem) => (item.groupedBy === CONST.SEARCH.GROUP_BY.QUARTER ? item.shortFormattedQuarter : undefined),
         getFilterQuery: (item: GroupedItem) => {
-            const quarterItem = item as TransactionQuarterGroupListItemType;
-            const {start, end} = DateUtils.getQuarterDateRange(quarterItem.year, quarterItem.quarter);
+            if (item.groupedBy !== CONST.SEARCH.GROUP_BY.QUARTER) {
+                return '';
+            }
+            const {start, end} = DateUtils.getQuarterDateRange(item.year, item.quarter);
             return `date>=${start} date<=${end}`;
         },
     },

--- a/tests/unit/Search/chartGroupByConfigTest.ts
+++ b/tests/unit/Search/chartGroupByConfigTest.ts
@@ -1,0 +1,235 @@
+import CHART_GROUP_BY_CONFIG from '@components/Search/chartGroupByConfig';
+import type {
+    TransactionCardGroupListItemType,
+    TransactionCategoryGroupListItemType,
+    TransactionMemberGroupListItemType,
+    TransactionMerchantGroupListItemType,
+    TransactionMonthGroupListItemType,
+    TransactionQuarterGroupListItemType,
+    TransactionTagGroupListItemType,
+    TransactionWeekGroupListItemType,
+    TransactionWithdrawalIDGroupListItemType,
+    TransactionYearGroupListItemType,
+} from '@components/Search/SearchList/ListItem/types';
+import type {GroupedItem, SearchGroupBy} from '@components/Search/types';
+
+import CONST from '@src/CONST';
+
+import type HybridAppModuleType from '@expensify/react-native-hybrid-app/src/types';
+
+import createMock from '../../utils/createMock';
+
+// The Jest environment has no ReactNativeHybridApp module, which DateUtils loads through IntlStore and Log.
+jest.mock('@expensify/react-native-hybrid-app', () => {
+    return {
+        __esModule: true,
+        default: {
+            isHybridApp: jest.fn<ReturnType<HybridAppModuleType['isHybridApp']>, Parameters<HybridAppModuleType['isHybridApp']>>(() => false),
+        },
+    };
+});
+
+type ChartGroupByCase = {
+    groupBy: SearchGroupBy;
+    item: GroupedItem;
+    expectedIcon: (typeof CHART_GROUP_BY_CONFIG)[SearchGroupBy]['titleIconName'];
+    expectedLabel: string;
+    expectedShortLabel?: string;
+    expectedFilterQuery: string;
+};
+
+const memberItem = createMock<TransactionMemberGroupListItemType>({
+    groupedBy: CONST.SEARCH.GROUP_BY.FROM,
+    accountID: 0,
+    formattedFrom: 'Ada Lovelace',
+});
+const cardItem = createMock<TransactionCardGroupListItemType>({
+    groupedBy: CONST.SEARCH.GROUP_BY.CARD,
+    cardID: 123,
+    formattedCardName: 'Travel card',
+});
+
+const cases: ChartGroupByCase[] = [
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.FROM,
+        item: memberItem,
+        expectedIcon: 'Users',
+        expectedLabel: 'Ada Lovelace',
+        expectedFilterQuery: 'from:0',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.CARD,
+        item: cardItem,
+        expectedIcon: 'CreditCard',
+        expectedLabel: 'Travel card',
+        expectedFilterQuery: 'cardID:123',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID,
+        item: createMock<TransactionWithdrawalIDGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID,
+            entryID: 456,
+            formattedWithdrawalID: '456',
+        }),
+        expectedIcon: 'Send',
+        expectedLabel: '456',
+        expectedFilterQuery: 'withdrawalID:456',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.CATEGORY,
+        item: createMock<TransactionCategoryGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.CATEGORY,
+            category: 'Travel meals',
+            formattedCategory: 'Travel meals',
+        }),
+        expectedIcon: 'Folder',
+        expectedLabel: 'Travel meals',
+        expectedFilterQuery: 'category:"Travel meals"',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.MERCHANT,
+        item: createMock<TransactionMerchantGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.MERCHANT,
+            merchant: 'Coffee shop',
+            formattedMerchant: 'Coffee shop',
+        }),
+        expectedIcon: 'Basket',
+        expectedLabel: 'Coffee shop',
+        expectedFilterQuery: 'merchant:"Coffee shop"',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.TAG,
+        item: createMock<TransactionTagGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.TAG,
+            tag: 'Client visit',
+            formattedTag: 'Client visit',
+        }),
+        expectedIcon: 'Tag',
+        expectedLabel: 'Client visit',
+        expectedFilterQuery: 'tag:"Client visit"',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.MONTH,
+        item: createMock<TransactionMonthGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.MONTH,
+            year: 2025,
+            month: 6,
+            formattedMonth: 'June 2025',
+            shortFormattedMonth: 'Jun 25',
+        }),
+        expectedIcon: 'Calendar',
+        expectedLabel: 'June 2025',
+        expectedShortLabel: 'Jun 25',
+        expectedFilterQuery: 'date>=2025-06-01 date<=2025-06-30',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.WEEK,
+        item: createMock<TransactionWeekGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.WEEK,
+            week: '2025-06-09',
+            formattedWeek: 'Jun 9 - Jun 15, 2025',
+            shortFormattedWeek: 'Jun 9 - 15, 25',
+        }),
+        expectedIcon: 'Calendar',
+        expectedLabel: 'Jun 9 - Jun 15, 2025',
+        expectedShortLabel: 'Jun 9 - 15, 25',
+        expectedFilterQuery: 'date>=2025-06-09 date<=2025-06-15',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.YEAR,
+        item: createMock<TransactionYearGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.YEAR,
+            year: 2025,
+            formattedYear: '2025',
+        }),
+        expectedIcon: 'Calendar',
+        expectedLabel: '2025',
+        expectedFilterQuery: 'date>=2025-01-01 date<=2025-12-31',
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.QUARTER,
+        item: createMock<TransactionQuarterGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.QUARTER,
+            year: 2025,
+            quarter: 3,
+            formattedQuarter: 'Q3 2025',
+            shortFormattedQuarter: 'Q3 25',
+        }),
+        expectedIcon: 'Calendar',
+        expectedLabel: 'Q3 2025',
+        expectedShortLabel: 'Q3 25',
+        expectedFilterQuery: 'date>=2025-07-01 date<=2025-09-30',
+    },
+];
+
+const optionalLabelCases: Array<Pick<ChartGroupByCase, 'groupBy' | 'item'>> = [
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.FROM,
+        item: createMock<TransactionMemberGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.FROM,
+            accountID: 1,
+        }),
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.CARD,
+        item: createMock<TransactionCardGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.CARD,
+            cardID: 2,
+            formattedCardName: '',
+        }),
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID,
+        item: createMock<TransactionWithdrawalIDGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID,
+            entryID: 3,
+        }),
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.CATEGORY,
+        item: createMock<TransactionCategoryGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.CATEGORY,
+            category: '',
+            formattedCategory: '',
+        }),
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.MERCHANT,
+        item: createMock<TransactionMerchantGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.MERCHANT,
+            merchant: '',
+        }),
+    },
+    {
+        groupBy: CONST.SEARCH.GROUP_BY.TAG,
+        item: createMock<TransactionTagGroupListItemType>({
+            groupedBy: CONST.SEARCH.GROUP_BY.TAG,
+            tag: '',
+            formattedTag: '',
+        }),
+    },
+];
+
+describe('CHART_GROUP_BY_CONFIG', () => {
+    test.each(cases)('returns the $groupBy chart values for a matching item', ({groupBy, item, expectedIcon, expectedLabel, expectedShortLabel, expectedFilterQuery}) => {
+        const config = CHART_GROUP_BY_CONFIG[groupBy];
+
+        expect(config.titleIconName).toBe(expectedIcon);
+        expect(config.getLabel(item)).toBe(expectedLabel);
+        expect(config.getShortLabel?.(item)).toBe(expectedShortLabel);
+        expect(config.getFilterQuery(item)).toBe(expectedFilterQuery);
+    });
+
+    test.each(cases)('rejects an item that does not match the $groupBy configuration', ({groupBy}) => {
+        const config = CHART_GROUP_BY_CONFIG[groupBy];
+        const mismatchedItem = groupBy === CONST.SEARCH.GROUP_BY.FROM ? cardItem : memberItem;
+
+        expect(config.getLabel(mismatchedItem)).toBe('');
+        expect(config.getShortLabel?.(mismatchedItem)).toBeUndefined();
+        expect(config.getFilterQuery(mismatchedItem)).toBe('');
+    });
+
+    test.each(optionalLabelCases)('returns an empty label for an absent or empty optional $groupBy label', ({groupBy, item}) => {
+        expect(CHART_GROUP_BY_CONFIG[groupBy].getLabel(item)).toBe('');
+    });
+});


### PR DESCRIPTION
<!-- Seatbelt Lite draft; run c13-260901-r13; exact head e78f89e5c777fce0df3f29d722975e36806fbe0d -->

### Explanation of Change

This cleanup removes 20 `@typescript-eslint/no-unsafe-type-assertion` findings from `src/components/Search/chartGroupByConfig.ts`.

The chart group-by configuration now narrows each `GroupedItem` through its `groupedBy` discriminant before reading branch-specific fields. Matching items keep the existing labels, compact labels, query syntax, identifiers, and date-range calculations. A mismatched item returns an empty label or query, and an absent compact label remains `undefined`.

The new focused unit test covers all ten group-by configurations, mismatch handling, optional label fallbacks, and a zero account identifier.

Verification evidence:

- Cleanup counting, focused formatting, focused lint, focused Jest, changed-path enforcement, TSV restoration, and `git diff --check` passed for exact diff `sha256:fbb58191cf4d4c63bba71a8711326ff3cf5da58138a44ddc05e5ce8772833894`.
- The verifier-owned focused typecheck had partial coverage because an unrelated `AddressSearch` diagnostic prevented a complete local result. It reported no diagnostic on either changed path.
- Independent scope, type-safety, and regression reviews are clean for the exact diff.
- Initial exact-head Fork CI provider run `33561169910` passed lint, format, React Compiler, and the focused Jest suite. Its typecheck failed on foreign path `src/libs/TransactionUtils/index.ts` with TS2459 because `getCurrencySymbol` was not exported from `CurrencyUtils`.
- Current `Expensify/App` `main` contains fix commit `98069003e30d7f74e2b1679dfc3e9ac9c18db7d9`, which exports `getCurrencySymbol` and removes the failing alias import. The exact current-main TypeScript check passed at observed head `6bf0775fa06f0ef7930252f5ab32abc0047668ec`.
- The initial Fork CI success protection is operator-overridden for `transition:draft-create` on signed head `e78f89e5c777fce0df3f29d722975e36806fbe0d`. Provider run `33561169910` remains recorded as `code-failure`; it is not a pass.

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Tests

Automated evidence already completed:

1. Run the focused `chartGroupByConfigTest.ts` Jest suite and verify all matching configuration, mismatch, optional-label, and zero-identifier cases pass.
2. Run focused cleanup counting, formatting, and lint for both changed files. Verify both cleanup counts are zero and no focused formatting or lint error appears.
3. Run `git diff --check` and verify `config/eslint/eslint.seatbelt.tsv` is restored byte-for-byte.

Manual QA required before review:

1. Open Search and produce chart results for each available group-by option.
2. Verify the chart labels and compact date labels match the selected grouping.
3. Select chart groups and verify the generated drill-down search preserves the expected member, card, withdrawal, category, merchant, tag, or date filter.
4. Verify the chart does not display a stale label or build a filter for a result whose `groupedBy` value does not match the selected configuration.
5. Verify no related error appears in the JavaScript console.

The exact regression review schedules QA before code review. Manual platform QA has not been performed in this session.

### Offline tests

The change adds no network or persistence behavior. During QA, load an existing Search chart, disconnect the network, and verify cached chart labels remain stable. Reconnect before exercising a drill-down that requires fresh results. No manual offline test has been performed in this session.

### QA Steps

Use the manual steps in `### Tests` on staging before code review. Exercise every group-by option that the available account data supports, including at least one date grouping and one text grouping. Confirm the selected chart group produces the same label and drill-down query as before this cleanup.

### PR Author Checklist

Every checklist item below is checked because it was considered. Manual QA is required before review and remains pending. Platform-wide execution, high-traffic-account testing, screenshots, design, CSS, assets, copy, Storybook, deeplink, message-formatting, and generic-component checks are not applicable because this change affects only the internal Search chart group-by configuration and its focused unit test. The change adds no UI, styling, asset, copy, navigation, message, or generic-component behavior.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Count change

Current baseline source:

- `config/eslint/eslint.seatbelt.tsv` at pinned base `d51f0ceb5c324a2d18033455ef80c8a95f74f92a`.

Before:

- `src/components/Search/chartGroupByConfig.ts`: 20 `@typescript-eslint/no-unsafe-type-assertion` findings.
- `tests/unit/Search/chartGroupByConfigTest.ts`: 0 findings because the support file did not exist at the pinned base.

After:

- `src/components/Search/chartGroupByConfig.ts`: 0 findings.
- `tests/unit/Search/chartGroupByConfigTest.ts`: 0 findings.

Net reduction:

- 20 fewer `@typescript-eslint/no-unsafe-type-assertion` findings.

TSV evidence:

- Authoritative cleanup counting reported zero findings for both changed files.
- Verification restored `config/eslint/eslint.seatbelt.tsv` byte-for-byte.
- The generated TSV is intentionally absent from this PR because Expensify/App post-merge automation tightens the baseline on `main`.

### Screenshots/Videos

No screenshots or videos are included at draft preparation. The change adds no visual design or layout. Manual behavioral QA of chart labels and drill-down queries is still required before review on a supported Search surface.

### Changed files (2)

- `src/components/Search/chartGroupByConfig.ts`
- `tests/unit/Search/chartGroupByConfigTest.ts` (reserved support path)
