### PR TITLE
[No QA] Add policy vendors Onyx collection type

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -885,6 +885,7 @@ const ONYXKEYS = {
         POLICY_CATEGORIES_DRAFT: 'policyCategoriesDraft_',
         POLICY_RECENTLY_USED_CATEGORIES: 'policyRecentlyUsedCategories_',
         POLICY_TAGS: 'policyTags_',
+        POLICY_VENDORS: 'policyVendors_',
         POLICY_RECENTLY_USED_TAGS: 'nvp_recentlyUsedTags_',
         POLICY_RECENTLY_USED_DESTINATIONS: 'nvp_recentlyUsedDestinations_',
         // Whether the policy's connection data was attempted to be fetched in
@@ -1488,6 +1489,7 @@ type OnyxCollectionValuesMapping = {
     [ONYXKEYS.COLLECTION.POLICY_CATEGORIES]: OnyxTypes.PolicyCategories;
     [ONYXKEYS.COLLECTION.POLICY_CATEGORIES_DRAFT]: OnyxTypes.PolicyCategories;
     [ONYXKEYS.COLLECTION.POLICY_TAGS]: OnyxTypes.PolicyTagLists;
+    [ONYXKEYS.COLLECTION.POLICY_VENDORS]: OnyxTypes.PolicyVendors;
     [ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_CATEGORIES]: OnyxTypes.RecentlyUsedCategories;
     [ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_DESTINATIONS]: OnyxTypes.RecentlyUsedCategories;
     [ONYXKEYS.COLLECTION.POLICY_HAS_CONNECTIONS_DATA_BEEN_FETCHED]: boolean;

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -143,6 +143,11 @@ const ONYX_KEY_EXPORT_RULES: Record<string, ExportRule> = {
         allowList: ['id', 'type', 'role', 'outputCurrency', 'areCategoriesEnabled', 'areTagsEnabled'],
         maskList: ['name', 'avatar'],
     },
+    // Vendor names can reveal a workspace's suppliers, so keep the collection structure but mask names in exports.
+    [ONYXKEYS.COLLECTION.POLICY_VENDORS]: {
+        allowList: ['externalID', 'enabled', 'origin'],
+        maskList: ['name'],
+    },
     [ONYXKEYS.USER_WALLET]: {
         allowList: ['currentBalance', 'availableBalance', 'tierName'],
         maskList: [],

--- a/src/types/onyx/PolicyVendor.ts
+++ b/src/types/onyx/PolicyVendor.ts
@@ -1,3 +1,5 @@
+import type {PolicyConnectionName} from './Policy';
+
 /** Record of normalized policy vendors, indexed by externalID. */
 type PolicyVendors = Record<
     string,
@@ -8,11 +10,11 @@ type PolicyVendors = Record<
         /** The accounting-system display name. */
         name: string;
 
-        /** Whether the workspace preference permits this vendor to be selected. */
+        /** Whether the policy preference permits this vendor to be selected. */
         enabled: boolean;
 
         /** The active accounting connection that supplied this vendor. */
-        origin?: string;
+        origin?: PolicyConnectionName;
     }
 >;
 

--- a/src/types/onyx/PolicyVendor.ts
+++ b/src/types/onyx/PolicyVendor.ts
@@ -1,19 +1,19 @@
-/** An imported vendor normalized by Auth from the active accounting connection. */
-type PolicyVendor = {
-    /** The vendor identifier scoped to its active accounting connection. */
-    externalID: string;
-
-    /** The accounting-system display name. */
-    name: string;
-
-    /** Whether the workspace preference permits this vendor to be selected. */
-    enabled: boolean;
-
-    /** The active accounting connection that supplied this vendor. */
-    origin?: string;
-};
-
 /** Record of normalized policy vendors, indexed by externalID. */
-type PolicyVendors = Record<string, PolicyVendor>;
+type PolicyVendors = Record<
+    string,
+    {
+        /** The vendor identifier scoped to its active accounting connection. */
+        externalID: string;
 
-export type {PolicyVendor, PolicyVendors};
+        /** The accounting-system display name. */
+        name: string;
+
+        /** Whether the workspace preference permits this vendor to be selected. */
+        enabled: boolean;
+
+        /** The active accounting connection that supplied this vendor. */
+        origin?: string;
+    }
+>;
+
+export default PolicyVendors;

--- a/src/types/onyx/PolicyVendor.ts
+++ b/src/types/onyx/PolicyVendor.ts
@@ -1,0 +1,19 @@
+/** An imported vendor normalized by Auth from the active accounting connection. */
+type PolicyVendor = {
+    /** The vendor identifier scoped to its active accounting connection. */
+    externalID: string;
+
+    /** The accounting-system display name. */
+    name: string;
+
+    /** Whether the workspace preference permits this vendor to be selected. */
+    enabled: boolean;
+
+    /** The active accounting connection that supplied this vendor. */
+    origin?: string;
+};
+
+/** Record of normalized policy vendors, indexed by externalID. */
+type PolicyVendors = Record<string, PolicyVendor>;
+
+export type {PolicyVendor, PolicyVendors};

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -133,6 +133,7 @@ import type PlaidData from './PlaidData';
 import type Policy from './Policy';
 import type {AutoReportingOffset, PolicyConnectionName, PolicyConnectionSyncProgress, PolicyReportField, TaxRate, TaxRates, TaxRatesWithDefault} from './Policy';
 import type {PolicyCategories, PolicyCategory} from './PolicyCategory';
+import type {PolicyVendor, PolicyVendors} from './PolicyVendor';
 import type {PolicyEmployeeList} from './PolicyEmployee';
 import type PolicyEmployee from './PolicyEmployee';
 import type PolicyJoinMember from './PolicyJoinMember';
@@ -304,6 +305,8 @@ export type {
     Policy,
     PolicyCategories,
     PolicyCategory,
+    PolicyVendor,
+    PolicyVendors,
     PolicyEmployee,
     PolicyEmployeeList,
     PolicyConnectionName,

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -133,12 +133,12 @@ import type PlaidData from './PlaidData';
 import type Policy from './Policy';
 import type {AutoReportingOffset, PolicyConnectionName, PolicyConnectionSyncProgress, PolicyReportField, TaxRate, TaxRates, TaxRatesWithDefault} from './Policy';
 import type {PolicyCategories, PolicyCategory} from './PolicyCategory';
-import type {PolicyVendor, PolicyVendors} from './PolicyVendor';
 import type {PolicyEmployeeList} from './PolicyEmployee';
 import type PolicyEmployee from './PolicyEmployee';
 import type PolicyJoinMember from './PolicyJoinMember';
 import type PolicyOwnershipChangeChecks from './PolicyOwnershipChangeChecks';
 import type {ParticipantsPolicyTags, PolicyTag, PolicyTagLists, PolicyTags} from './PolicyTag';
+import type PolicyVendors from './PolicyVendor';
 import type PrivatePersonalDetails from './PrivatePersonalDetails';
 import type PrivatePromoDiscount from './PrivatePromoDiscount';
 import type PrivateSubscription from './PrivateSubscription';
@@ -305,7 +305,6 @@ export type {
     Policy,
     PolicyCategories,
     PolicyCategory,
-    PolicyVendor,
     PolicyVendors,
     PolicyEmployee,
     PolicyEmployeeList,

--- a/tests/unit/ExportOnyxStateTest.ts
+++ b/tests/unit/ExportOnyxStateTest.ts
@@ -211,6 +211,30 @@ describe('maskOnyxState', () => {
         });
     });
 
+    it('should mask policy vendor names while preserving the matching fields', () => {
+        const vendorKey = `${ONYXKEYS.COLLECTION.POLICY_VENDORS}123`;
+        const externalID = 'vendor-1';
+        const input = {
+            [vendorKey]: {
+                [externalID]: {
+                    externalID,
+                    name: 'Acme Supplies',
+                    enabled: true,
+                    origin: 'quickbooksOnline',
+                },
+            },
+        };
+
+        const result = maskOnyxState(input);
+        const vendors = result[vendorKey];
+        if (!isRecord(vendors) || !isRecord(vendors[externalID])) {
+            throw new Error('Expected policy vendors record');
+        }
+
+        expect(vendors[externalID]).toMatchObject({externalID, enabled: true, origin: 'quickbooksOnline'});
+        expect(vendors[externalID].name).not.toBe('Acme Supplies');
+    });
+
     describe('full pass-through safe collection keys', () => {
         it('should pass through data as-is for safe collection keys', () => {
             const mockViolations = [


### PR DESCRIPTION
### Explanation of Change

Problem: Phase 1A publishes a generic Auth-owned `policyVendors_{policyID}` collection, but App needs a typed Onyx prefix and collection shape before its parallel vendor UI work can safely consume it.

Implementation: add the `policyVendors_` collection prefix and a `PolicyVendors` record keyed by external ID. Each entry has `externalID`, `name`, derived `enabled`, and optional `origin`; `origin` is restricted to the existing `PolicyConnectionName` union. Onyx-state exports preserve matching fields while masking vendor names.

Non-goals: no UI, actions, optimistic updates, connection-data reads, preference persistence, picker filtering, matching, violations, or lifecycle behavior. Those belong to the linked App/Phase 1B/Phase 2 work.

Related: [Auth implementation PR #24216](https://github.com/Expensify/Auth/pull/24216), [tracker #678247](https://github.com/Expensify/Expensify/issues/678247), [contract #678248](https://github.com/Expensify/Expensify/issues/678248), [Phase 1A #650596](https://github.com/Expensify/Expensify/issues/650596), [Phase 1B #670690](https://github.com/Expensify/Expensify/issues/670690), and [Phase 2 #678249](https://github.com/Expensify/Expensify/issues/678249).

### Fixed Issues

$ https://github.com/Expensify/App/issues/98355
$ https://github.com/Expensify/Expensify/issues/650596

PROPOSAL: N/A — the agreed data contract is documented in https://github.com/Expensify/Expensify/issues/678248

### Tests

1. `npm run fmt` — passed.
2. `npm run typecheck` — passed.
3. `npx jest tests/unit/ExportOnyxStateTest.ts --runInBand` — passed (30 tests).
4. `npm run lint-changed` — passed.
5. `npm run spell-changed` — passed.
6. Required App CI, including TypeScript, Jest, Oxfmt, Knip, export coverage, and the independent-approval gate — passed.

### Manual verification

1. With Auth PR #24216 deployed, inspect an App Onyx update containing `policyVendors_{policyID}`.
2. Verify TypeScript resolves the collection as a record keyed by external ID whose entries expose `externalID`, `name`, `enabled`, and an optional valid policy-connection `origin`.
3. Export Onyx state and verify vendor names are masked while `externalID`, `enabled`, and `origin` remain inspectable.
4. Verify this change alone exposes no vendor UI or mutation action.

### Offline tests

Not applicable: this PR only declares a typed server-projected collection key and makes no offline mutation.

### QA Steps

Not applicable: this is a no-UI typed Onyx contract change. Follow the manual verification after Auth PR #24216 is deployed and verify there are no JavaScript console errors.

🤖 Posted by Codex, an AI coding agent acting for @Beamanator.