### PR TITLE
[No QA] Fix monthly NextStepUtils test determinism

### DIFF
--- a/src/libs/DateUtils.ts
+++ b/src/libs/DateUtils.ts
@@ -1281,6 +1281,21 @@ function getShortFormattedQuarterForSearch(year: number, quarter: number): strin
     return `Q${quarter} ${format(new Date(year, 0, 1), '’yy')}`;
 }
 
+function getNextNthOfMonth(nth: number) {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth();
+    const day = now.getDate();
+
+    // If today is before the nth day, return the nth of this month.
+    if (day < nth) {
+        return new Date(year, month, nth);
+    }
+
+    // Otherwise, return the nth of next month.
+    return new Date(year, month + 1, nth);
+}
+
 const DateUtils = {
     isDate,
     formatToDayOfWeek,
@@ -1364,6 +1379,7 @@ const DateUtils = {
     getQuarterDateRange,
     getFormattedQuarterForSearch,
     getShortFormattedQuarterForSearch,
+    getNextNthOfMonth,
 };
 
 export default DateUtils;

--- a/src/libs/DateUtils.ts
+++ b/src/libs/DateUtils.ts
@@ -1281,21 +1281,6 @@ function getShortFormattedQuarterForSearch(year: number, quarter: number): strin
     return `Q${quarter} ${format(new Date(year, 0, 1), '’yy')}`;
 }
 
