### PR TITLE
feat: add require company cards toggle to rules revamp

### DIFF
--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -129,12 +129,15 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
     const areEReceiptsEnabled = policy?.eReceipts ?? false;
     const isAttendeeTrackingEnabledForPolicy = isAttendeeTrackingEnabled(policy);
 
-    // There has to be a card to require before the rule means anything, and either card product counts. Collect is the
-    // one lock reason the pre-revamp row didn't have, so it is the only one that behaves differently: it goes to the
-    // upgrade the other rules use, and drops the More features tooltip, which isn't why the row is locked there.
+    // There has to be a card to require before the rule means anything, and either card product counts. Three separate
+    // things can lock the row, so each gets the response that actually explains it: no write access opens the read-only
+    // modal, Collect opens the upgrade the other rules use, and only a missing card product earns the More features
+    // tooltip. The pre-revamp row showed that tooltip for all three, which told an auditor to enable a feature that was
+    // already on.
     const requireCompanyCardsEnabled = policy?.requireCompanyCardsEnabled ?? false;
     const areAnyCardsEnabled = !!policy?.areCompanyCardsEnabled || !!policy?.areExpensifyCardsEnabled;
     const isRequireCompanyCardsLocked = !canWriteRules || isCollect || !areAnyCardsEnabled;
