### PR TITLE
Fix - Workspace chat - Export to NetSuite button still shows while an export is in progress

### DIFF
--- a/src/libs/ReportPreviewActionUtils.ts
+++ b/src/libs/ReportPreviewActionUtils.ts
@@ -35,6 +35,7 @@ import {
     isProcessingReport,
     isReportApproved,
     isSettled,
+    isExportInProgress,
 } from './ReportUtils';
 import {hasOnlyPendingCardTransactions, hasSmartScanFailedWithMissingFields, hasSubmissionBlockingViolations, isPending, isScanning} from './TransactionUtils';
 
@@ -192,7 +193,11 @@ function canPay(
     return invoiceReceiverPolicy?.role === CONST.POLICY.ROLE.ADMIN && reimbursableSpend > 0;
 }
 
-function canExport(report: Report, currentUserLogin: string, policy?: Policy) {
+function canExport(report: Report, currentUserLogin: string, policy?: Policy, reportMetadata?: OnyxEntry<ReportMetadata>) {
+    if (isExportInProgress(report, reportMetadata)) {
+        return false;
+    }
+
     const isExpense = isExpenseReport(report);
     const isExporter = policy ? isPreferredExporter(policy, currentUserLogin) : false;
     const isReimbursed = isSettled(report);
@@ -285,7 +290,7 @@ function getReportPreviewAction({
     if (canPay(report, isReportArchived, currentUserAccountID, currentUserLogin, bankAccountList, transactions, policy, invoiceReceiverPolicy)) {
         return CONST.REPORT.REPORT_PREVIEW_ACTIONS.PAY;
     }
-    if (canExport(report, currentUserLogin, policy)) {
+    if (canExport(report, currentUserLogin, policy, reportMetadata)) {
         return CONST.REPORT.REPORT_PREVIEW_ACTIONS.EXPORT_TO_ACCOUNTING;
     }
 

--- a/src/libs/ReportPrimaryActionUtils.ts
+++ b/src/libs/ReportPrimaryActionUtils.ts
@@ -55,6 +55,7 @@ import {
     isReportApproved as isReportApprovedUtils,
     isReportManager,
     isSettled,
+    isExportInProgress,
 } from './ReportUtils';
 import {
     allHavePendingRTERViolation,
@@ -286,8 +287,12 @@ function isPrimaryPayAction({
     return invoiceReceiverPolicy?.role === CONST.POLICY.ROLE.ADMIN && reimbursableSpend > 0;
 }
 
-function isExportAction(report: Report, currentUserLogin: string, policy?: Policy, reportActions?: ReportAction[]) {
+function isExportAction(report: Report, currentUserLogin: string, policy?: Policy, reportActions?: ReportAction[], reportMetadata?: OnyxEntry<ReportMetadata>) {
     if (!policy) {
+        return false;
+    }
+
+    if (isExportInProgress(report, reportMetadata)) {
         return false;
     }
 
@@ -572,7 +577,7 @@ function getReportPrimaryAction(params: GetReportPrimaryActionParams): ValueOf<t
         return CONST.REPORT.PRIMARY_ACTIONS.PAY;
     }
 
-    if (isExportAction(report, currentUserLogin, policy, reportActions)) {
+    if (isExportAction(report, currentUserLogin, policy, reportActions, reportMetadata)) {
         return CONST.REPORT.PRIMARY_ACTIONS.EXPORT_TO_ACCOUNTING;
     }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -13526,7 +13526,7 @@ function getExportErrorCount(report: OnyxEntry<Report>): number {
  */
 function isExportInProgress(report: OnyxEntry<Report>, reportMetadata: OnyxEntry<ReportMetadata>): boolean {
     const {exportErrorCountAtRequest} = reportMetadata ?? {};
-    // Checked against null rather than falsiness, because zero is the usual count for a report that never failed.
+    // Checked against null rather than falsy value, because zero is the usual count for a report that never failed.
     if (exportErrorCountAtRequest == null) {
         return false;
     }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -13507,6 +13507,14 @@ function isExported(reportActions: OnyxEntry<ReportActions> | ReportAction[], re
 }
 
 /**
+ * Count the export errors a report currently carries because it is
+ * what identifies a new failure against a snapshotted baseline.
+ */
+function getExportErrorCount(report: OnyxEntry<Report>): number {
+    return Object.values(report?.errorFields?.export ?? {}).filter((error) => error != null).length;
+}
+
+/**
  * Whether an export this client started is still running.
  *
  * There is no client event meaning "the export finished" - the 200 only means the request was accepted, `failureData`
@@ -13525,9 +13533,8 @@ function isExportInProgress(report: OnyxEntry<Report>, reportMetadata: OnyxEntry
 
     // Only an export error the report did not already carry belongs to this attempt. Pre-existing ones must not
     // resolve it, because a report that already failed to export is exactly the retry case where the button is
-    // offered again. The entries are keyed by microsecond timestamp, so counting them is what identifies a new one.
-    const exportErrorCount = Object.values(report?.errorFields?.export ?? {}).filter((error) => error != null).length;
-    return exportErrorCount === exportErrorCountAtRequest;
+    // offered again.
+    return getExportErrorCount(report) === exportErrorCountAtRequest;
 }
 
 function hasExportError(reportActions: OnyxEntry<ReportActions> | ReportAction[], report?: OnyxEntry<Report>) {
@@ -14772,6 +14779,7 @@ export {
     isExported,
     hasExpensifyGuidesEmails,
     hasExportError,
+    getExportErrorCount,
     isExportInProgress,
     hasOnlyNonReimbursableTransactions,
     getReportLastMessage,

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -13506,6 +13506,30 @@ function isExported(reportActions: OnyxEntry<ReportActions> | ReportAction[], re
     return lastSuccessfulExportCreated > lastResetCreated;
 }
 
+/**
+ * Whether an export this client started is still running.
+ *
+ * There is no client event meaning "the export finished" - the 200 only means the request was accepted, `failureData`
+ * never runs, and the real outcome arrives later over Pusher - so the state is resolved by comparison at read time
+ * rather than cleared from a callback. That also means a stale flag can never strand the button.
+ *
+ * Both signals live on the report, so this holds in a preview where the report actions are not loaded, and it
+ * survives a refresh.
+ */
+function isExportInProgress(report: OnyxEntry<Report>, reportMetadata: OnyxEntry<ReportMetadata>): boolean {
+    const {exportErrorCountAtRequest} = reportMetadata ?? {};
+    // Checked against null rather than falsiness, because zero is the usual count for a report that never failed.
+    if (exportErrorCountAtRequest == null) {
+        return false;
+    }
+
+    // Only an export error the report did not already carry belongs to this attempt. Pre-existing ones must not
+    // resolve it, because a report that already failed to export is exactly the retry case where the button is
+    // offered again. The entries are keyed by microsecond timestamp, so counting them is what identifies a new one.
+    const exportErrorCount = Object.values(report?.errorFields?.export ?? {}).filter((error) => error != null).length;
+    return exportErrorCount === exportErrorCountAtRequest;
+}
+
 function hasExportError(reportActions: OnyxEntry<ReportActions> | ReportAction[], report?: OnyxEntry<Report>) {
     if (report?.hasExportError) {
         return true;
@@ -14748,6 +14772,7 @@ export {
     isExported,
     hasExpensifyGuidesEmails,
     hasExportError,
+    isExportInProgress,
     hasOnlyNonReimbursableTransactions,
     getReportLastMessage,
     getReportLastVisibleActionCreated,

--- a/src/libs/actions/IOU/ReportWorkflow.ts
+++ b/src/libs/actions/IOU/ReportWorkflow.ts
@@ -618,6 +618,17 @@ function approveMoneyRequest(params: ApproveMoneyRequestFunctionParams) {
         });
     }
 
+    // Approving is how a report re-enters an exportable state, so any snapshot left by an earlier export has to go.
+    // `canExport` offers the button only while the report is approved, reimbursed or closed, which means clearing here
+    // also covers a reset the client never saw, such as one driven by the server.
+    optimisticData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            exportErrorCountAtRequest: null,
+        },
+    });
+
     const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [];
 
     if (!isDEWPolicy) {
@@ -897,7 +908,20 @@ function reopenReport(
         },
     };
 
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS>> = [optimisticIOUReportData, optimisticReportActionsData];
+    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [
+        optimisticIOUReportData,
+        optimisticReportActionsData,
+    ];
+
+    // A reset of the approval state invalidates the previous export, so drop any in-flight export snapshot. Without
+    // this it survives a successful export and keeps both export buttons hidden once the report is exportable again.
+    optimisticData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            exportErrorCountAtRequest: null,
+        },
+    });
 
     const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT>> = [
         {
@@ -1058,7 +1082,20 @@ function retractReport(
         },
     };
 
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS>> = [optimisticIOUReportData, optimisticReportActionsData];
+    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [
+        optimisticIOUReportData,
+        optimisticReportActionsData,
+    ];
+
+    // A reset of the approval state invalidates the previous export, so drop any in-flight export snapshot. Without
+    // this it survives a successful export and keeps both export buttons hidden once the report is exportable again.
+    optimisticData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            exportErrorCountAtRequest: null,
+        },
+    });
 
     if (chatReport) {
         optimisticData.push({
@@ -1219,7 +1256,20 @@ function unapproveExpenseReport(
         },
     };
 
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT>> = [optimisticIOUReportData, optimisticReportActionData];
+    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [
+        optimisticIOUReportData,
+        optimisticReportActionData,
+    ];
+
+    // A reset of the approval state invalidates the previous export, so drop any in-flight export snapshot. Without
+    // this it survives a successful export and keeps both export buttons hidden once the report is exportable again.
+    optimisticData.push({
+        onyxMethod: Onyx.METHOD.MERGE,
+        key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${expenseReport.reportID}`,
+        value: {
+            exportErrorCountAtRequest: null,
+        },
+    });
 
     const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT>> = [
         {

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -172,6 +172,7 @@ import {
     isSelfDM,
     isUploadingAttachmentRemovedFromDraft,
     isValidReportIDFromPath,
+    getExportErrorCount,
     prepareOnboardingOnyxData,
     replaceLocalAttachmentReferences,
 } from '@libs/ReportUtils';
@@ -6472,7 +6473,7 @@ function exportToIntegration(reportID: string, connectionName: ConnectionName, p
     const optimisticReportActionID = action.reportActionID;
     const report = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
     // Snapshot the export errors the report already carries, so only a new one counts as this attempt's outcome.
-    const exportErrorCountAtRequest = Object.values(report?.errorFields?.export ?? {}).filter((error) => error != null).length;
+    const exportErrorCountAtRequest = getExportErrorCount(report);
 
     // `isExportedToIntegration` is deliberately not updated optimistically because the server doesn't set it false
     // when export fails so we track export errors to identify an export failure.

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -6470,9 +6470,13 @@ function setGroupDraft(newGroupDraft: Partial<NewGroupChatDraft>) {
 function exportToIntegration(reportID: string, connectionName: ConnectionName, policy: OnyxEntry<Policy>) {
     const action = buildOptimisticExportIntegrationAction(connectionName, false, getExportLabelForConnection(connectionName, policy));
     const optimisticReportActionID = action.reportActionID;
-    const previousExportedValue = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]?.isExportedToIntegration;
+    const report = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
+    // Snapshot the export errors the report already carries, so only a new one counts as this attempt's outcome.
+    const exportErrorCountAtRequest = Object.values(report?.errorFields?.export ?? {}).filter((error) => error != null).length;
 
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT>> = [
+    // `isExportedToIntegration` is deliberately not updated optimistically because the server doesn't set it false
+    // when export fails so we track export errors to identify an export failure.
+    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
@@ -6482,14 +6486,14 @@ function exportToIntegration(reportID: string, connectionName: ConnectionName, p
         },
         {
             onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+            key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportID}`,
             value: {
-                isExportedToIntegration: true,
+                exportErrorCountAtRequest,
             },
         },
     ];
 
-    const failureData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT>> = [
+    const failureData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.REPORT_METADATA>> = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
@@ -6501,9 +6505,9 @@ function exportToIntegration(reportID: string, connectionName: ConnectionName, p
         },
         {
             onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+            key: `${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportID}`,
             value: {
-                isExportedToIntegration: previousExportedValue,
+                exportErrorCountAtRequest: null,
             },
         },
     ];

--- a/src/types/onyx/ReportMetadata.ts
+++ b/src/types/onyx/ReportMetadata.ts
@@ -34,6 +34,11 @@ type ReportMetadata = {
 
     /** Transaction IDs that were just submitted/moved to this report and should be highlighted on first load */
     pendingNewTransactionIDs?: Record<string, true | null>;
+
+    /** How many `errorFields.export` entries the report carried when a manual export was started from this client,
+     *  so if a new export error entry is added it means the export attempt failed.
+     * */
+    exportErrorCountAtRequest?: number | null;
 };
 
 export default ReportMetadata;

--- a/tests/actions/ReportPreviewActionUtilsTest.ts
+++ b/tests/actions/ReportPreviewActionUtilsTest.ts
@@ -1264,6 +1264,119 @@ describe('getReportPreviewAction', () => {
         ).toBe(CONST.REPORT.REPORT_PREVIEW_ACTIONS.EXPORT_TO_ACCOUNTING);
     });
 
+    it('canExport should return false while an export started from this client is still running', async () => {
+        const report = {
+            ...createRandomReport(REPORT_ID, undefined),
+            type: CONST.REPORT.TYPE.EXPENSE,
+            ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+            statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
+            isWaitingOnBankAccount: false,
+        };
+
+        const policy = createRandomPolicy(0);
+        policy.type = CONST.POLICY.TYPE.CORPORATE;
+        policy.connections = {[CONST.POLICY.CONNECTIONS.NAME.NETSUITE]: createMock<NetSuiteConnection>({})};
+        policy.reimbursementChoice = CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+        const transaction = createMock<Transaction>({
+            reportID: `${REPORT_ID}`,
+        });
+
+        const {result: isReportArchived} = renderHook(() => useReportIsArchived(report?.parentReportID));
+        await waitForBatchedUpdatesWithAct();
+
+        // The report carried no export errors when the export was started, so no new one has arrived yet.
+        expect(
+            getReportPreviewAction({
+                isReportArchived: isReportArchived.current,
+                currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+                currentUserLogin: CURRENT_USER_EMAIL,
+                report,
+                policy,
+                transactions: [transaction],
+                bankAccountList: {},
+                reportMetadata: {exportErrorCountAtRequest: 0},
+                ownerLogin: CURRENT_USER_EMAIL,
+            }),
+        ).not.toBe(CONST.REPORT.REPORT_PREVIEW_ACTIONS.EXPORT_TO_ACCOUNTING);
+    });
+
+    it('canExport should return true again once the export fails with a new error', async () => {
+        const report = {
+            ...createRandomReport(REPORT_ID, undefined),
+            type: CONST.REPORT.TYPE.EXPENSE,
+            ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+            statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
+            isWaitingOnBankAccount: false,
+            errorFields: {export: {exportError: 'export failed'}},
+        };
+
+        const policy = createRandomPolicy(0);
+        policy.type = CONST.POLICY.TYPE.CORPORATE;
+        policy.connections = {[CONST.POLICY.CONNECTIONS.NAME.NETSUITE]: createMock<NetSuiteConnection>({})};
+        policy.reimbursementChoice = CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+        const transaction = createMock<Transaction>({
+            reportID: `${REPORT_ID}`,
+        });
+
+        const {result: isReportArchived} = renderHook(() => useReportIsArchived(report?.parentReportID));
+        await waitForBatchedUpdatesWithAct();
+
+        // One export error has arrived since the request, so this attempt is resolved and the button comes back.
+        expect(
+            getReportPreviewAction({
+                isReportArchived: isReportArchived.current,
+                currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+                currentUserLogin: CURRENT_USER_EMAIL,
+                report,
+                policy,
+                transactions: [transaction],
+                bankAccountList: {},
+                reportMetadata: {exportErrorCountAtRequest: 0},
+                ownerLogin: CURRENT_USER_EMAIL,
+            }),
+        ).toBe(CONST.REPORT.REPORT_PREVIEW_ACTIONS.EXPORT_TO_ACCOUNTING);
+    });
+
+    it('canExport should stay hidden when the report already carried the same export errors', async () => {
+        const report = {
+            ...createRandomReport(REPORT_ID, undefined),
+            type: CONST.REPORT.TYPE.EXPENSE,
+            ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+            statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
+            isWaitingOnBankAccount: false,
+            errorFields: {export: {exportError: 'export failed'}},
+        };
+
+        const policy = createRandomPolicy(0);
+        policy.type = CONST.POLICY.TYPE.CORPORATE;
+        policy.connections = {[CONST.POLICY.CONNECTIONS.NAME.NETSUITE]: createMock<NetSuiteConnection>({})};
+        policy.reimbursementChoice = CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO;
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${REPORT_ID}`, report);
+        const transaction = createMock<Transaction>({
+            reportID: `${REPORT_ID}`,
+        });
+
+        const {result: isReportArchived} = renderHook(() => useReportIsArchived(report?.parentReportID));
+        await waitForBatchedUpdatesWithAct();
+
+        // Retrying an export on a report that already failed once: the pre-existing error must not resolve the attempt.
+        expect(
+            getReportPreviewAction({
+                isReportArchived: isReportArchived.current,
+                currentUserAccountID: CURRENT_USER_ACCOUNT_ID,
+                currentUserLogin: CURRENT_USER_EMAIL,
+                report,
+                policy,
+                transactions: [transaction],
+                bankAccountList: {},
+                reportMetadata: {exportErrorCountAtRequest: 1},
+                ownerLogin: CURRENT_USER_EMAIL,
+            }),
+        ).not.toBe(CONST.REPORT.REPORT_PREVIEW_ACTIONS.EXPORT_TO_ACCOUNTING);
+    });
+
     describe('DEW (Dynamic External Workflow) submit pending', () => {
         it('should return VIEW action when DEW submit is pending and report is OPEN', async () => {
             // Given an open expense report with a corporate policy where DEW submit is pending


### PR DESCRIPTION
### Explanation of Change

Neither export button knows an export is running, because nothing in Onyx durably says so. The only thing resembling an in-flight signal was `isExportedToIntegration`, which `exportToIntegration` set optimistically — but that field is server owned. It never cleared on failure, since `Report_Export` answers 200 as soon as the request is accepted and `failureData` never runs, and it was wiped by the next server update, so refreshing mid-export brought the button back and a second press queued a duplicate export.

This drops the optimistic `isExportedToIntegration` write entirely and records the in-flight attempt in report metadata instead, as `exportErrorCountAtRequest` — how many `errorFields.export` entries the report already carried. `isExportInProgress` resolves the attempt by comparison at read time rather than from a callback the API never fires: a new export error means this attempt failed, and the button returns. Both signals live on the report, so it holds in a preview where report actions are not loaded, and it survives a refresh. Both `isExportAction()` and `canExport()` are gated on it so the header and the preview agree.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98025
PROPOSAL: https://github.com/Expensify/App/issues/98025#issuecomment-5402689135

### Tests

1. Open a workspace with a NetSuite connection set up and auto-sync disabled.
2. Open a workspace chat containing an expense report that is ready to export.
3. Verify the green **Export to NetSuite** button is shown on the report preview.
4. Click the button and confirm the export.
5. Verify the button disappears immediately.
6. Refresh the page while the export is still running.
7. Verify the button is still hidden after the refresh, so it cannot be pressed a second time.
8. Wait for the export to finish and verify the report shows as exported, with only one export action recorded.
9. Repeat steps 2 to 5 against a connection that will fail, for example one with invalid currencies like `ETB`.
10. Verify that once the failure is recorded the button comes back, and that re-exporting from it works.
11. Take a report that has **already** failed to export before, press Export on it, and verify the button hides rather than staying pressable.
12. Verify the button behaves identically when opened from the report header instead of the preview.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests

### QA Steps

Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/4cea9353-361e-4093-9095-9fa2cfd77a72


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/080d6032-28b7-4941-adc4-d3352155501a


</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/cd63c762-9e29-42e9-824a-622be4916d49


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/54879de1-cadc-425d-990f-a71f339a593d


</details>