-function getNextNthOfMonth(nth: number) {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth();
-    const day = now.getDate();
-
-    // If today is before the nth day, return the nth of this month.
-    if (day < nth) {
-        return new Date(year, month, nth);
-    }
-
-    // Otherwise, return the nth of next month.
-    return new Date(year, month + 1, nth);
-}
-
 const DateUtils = {
     isDate,
     formatToDayOfWeek,
@@ -1379,7 +1364,6 @@ const DateUtils = {
     getQuarterDateRange,
     getFormattedQuarterForSearch,
     getShortFormattedQuarterForSearch,
-    getNextNthOfMonth,
 };
 
 export default DateUtils;

--- a/tests/unit/NextStepUtilsTest.ts
+++ b/tests/unit/NextStepUtilsTest.ts
@@ -1,6 +1,5 @@
 import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 
-import DateUtils from '@libs/DateUtils';
 import {
     buildNextStepMessage,
     buildOptimisticNextStepForPreventSelfApprovalsEnabled,
@@ -19,7 +18,6 @@ import {toCollectionDataSet} from '@src/types/utils/CollectionDataSet';
 import type {OnyxCollection} from 'react-native-onyx';
 
 import {execFileSync} from 'child_process';
-import {format} from 'date-fns';
 import Onyx from 'react-native-onyx';
 
 import createMock from '../utils/createMock';
@@ -280,38 +278,66 @@ describe('libs/NextStepUtils', () => {
                     expect(result).toMatchObject(expectedResult);
                 });
 
-                test('monthly on the 2nd', () => {
-                    // Waiting for userSubmitter's expense(s) to automatically submit on the 2nd of each month
-                    const expectedResult: ReportNextStep = {
+                // Waiting for userSubmitter's expense(s) to automatically submit on the 2nd of each month.
+                // The eta is derived from the live clock, so "now" is pinned here. Deriving the expectation from a
+                // real `new Date()` made these cases pass on most days and fail on the 2nd of every month, when the
+                // eta lands on today and `isPast` degenerates into a sub-millisecond comparison against "now".
+                describe('monthly on the 2nd', () => {
+                    const buildMonthlyOnThe2ndNextStep = () =>
+                        buildOptimisticNextStep({
+                            report,
+                            policy: {
+                                ...policy,
+                                autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MONTHLY,
+                                autoReportingOffset: 2,
+                                harvesting: {
+                                    enabled: true,
+                                },
+                            },
+                            currentUserAccountIDParam: currentUserAccountID,
+                            currentUserEmailParam: currentUserEmail,
+                            hasViolations: false,
+                            isASAPSubmitBetaEnabled: false,
+                            predictedNextStatus: CONST.REPORT.STATUS_NUM.OPEN,
+                            shouldFixViolations: false,
+                            isUnapprove: false,
+                            isReopen: false,
+                            isTrackIntentUser: false,
+                        });
+
+                    const expectedResultWithEtaDate = (dateTime: string): ReportNextStep => ({
                         messageKey: CONST.NEXT_STEP.MESSAGE_KEY.WAITING_FOR_AUTOMATIC_SUBMIT,
                         icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
                         actorAccountID: currentUserAccountID,
                         eta: {
-                            dateTime: format(DateUtils.getNextNthOfMonth(2), 'yyyy-MM-dd'),
+                            dateTime,
                         },
-                    };
-                    const result = buildOptimisticNextStep({
-                        report,
-                        policy: {
-                            ...policy,
-                            autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MONTHLY,
-                            autoReportingOffset: 2,
-                            harvesting: {
-                                enabled: true,
-                            },
-                        },
-                        currentUserAccountIDParam: currentUserAccountID,
-                        currentUserEmailParam: currentUserEmail,
-                        hasViolations: false,
-                        isASAPSubmitBetaEnabled: false,
-                        predictedNextStatus: CONST.REPORT.STATUS_NUM.OPEN,
-                        shouldFixViolations: false,
-                        isUnapprove: false,
-                        isReopen: false,
-                        isTrackIntentUser: false,
                     });
 
-                    expect(result).toMatchObject(expectedResult);
+                    afterEach(() => {
+                        jest.useRealTimers();
+                    });
+
+                    test('is the 2nd of this month when the 2nd is still ahead', () => {
+                        jest.useFakeTimers();
+                        jest.setSystemTime(new Date('2026-01-01T12:00:00Z'));
+
+                        expect(buildMonthlyOnThe2ndNextStep()).toMatchObject(expectedResultWithEtaDate('2026-01-02'));
+                    });
+
+                    test('is today when today is the 2nd', () => {
+                        jest.useFakeTimers();
+                        jest.setSystemTime(new Date('2026-01-02T12:00:00Z'));
+
+                        expect(buildMonthlyOnThe2ndNextStep()).toMatchObject(expectedResultWithEtaDate('2026-01-02'));
+                    });
+
+                    test('is the 2nd of next month once the 2nd has passed', () => {
+                        jest.useFakeTimers();
+                        jest.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+
+                        expect(buildMonthlyOnThe2ndNextStep()).toMatchObject(expectedResultWithEtaDate('2026-02-02'));
+                    });
                 });
 
                 test('monthly on the last day', () => {

--- a/tests/unit/NextStepUtilsTest.ts
+++ b/tests/unit/NextStepUtilsTest.ts
@@ -278,10 +278,6 @@ describe('libs/NextStepUtils', () => {
                     expect(result).toMatchObject(expectedResult);
                 });
 
-                // Waiting for userSubmitter's expense(s) to automatically submit on the 2nd of each month.
-                // The eta is derived from the live clock, so "now" is pinned here. Deriving the expectation from a
-                // real `new Date()` made these cases pass on most days and fail on the 2nd of every month, when the
-                // eta lands on today and `isPast` degenerates into a sub-millisecond comparison against "now".
                 describe('monthly on the 2nd', () => {
                     const buildMonthlyOnThe2ndNextStep = () =>
                         buildOptimisticNextStep({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The monthly-on-the-2nd test derived its expected date from `DateUtils.getNextNthOfMonth`, while production uses a different boundary rule. As a result, the test failed whenever CI ran on the 2nd of the month.

The test now pins the system clock and explicitly verifies the monthly ETA before, on, and after the 2nd. Production code is unchanged.

### Fixed Issues
$ https://github.com/Expensify/App/issues/100134
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests
No production code changes, so offline behavior is unchanged.

### QA Steps
Not applicable; this is a test-only change. The PR title includes `[No QA]`.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors
- [x] I followed proper code patterns
- [x] I followed the guidelines stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for this bug fix

### Screenshots/Videos
No UI changes.

<details>
<summary>Android: Native</summary>
</details>

<details>
<summary>Android: mWeb Chrome</summary>
</details>

<details>
<summary>iOS: Native</summary>
</details>

<details>
<summary>iOS: mWeb Safari</summary>
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
</details>