+    const shouldExplainMissingCards = canWriteRules && !isCollect && !areAnyCardsEnabled;
 
     useEffect(() => {
         // The subtitle names the required tag lists, and only the Tags pages fetch them, so it would otherwise read
@@ -285,7 +288,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
                     isActive={requireCompanyCardsEnabled}
                     disabled={isRequireCompanyCardsLocked}
                     showLockIcon={isRequireCompanyCardsLocked}
-                    disabledText={isCollect ? undefined : translate('workspace.rules.individualExpenseRules.requireCompanyCardDisabledTooltip')}
+                    disabledText={shouldExplainMissingCards ? translate('workspace.rules.individualExpenseRules.requireCompanyCardDisabledTooltip') : undefined}
                     disabledAction={withReadOnlyFallback(isCollect ? navigateToRulesControlUpgrade : undefined)}
                     onToggle={() => (canWriteRules && policy ? setPolicyRequireCompanyCardsEnabled(policy, !requireCompanyCardsEnabled) : undefined)}
                     pendingAction={policy?.pendingFields?.requireCompanyCardsEnabled}

--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -7,6 +7,7 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePolicy from '@hooks/usePolicy';
+import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {
@@ -68,6 +69,8 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const policy = usePolicy(policyID);
+    // Only for the read-only modal a locked row still owes a member. `canWrite` is the `canWriteRules` prop already.
+    const {withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.RULES);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
     const icons = useMemoizedLazyExpensifyIcons(['CalendarSolid', 'Coins', 'CreditCard', 'Receipt', 'ReceiptCheck', 'Task', 'Cash', 'Users', 'Eye']);
 
@@ -126,9 +129,9 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
     const areEReceiptsEnabled = policy?.eReceipts ?? false;
     const isAttendeeTrackingEnabledForPolicy = isAttendeeTrackingEnabled(policy);
 
-    // There has to be a card to require before the rule means anything, and either card product counts. The lock has
-    // two reasons on this row, so they lead to different places: Collect goes to the upgrade the other rules use, and
-    // a Control workspace with no cards gets the tooltip pointing at More features instead.
+    // There has to be a card to require before the rule means anything, and either card product counts. Collect is the
+    // one lock reason the pre-revamp row didn't have, so it is the only one that behaves differently: it goes to the
+    // upgrade the other rules use, and drops the More features tooltip, which isn't why the row is locked there.
     const requireCompanyCardsEnabled = policy?.requireCompanyCardsEnabled ?? false;
     const areAnyCardsEnabled = !!policy?.areCompanyCardsEnabled || !!policy?.areExpensifyCardsEnabled;
     const isRequireCompanyCardsLocked = !canWriteRules || isCollect || !areAnyCardsEnabled;
@@ -282,8 +285,8 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
                     isActive={requireCompanyCardsEnabled}
                     disabled={isRequireCompanyCardsLocked}
                     showLockIcon={isRequireCompanyCardsLocked}
-                    disabledText={!isCollect && !areAnyCardsEnabled ? translate('workspace.rules.individualExpenseRules.requireCompanyCardDisabledTooltip') : undefined}
-                    disabledAction={isCollect && canWriteRules ? navigateToRulesControlUpgrade : undefined}
+                    disabledText={isCollect ? undefined : translate('workspace.rules.individualExpenseRules.requireCompanyCardDisabledTooltip')}
+                    disabledAction={withReadOnlyFallback(isCollect ? navigateToRulesControlUpgrade : undefined)}
                     onToggle={() => (canWriteRules && policy ? setPolicyRequireCompanyCardsEnabled(policy, !requireCompanyCardsEnabled) : undefined)}
                     pendingAction={policy?.pendingFields?.requireCompanyCardsEnabled}
                     rowIcon={icons.CreditCard}

--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -69,7 +69,9 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const policy = usePolicy(policyID);
-    // Only for the read-only modal a locked row still owes a member. `canWrite` is the `canWriteRules` prop already.
+    // Every toggle here owes a locked-out member the read-only modal, the way the pre-revamp section gave all four of
+    // them. Splitting this section out dropped it, so a member saw a lock with nothing explaining it. Only the modal is
+    // taken from the hook: its `canWrite` is the `canWriteRules` prop already.
     const {withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.RULES);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
     const icons = useMemoizedLazyExpensifyIcons(['CalendarSolid', 'Coins', 'CreditCard', 'Receipt', 'ReceiptCheck', 'Task', 'Cash', 'Users', 'Eye']);
@@ -303,7 +305,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
                     isActive={areEReceiptsEnabled}
                     disabled={!canWriteRules || policyCurrency !== CONST.CURRENCY.USD || isCollect}
                     showLockIcon={!canWriteRules || policyCurrency !== CONST.CURRENCY.USD || isCollect}
-                    disabledAction={isCollect && canWriteRules ? navigateToRulesControlUpgrade : undefined}
+                    disabledAction={withReadOnlyFallback(isCollect ? navigateToRulesControlUpgrade : undefined)}
                     onToggle={() => (canWriteRules ? setWorkspaceEReceiptsEnabled(policyID, !areEReceiptsEnabled, policy?.eReceipts) : undefined)}
                     pendingAction={policy?.pendingFields?.eReceipts}
                     rowIcon={icons.Receipt}
@@ -316,7 +318,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
                     isActive={isAttendeeTrackingEnabledForPolicy}
                     disabled={!canWriteRules || isCollect}
                     showLockIcon={!canWriteRules || isCollect}
-                    disabledAction={isCollect && canWriteRules ? navigateToRulesControlUpgrade : undefined}
+                    disabledAction={withReadOnlyFallback(isCollect ? navigateToRulesControlUpgrade : undefined)}
                     onToggle={() => (canWriteRules ? handleAttendeeTrackingToggle(!isAttendeeTrackingEnabledForPolicy) : undefined)}
                     pendingAction={policy?.pendingFields?.isAttendeeTrackingEnabled}
                     rowIcon={icons.Users}
@@ -324,6 +326,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
                 <PublicReceiptVisibilityToggle
                     policyID={policyID}
                     canWriteRules={canWriteRules}
+                    withReadOnlyFallback={withReadOnlyFallback}
                     rowIcon={icons.Eye}
                 />
             </View>

--- a/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSectionRevamp.tsx
@@ -9,7 +9,13 @@ import useOnyx from '@hooks/useOnyx';
 import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {getBillableExpensesPendingAction, getCashExpenseReimbursableMode, setPolicyAttendeeTrackingEnabled, setWorkspaceEReceiptsEnabled} from '@libs/actions/Policy/Policy';
+import {
+    getBillableExpensesPendingAction,
+    getCashExpenseReimbursableMode,
+    setPolicyAttendeeTrackingEnabled,
+    setPolicyRequireCompanyCardsEnabled,
+    setWorkspaceEReceiptsEnabled,
+} from '@libs/actions/Policy/Policy';
 import {openPolicyTagsPage} from '@libs/actions/Policy/Tag';
 import Navigation from '@libs/Navigation/Navigation';
 import {getTagListLabel, getTagLists, hasPerTagListRequired, isAttendeeTrackingEnabled, isCollectPolicy, isMaxExpenseAmountSet, tryNavigateToControlPolicyUpgrade} from '@libs/PolicyUtils';
@@ -63,7 +69,7 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
     const styles = useThemeStyles();
     const policy = usePolicy(policyID);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
-    const icons = useMemoizedLazyExpensifyIcons(['CalendarSolid', 'Coins', 'Receipt', 'ReceiptCheck', 'Task', 'Cash', 'Users', 'Eye']);
+    const icons = useMemoizedLazyExpensifyIcons(['CalendarSolid', 'Coins', 'CreditCard', 'Receipt', 'ReceiptCheck', 'Task', 'Cash', 'Users', 'Eye']);
 
     const policyCurrency = policy?.outputCurrency ?? CONST.CURRENCY.USD;
 
@@ -119,6 +125,13 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
 
     const areEReceiptsEnabled = policy?.eReceipts ?? false;
     const isAttendeeTrackingEnabledForPolicy = isAttendeeTrackingEnabled(policy);
+
+    // There has to be a card to require before the rule means anything, and either card product counts. The lock has
+    // two reasons on this row, so they lead to different places: Collect goes to the upgrade the other rules use, and
+    // a Control workspace with no cards gets the tooltip pointing at More features instead.
+    const requireCompanyCardsEnabled = policy?.requireCompanyCardsEnabled ?? false;
+    const areAnyCardsEnabled = !!policy?.areCompanyCardsEnabled || !!policy?.areExpensifyCardsEnabled;
+    const isRequireCompanyCardsLocked = !canWriteRules || isCollect || !areAnyCardsEnabled;
 
     useEffect(() => {
         // The subtitle names the required tag lists, and only the Tags pages fetch them, so it would otherwise read
@@ -261,6 +274,20 @@ function IndividualExpenseRulesSectionRevamp({policyID, canWriteRules}: Individu
                 {renderMenuItems(policyControlItems)}
                 <View style={[styles.sectionDividerLine, styles.mv3]} />
                 {renderMenuItems(productDefaultItems)}
+                <ToggleSettingOptionRow
+                    title={translate('workspace.rules.individualExpenseRules.requireCompanyCard')}
+                    subtitle={translate('workspace.rules.individualExpenseRules.requireCompanyCardDescription')}
+                    switchAccessibilityLabel={translate('workspace.rules.individualExpenseRules.requireCompanyCard')}
+                    wrapperStyle={[styles.pv3]}
+                    isActive={requireCompanyCardsEnabled}
+                    disabled={isRequireCompanyCardsLocked}
+                    showLockIcon={isRequireCompanyCardsLocked}
+                    disabledText={!isCollect && !areAnyCardsEnabled ? translate('workspace.rules.individualExpenseRules.requireCompanyCardDisabledTooltip') : undefined}
+                    disabledAction={isCollect && canWriteRules ? navigateToRulesControlUpgrade : undefined}
+                    onToggle={() => (canWriteRules && policy ? setPolicyRequireCompanyCardsEnabled(policy, !requireCompanyCardsEnabled) : undefined)}
+                    pendingAction={policy?.pendingFields?.requireCompanyCardsEnabled}
+                    rowIcon={icons.CreditCard}
+                />
                 <ToggleSettingOptionRow
                     title={translate('workspace.rules.individualExpenseRules.eReceipts')}
                     subtitle={translate('workspace.rules.individualExpenseRules.eReceiptsHint')}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/100218
PROPOSAL:


### Tests
1. Open a **Control** workspace and enable **Rules** and **Company cards** under *More features*.
2. Go to *Workspace settings > Rules > General* tab.
3. Verify a **Require company cards for all purchases** toggle appears with a credit card icon, directly above **eReceipts**, with the subtitle "Flag all cash spend, including mileage and per-diem expenses."
4. Verify the toggle is off and interactive (no lock icon).
5. Toggle it on. Verify it turns on with no error.
6. Refresh the page. Verify the toggle is still on.
7. Open the workspace chat. Verify a report action reads "enabled the company card purchases requirement".
8. Go back to *Rules > General* and toggle it off. Verify the workspace chat now shows "disabled the company card purchases requirement".
9. Toggle it back on, then submit a **manually created cash expense** (not a card transaction) on that workspace.
10. Open the expense. Verify a **Company card purchases required** violation shows on the expense.
11. Return to *Rules > General*, toggle the rule off, and reopen the expense. Verify the violation is gone.


**Collect workspace (upgrade path)**

1. Open a **Collect** workspace with Rules accessible and go to *Rules > General*.
2. Verify the **Require company cards for all purchases** toggle shows a lock icon and cannot be switched.
3. Tap the toggle. Verify the **Control upgrade** page opens.
4. Complete the upgrade. Verify you land back on the Rules page and the toggle is now interactive.

**Control workspace with no card product**

1. Open a Control workspace and turn **off** both **Company cards** and **Expensify Card** under *More features*.
2. Go to *Rules > General*. Verify the toggle shows a lock icon.
3. Hover the lock. Verify the tooltip reads "Enable Company cards (under More features) to unlock." and that tapping it does **not** open the upgrade page.
4. Turn **Company cards** back on. Verify the toggle becomes interactive and the tooltip is gone.

**Read-only access**
1. Sign in as a **member or auditor** of the Control workspace and open *Rules > General*.
2. Verify the toggle is locked and its value is still readable.


- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go offline. Toggle **Require company cards for all purchases**. Verify the row greys out as pending and the new value is shown.
2. Go back online. Verify the pending style clears and the value sticks.


### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/6636e876-dada-4583-8c7d-8afca4a97c45

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/user-attachments/assets/677368cf-5cb1-4482-8ec9-c48af2a9b9cd


</details>
