### PR TITLE
Fix undefined toString() calls in workspace components

### DIFF
--- a/src/components/Avatar/WorkspaceAvatar.tsx
+++ b/src/components/Avatar/WorkspaceAvatar.tsx
@@ -55,7 +55,7 @@ function WorkspaceAvatar({source, imageStyles, iconAdditionalStyles, containerSt
         );
     }
 
-    const iconColors = StyleUtils.getDefaultWorkspaceAvatarColor(avatarID.toString());
+    const iconColors = StyleUtils.getDefaultWorkspaceAvatarColor(avatarID?.toString() || '');
 
     return (
         <AvatarContainer

--- a/src/components/Tables/WorkspaceListTable/WorkspaceTableRow.tsx
+++ b/src/components/Tables/WorkspaceListTable/WorkspaceTableRow.tsx
@@ -130,7 +130,7 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
                             <WorkspaceAvatar
                                 name={item.title}
                                 source={item.icon}
-                                avatarID={item.policyID}
+                                avatarID={item.policyID || ''}
                                 size={CONST.AVATAR_SIZE.DEFAULT}
                                 imageStyles={styles.alignSelfCenter}
                             />
@@ -175,7 +175,7 @@ export default function WorkspaceRow({item, shouldUseNarrowTableLayout, rowIndex
                                 <WorkspaceAvatar
                                     name={item.title}
                                     source={item.icon}
-                                    avatarID={item.policyID}
+                                    avatarID={item.policyID || ''}
                                     size={CONST.AVATAR_SIZE.SMALL}
                                     imageStyles={styles.alignSelfCenter}
                                 />


### PR DESCRIPTION
Fixes undefined toString() calls that could cause crashes in workspace components.\n\nThis fix addresses Sentry report 7684111007.\n\nChanges:\n- Fixed undefined toString() call in WorkspaceAvatar.tsx\n- Fixed undefined toString() calls in WorkspaceTableRow.tsx\n\nThis prevents potential crashes when avatarID is undefined.