### PR TITLE
Cover both halves of a combo card duo in the Your spend card query

### DIFF
--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -142,6 +142,14 @@ type CardConnectionStatusDisplayParams = {
     policyID?: string;
 };
 
+type DisplayableExpensifyCards = {
+    /** The cards to show, with each combo card duo collapsed to its physical card. */
+    cards: Card[];
+
+    /** Every cardID that a shown card stands for, keyed by the shown cardID. A combo card lists both halves of the duo. */
+    cardIDsByCardID: Record<number, number[]>;
+};
+
 const feedNamesMapping = {
     [CONST.COMPANY_CARD.FEED_BANK_NAME.CSV]: CONST.COMPANY_CARDS.CARD_TYPE_NAMES.CSV,
     [CONST.COMPANY_CARD.FEED_BANK_NAME.VISA]: CONST.COMPANY_CARDS.CARD_TYPE_NAMES.VISA,
@@ -1966,11 +1974,11 @@ function isTravelCardTransaction(feedCountry: string | undefined, card: Card | u
  * (physical + virtual pairs) so only the physical card is shown per domain.
  *
  * @param cardList - The card list to filter
- * @returns Array of displayable Expensify cards with combo cards deduplicated by domain
+ * @returns The displayable cards with combo cards deduplicated by domain, plus the cardIDs each returned card stands for
  */
-function getDisplayableExpensifyCards(cardList: CardList | undefined): Card[] {
+function getDisplayableExpensifyCards(cardList: CardList | undefined): DisplayableExpensifyCards {
     if (!hasDisplayableAssignedCards(cardList)) {
-        return [];
+        return {cards: [], cardIDsByCardID: {}};
     }
 
     const activeCards = filterAllInactiveCards(cardList);
@@ -1986,25 +1994,37 @@ function getDisplayableExpensifyCards(cardList: CardList | undefined): Card[] {
     );
 
     const sortedCards = lodashSortBy(activeExpensifyCards, getAssignedCardSortKey);
-    const seenDomains = new Set<string>();
+    const cards: Card[] = [];
+    const cardIDsByCardID: Record<number, number[]> = {};
+    const shownCardIDByDomain = new Map<string, number>();
 
-    return sortedCards.filter((card) => {
+    for (const card of sortedCards) {
         const isAdminIssuedVirtualCard = !!card.nameValuePairs?.issuedBy && !!card.nameValuePairs?.isVirtual;
         const isComboCard = !!card.domainName && !isAdminIssuedVirtualCard;
 
         // Always show non-combo cards (admin-issued virtual or cards without domain)
         if (!isComboCard) {
-            return true;
+            cards.push(card);
+            cardIDsByCardID[card.cardID] = [card.cardID];
+            continue;
         }
 
-        // For combo cards, only show the first one per domain (physical card comes first due to sorting)
-        if (seenDomains.has(card.domainName)) {
-            return false;
+        const shownCardID = shownCardIDByDomain.get(card.domainName);
+
+        // For combo cards, only show the first one per domain (physical card comes first due to sorting).
+        // The hidden half of the duo still spends against the same limit, so record its cardID under the
+        // shown card. Callers that query transactions need both IDs to see the duo's full spend.
+        if (shownCardID !== undefined) {
+            cardIDsByCardID[shownCardID].push(card.cardID);
+            continue;
         }
 
-        seenDomains.add(card.domainName);
-        return true;
-    });
+        shownCardIDByDomain.set(card.domainName, card.cardID);
+        cards.push(card);
+        cardIDsByCardID[card.cardID] = [card.cardID];
+    }
+
+    return {cards, cardIDsByCardID};
 }
 
 /**
@@ -2294,4 +2314,4 @@ export {
     resolveTransactionCardFields,
 };
 
-export type {CompanyCardFeedIcons, CompanyCardBankIcons, CardProgramKey};
+export type {CompanyCardFeedIcons, CompanyCardBankIcons, CardProgramKey, DisplayableExpensifyCards};

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -147,7 +147,7 @@ type DisplayableExpensifyCards = {
     cards: Card[];
 
     /** Every cardID that a shown card stands for, keyed by the shown cardID. A combo card lists both halves of the duo. */
-    cardIDsByCardID: Record<number, number[]>;
+    cardIDsByShownCardID: Record<number, number[]>;
 };
 
 const feedNamesMapping = {
@@ -1978,7 +1978,7 @@ function isTravelCardTransaction(feedCountry: string | undefined, card: Card | u
  */
 function getDisplayableExpensifyCards(cardList: CardList | undefined): DisplayableExpensifyCards {
     if (!hasDisplayableAssignedCards(cardList)) {
-        return {cards: [], cardIDsByCardID: {}};
+        return {cards: [], cardIDsByShownCardID: {}};
     }
 
     const activeCards = filterAllInactiveCards(cardList);
@@ -1995,7 +1995,7 @@ function getDisplayableExpensifyCards(cardList: CardList | undefined): Displayab
 
     const sortedCards = lodashSortBy(activeExpensifyCards, getAssignedCardSortKey);
     const cards: Card[] = [];
-    const cardIDsByCardID: Record<number, number[]> = {};
+    const cardIDsByShownCardID: Record<number, number[]> = {};
     const shownCardIDByDomain = new Map<string, number>();
 
     for (const card of sortedCards) {
@@ -2005,7 +2005,7 @@ function getDisplayableExpensifyCards(cardList: CardList | undefined): Displayab
         // Always show non-combo cards (admin-issued virtual or cards without domain)
         if (!isComboCard) {
             cards.push(card);
-            cardIDsByCardID[card.cardID] = [card.cardID];
+            cardIDsByShownCardID[card.cardID] = [card.cardID];
             continue;
         }
 
@@ -2015,16 +2015,16 @@ function getDisplayableExpensifyCards(cardList: CardList | undefined): Displayab
         // The hidden half of the duo still spends against the same limit, so record its cardID under the
         // shown card. Callers that query transactions need both IDs to see the duo's full spend.
         if (shownCardID !== undefined) {
-            cardIDsByCardID[shownCardID].push(card.cardID);
+            cardIDsByShownCardID[shownCardID].push(card.cardID);
             continue;
         }
 
         shownCardIDByDomain.set(card.domainName, card.cardID);
         cards.push(card);
-        cardIDsByCardID[card.cardID] = [card.cardID];
+        cardIDsByShownCardID[card.cardID] = [card.cardID];
     }
 
-    return {cards, cardIDsByCardID};
+    return {cards, cardIDsByShownCardID};
 }
 
 /**

--- a/src/pages/home/YourSpendSection/queries.ts
+++ b/src/pages/home/YourSpendSection/queries.ts
@@ -33,11 +33,13 @@ function buildRepaidLast30DaysQuery(accountID: number): string {
     });
 }
 
-function buildRecentCardTransactionsQuery(accountID: number, cardID: number): string {
+// A combo card duo shows as one row, so the row takes every cardID it stands for and the
+// Search page it opens lists the transactions of either half of the duo.
+function buildRecentCardTransactionsQuery(accountID: number, cardIDs: number[]): string {
     return buildQueryStringFromFilterFormValues({
         type: CONST.SEARCH.DATA_TYPES.EXPENSE,
         from: [String(accountID)],
-        cardID: [String(cardID)],
+        cardID: cardIDs.map(String),
         [FILTER_KEYS.DATE_AFTER]: get30DaysAgoDateString(),
     });
 }

--- a/src/pages/home/YourSpendSection/useYourSpendData.ts
+++ b/src/pages/home/YourSpendSection/useYourSpendData.ts
@@ -420,7 +420,7 @@ function useYourSpendData(): UseYourSpendDataReturn {
 
     // Memo anchor: the compiler does not auto-cache these calls, so downstream
     // memos would invalidate every render without it.
-    const expensifyCards = useMemo(() => getDisplayableExpensifyCards(cardList), [cardList]);
+    const {cards: expensifyCards, cardIDsByCardID: expensifyCardIDsByCardID} = useMemo(() => getDisplayableExpensifyCards(cardList), [cardList]);
     const thirdPartyCards = useMemo(
         () => getDisplayableThirdPartyCards(cardList, {cardsWithBrokenFeedConnection, personalCardsWithBrokenConnection}),
         [cardList, cardsWithBrokenFeedConnection, personalCardsWithBrokenConnection],
@@ -435,14 +435,28 @@ function useYourSpendData(): UseYourSpendDataReturn {
         [expensifyCards, thirdPartyCards],
     );
 
+    // A combo card duo collapses to one row keyed by the physical card, so the row stands for both
+    // halves. Third-party cards are never part of a duo and stand only for themselves.
+    const queriedCardIDsByCardID = useMemo(
+        () =>
+            displayableCards.reduce<Record<number, number[]>>((acc, {card}) => {
+                acc[card.cardID] = expensifyCardIDsByCardID[card.cardID] ?? [card.cardID];
+                return acc;
+            }, {}),
+        [displayableCards, expensifyCardIDsByCardID],
+    );
+
     const cardGroupQueryJSON = displayableCards.length > 0 ? buildSearchQueryJSON(buildCardGroupQuery(accountID)) : undefined;
     const [cardTotalsByCardID] = useOnyx(`${ONYXKEYS.COLLECTION.SNAPSHOT}${cardGroupQueryJSON?.hash}`, {selector: getCardTotalsByCardID});
 
     const cardRows: YourSpendCardRow[] = useMemo(
         () =>
             displayableCards.reduce<YourSpendCardRow[]>((acc, {card, kind}) => {
-                const totals = cardTotalsByCardID?.[card.cardID];
-                if (!totals) {
+                // The grouped search reports one entry per cardID, so a combo card duo arrives as two
+                // entries. Add them up so the row carries the duo's whole spend and shows up when
+                // either half of the duo spent.
+                const duoTotals = queriedCardIDsByCardID[card.cardID].map((duoCardID) => cardTotalsByCardID?.[duoCardID]).filter((entry): entry is YourSpendRowTotals => !!entry);
+                if (duoTotals.length === 0) {
                     return acc;
                 }
 
@@ -462,9 +476,9 @@ function useYourSpendData(): UseYourSpendDataReturn {
                 acc.push({
                     cardID: card.cardID,
                     lastFour,
-                    query: buildRecentCardTransactionsQuery(accountID, card.cardID),
-                    total: totals.total,
-                    currency: totals.currency,
+                    query: buildRecentCardTransactionsQuery(accountID, queriedCardIDsByCardID[card.cardID]),
+                    total: duoTotals.every((entry) => entry.total === undefined) ? undefined : duoTotals.reduce((sum, entry) => sum + (entry.total ?? 0), 0),
+                    currency: duoTotals.find((entry) => !!entry.currency)?.currency,
                     spentFraction,
                     kind,
                     bank: card.bank,
@@ -473,7 +487,7 @@ function useYourSpendData(): UseYourSpendDataReturn {
                 });
                 return acc;
             }, []),
-        [displayableCards, cardTotalsByCardID, accountID],
+        [displayableCards, cardTotalsByCardID, queriedCardIDsByCardID, accountID],
     );
 
     const approvalRowStateRaw = getYourSpendRowState({isApplicable: isApprovalApplicable, isOffline, searchResults: approvalSearchResults});

--- a/src/pages/home/YourSpendSection/useYourSpendData.ts
+++ b/src/pages/home/YourSpendSection/useYourSpendData.ts
@@ -420,7 +420,7 @@ function useYourSpendData(): UseYourSpendDataReturn {
 
     // Memo anchor: the compiler does not auto-cache these calls, so downstream
     // memos would invalidate every render without it.
-    const {cards: expensifyCards, cardIDsByCardID: expensifyCardIDsByCardID} = useMemo(() => getDisplayableExpensifyCards(cardList), [cardList]);
+    const {cards: expensifyCards, cardIDsByShownCardID: expensifyCardIDsByShownCardID} = useMemo(() => getDisplayableExpensifyCards(cardList), [cardList]);
     const thirdPartyCards = useMemo(
         () => getDisplayableThirdPartyCards(cardList, {cardsWithBrokenFeedConnection, personalCardsWithBrokenConnection}),
         [cardList, cardsWithBrokenFeedConnection, personalCardsWithBrokenConnection],
@@ -435,27 +435,20 @@ function useYourSpendData(): UseYourSpendDataReturn {
         [expensifyCards, thirdPartyCards],
     );
 
-    // A combo card duo collapses to one row keyed by the physical card, so the row stands for both
-    // halves. Third-party cards are never part of a duo and stand only for themselves.
-    const queriedCardIDsByCardID = useMemo(
-        () =>
-            displayableCards.reduce<Record<number, number[]>>((acc, {card}) => {
-                acc[card.cardID] = expensifyCardIDsByCardID[card.cardID] ?? [card.cardID];
-                return acc;
-            }, {}),
-        [displayableCards, expensifyCardIDsByCardID],
-    );
-
     const cardGroupQueryJSON = displayableCards.length > 0 ? buildSearchQueryJSON(buildCardGroupQuery(accountID)) : undefined;
     const [cardTotalsByCardID] = useOnyx(`${ONYXKEYS.COLLECTION.SNAPSHOT}${cardGroupQueryJSON?.hash}`, {selector: getCardTotalsByCardID});
 
     const cardRows: YourSpendCardRow[] = useMemo(
         () =>
             displayableCards.reduce<YourSpendCardRow[]>((acc, {card, kind}) => {
+                // A combo card duo collapses to one row keyed by the physical card, so the row stands
+                // for both halves. Third-party cards are never part of a duo and stand only for themselves.
+                const queriedCardIDs = expensifyCardIDsByShownCardID[card.cardID] ?? [card.cardID];
+
                 // The grouped search reports one entry per cardID, so a combo card duo arrives as two
                 // entries. Add them up so the row carries the duo's whole spend and shows up when
                 // either half of the duo spent.
-                const duoTotals = queriedCardIDsByCardID[card.cardID].map((duoCardID) => cardTotalsByCardID?.[duoCardID]).filter((entry): entry is YourSpendRowTotals => !!entry);
+                const duoTotals = queriedCardIDs.map((duoCardID) => cardTotalsByCardID?.[duoCardID]).filter((entry): entry is YourSpendRowTotals => !!entry);
                 if (duoTotals.length === 0) {
                     return acc;
                 }
@@ -476,8 +469,10 @@ function useYourSpendData(): UseYourSpendDataReturn {
                 acc.push({
                     cardID: card.cardID,
                     lastFour,
-                    query: buildRecentCardTransactionsQuery(accountID, queriedCardIDsByCardID[card.cardID]),
+                    query: buildRecentCardTransactionsQuery(accountID, queriedCardIDs),
                     total: duoTotals.every((entry) => entry.total === undefined) ? undefined : duoTotals.reduce((sum, entry) => sum + (entry.total ?? 0), 0),
+                    // Both halves of a duo are issued against the same fund and card program, so they
+                    // always report the same currency and the summed total above stays meaningful.
                     currency: duoTotals.find((entry) => !!entry.currency)?.currency,
                     spentFraction,
                     kind,
@@ -487,7 +482,7 @@ function useYourSpendData(): UseYourSpendDataReturn {
                 });
                 return acc;
             }, []),
-        [displayableCards, cardTotalsByCardID, queriedCardIDsByCardID, accountID],
+        [displayableCards, cardTotalsByCardID, expensifyCardIDsByShownCardID, accountID],
     );
 
     const approvalRowStateRaw = getYourSpendRowState({isApplicable: isApprovalApplicable, isOffline, searchResults: approvalSearchResults});

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -2634,7 +2634,7 @@ describe('CardUtils', () => {
 
     describe('getDisplayableExpensifyCards', () => {
         it('should return empty array when cardList is undefined', () => {
-            const result = getDisplayableExpensifyCards(undefined);
+            const {cards: result} = getDisplayableExpensifyCards(undefined);
             expect(result).toEqual([]);
         });
 
@@ -2653,7 +2653,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.CLOSED,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toEqual([]);
         });
 
@@ -2684,7 +2684,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.CLOSED,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(1);
         });
@@ -2716,7 +2716,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.OPEN,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(1);
         });
@@ -2736,7 +2736,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.OPEN,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toEqual([]);
         });
 
@@ -2775,10 +2775,264 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(18468850); // Physical card comes first
             expect(result.at(0)?.nameValuePairs?.isVirtual).toBeFalsy();
+        });
+
+        it('should map a combo card to both halves of the duo', () => {
+            const cardList = createMock<CardList>({
+                1: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468850,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '7428',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+                2: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468851,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '4592',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: true,
+                    },
+                },
+            });
+            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByCardID).toEqual({18468850: [18468850, 18468851]});
+        });
+
+        it('should map a card that is not part of a combo duo to itself only', () => {
+            const cardList = createMock<CardList>({
+                1: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468850,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '7428',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+                2: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468852,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '1111',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: true,
+                        issuedBy: 10160772,
+                    },
+                },
+            });
+            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByCardID).toEqual({18468850: [18468850], 18468852: [18468852]});
+        });
+
+        it('maps a combo card to both halves regardless of the order the card list lists them in', () => {
+            const cardList = createMock<CardList>({
+                1: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468851,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '4592',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: true,
+                    },
+                },
+                2: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468850,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '7428',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+            });
+            const {cards, cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cards).toHaveLength(1);
+            expect(cards.at(0)?.cardID).toBe(18468850);
+            expect(cardIDsByCardID).toEqual({18468850: [18468850, 18468851]});
+        });
+
+        it('leaves a filtered-out half of the duo out of the mapping', () => {
+            const cardList = createMock<CardList>({
+                1: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468850,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '7428',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+                2: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468851,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '4592',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.CLOSED,
+                    nameValuePairs: {
+                        isVirtual: true,
+                    },
+                },
+            });
+            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByCardID).toEqual({18468850: [18468850]});
+        });
+
+        it('keeps the duos of two domains apart', () => {
+            const cardList = createMock<CardList>({
+                1: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 1,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '7428',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+                2: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 2,
+                    cardName: 'Expensify Card',
+                    domainName: 'expensify.com',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '4592',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: true,
+                    },
+                },
+                3: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 3,
+                    cardName: 'Expensify Card',
+                    domainName: 'other.com',
+                    fraud: 'none',
+                    fundID: '767579',
+                    lastFourPAN: '1111',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+                4: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 4,
+                    cardName: 'Expensify Card',
+                    domainName: 'other.com',
+                    fraud: 'none',
+                    fundID: '767579',
+                    lastFourPAN: '2222',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: true,
+                    },
+                },
+            });
+            const {cards, cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cards).toHaveLength(2);
+            expect(cardIDsByCardID).toEqual({1: [1, 2], 3: [3, 4]});
+        });
+
+        it('maps a card without a domainName to itself only', () => {
+            const cardList = createMock<CardList>({
+                1: {
+                    accountID: 10160771,
+                    bank: CONST.EXPENSIFY_CARD.BANK,
+                    cardID: 18468850,
+                    cardName: 'Expensify Card',
+                    domainName: '',
+                    fraud: 'none',
+                    fundID: '767578',
+                    lastFourPAN: '7428',
+                    lastScrape: '',
+                    lastUpdated: '',
+                    state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+                    nameValuePairs: {
+                        isVirtual: false,
+                    },
+                },
+            });
+            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByCardID).toEqual({18468850: [18468850]});
         });
 
         it('should show admin-issued virtual cards separately', () => {
@@ -2817,7 +3071,7 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(2); // Both cards shown (admin-issued virtual is not grouped)
         });
 
@@ -2857,7 +3111,7 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(18468850);
         });
@@ -2897,7 +3151,7 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(2); // Cards from different domains shown separately
         });
 
@@ -2936,7 +3190,7 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(18468850); // Physical card comes first even if virtual was added first
         });
@@ -2977,7 +3231,7 @@ describe('CardUtils', () => {
                 },
             });
 
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(2);
         });
@@ -2997,7 +3251,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.STATE_NOT_ISSUED,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toEqual([]);
         });
 
@@ -3016,7 +3270,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.NOT_ACTIVATED,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toEqual([]);
         });
 
@@ -3035,7 +3289,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.OPEN,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toHaveLength(1);
             expect(result.at(0)?.cardID).toBe(1);
         });
@@ -3055,7 +3309,7 @@ describe('CardUtils', () => {
                     state: CONST.EXPENSIFY_CARD.STATE.STATE_DEACTIVATED,
                 },
             };
-            const result = getDisplayableExpensifyCards(cardList);
+            const {cards: result} = getDisplayableExpensifyCards(cardList);
             expect(result).toEqual([]);
         });
     });

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -2816,8 +2816,8 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
-            expect(cardIDsByCardID).toEqual({18468850: [18468850, 18468851]});
+            const {cardIDsByShownCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByShownCardID).toEqual({18468850: [18468850, 18468851]});
         });
 
         it('should map a card that is not part of a combo duo to itself only', () => {
@@ -2856,8 +2856,8 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
-            expect(cardIDsByCardID).toEqual({18468850: [18468850], 18468852: [18468852]});
+            const {cardIDsByShownCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByShownCardID).toEqual({18468850: [18468850], 18468852: [18468852]});
         });
 
         it('maps a combo card to both halves regardless of the order the card list lists them in', () => {
@@ -2895,10 +2895,10 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const {cards, cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            const {cards, cardIDsByShownCardID} = getDisplayableExpensifyCards(cardList);
             expect(cards).toHaveLength(1);
             expect(cards.at(0)?.cardID).toBe(18468850);
-            expect(cardIDsByCardID).toEqual({18468850: [18468850, 18468851]});
+            expect(cardIDsByShownCardID).toEqual({18468850: [18468850, 18468851]});
         });
 
         it('leaves a filtered-out half of the duo out of the mapping', () => {
@@ -2936,8 +2936,8 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
-            expect(cardIDsByCardID).toEqual({18468850: [18468850]});
+            const {cardIDsByShownCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByShownCardID).toEqual({18468850: [18468850]});
         });
 
         it('keeps the duos of two domains apart', () => {
@@ -3007,9 +3007,9 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const {cards, cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
+            const {cards, cardIDsByShownCardID} = getDisplayableExpensifyCards(cardList);
             expect(cards).toHaveLength(2);
-            expect(cardIDsByCardID).toEqual({1: [1, 2], 3: [3, 4]});
+            expect(cardIDsByShownCardID).toEqual({1: [1, 2], 3: [3, 4]});
         });
 
         it('maps a card without a domainName to itself only', () => {
@@ -3031,8 +3031,8 @@ describe('CardUtils', () => {
                     },
                 },
             });
-            const {cardIDsByCardID} = getDisplayableExpensifyCards(cardList);
-            expect(cardIDsByCardID).toEqual({18468850: [18468850]});
+            const {cardIDsByShownCardID} = getDisplayableExpensifyCards(cardList);
+            expect(cardIDsByShownCardID).toEqual({18468850: [18468850]});
         });
 
         it('should show admin-issued virtual cards separately', () => {

--- a/tests/unit/HomePage/YourSpendSection/YourSpendSectionTest.tsx
+++ b/tests/unit/HomePage/YourSpendSection/YourSpendSectionTest.tsx
@@ -72,13 +72,15 @@ jest.mock('@libs/CardUtils', () => {
     const actual: typeof CardUtils = jest.requireActual('@libs/CardUtils');
     return {
         ...actual,
-        getDisplayableExpensifyCards: jest.fn(() => ({
-            cards: [
+        getDisplayableExpensifyCards: jest.fn(() => {
+            const cards = [
                 {cardID: 1, lastFourPAN: '1234', nameValuePairs: {}},
                 {cardID: 2, lastFourPAN: '5678', nameValuePairs: {}},
-            ],
-            cardIDsByCardID: {1: [1], 2: [2]},
-        })),
+            ];
+
+            // Neither stub card is half of a combo duo, so each one stands only for itself.
+            return {cards, cardIDsByCardID: Object.fromEntries(cards.map(({cardID}) => [cardID, [cardID]]))};
+        }),
         getDisplayableThirdPartyCards: jest.fn(() => []),
         getCardDescription: jest.fn(() => 'Card description'),
     };

--- a/tests/unit/HomePage/YourSpendSection/YourSpendSectionTest.tsx
+++ b/tests/unit/HomePage/YourSpendSection/YourSpendSectionTest.tsx
@@ -72,10 +72,13 @@ jest.mock('@libs/CardUtils', () => {
     const actual: typeof CardUtils = jest.requireActual('@libs/CardUtils');
     return {
         ...actual,
-        getDisplayableExpensifyCards: jest.fn(() => [
-            {cardID: 1, lastFourPAN: '1234', nameValuePairs: {}},
-            {cardID: 2, lastFourPAN: '5678', nameValuePairs: {}},
-        ]),
+        getDisplayableExpensifyCards: jest.fn(() => ({
+            cards: [
+                {cardID: 1, lastFourPAN: '1234', nameValuePairs: {}},
+                {cardID: 2, lastFourPAN: '5678', nameValuePairs: {}},
+            ],
+            cardIDsByCardID: {1: [1], 2: [2]},
+        })),
         getDisplayableThirdPartyCards: jest.fn(() => []),
         getCardDescription: jest.fn(() => 'Card description'),
     };

--- a/tests/unit/HomePage/YourSpendSection/YourSpendSectionTest.tsx
+++ b/tests/unit/HomePage/YourSpendSection/YourSpendSectionTest.tsx
@@ -79,7 +79,7 @@ jest.mock('@libs/CardUtils', () => {
             ];
 
             // Neither stub card is half of a combo duo, so each one stands only for itself.
-            return {cards, cardIDsByCardID: Object.fromEntries(cards.map(({cardID}) => [cardID, [cardID]]))};
+            return {cards, cardIDsByShownCardID: Object.fromEntries(cards.map(({cardID}) => [cardID, [cardID]]))};
         }),
         getDisplayableThirdPartyCards: jest.fn(() => []),
         getCardDescription: jest.fn(() => 'Card description'),

--- a/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
+++ b/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
@@ -98,7 +98,7 @@ jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
 
 jest.mock('@libs/CardUtils', () => ({
     ...jest.requireActual<Record<string, unknown>>('@libs/CardUtils'),
-    getDisplayableExpensifyCards: jest.fn(() => ({cards: [], cardIDsByCardID: {}})),
+    getDisplayableExpensifyCards: jest.fn(() => ({cards: [], cardIDsByShownCardID: {}})),
     getDisplayableThirdPartyCards: jest.fn(() => []),
 }));
 
@@ -255,7 +255,7 @@ function networkState(isOffline: boolean): ReturnType<typeof useNetwork> {
 function makeDisplayableCards(cards: Array<{cardID: number; lastFourPAN: string; comboCardIDs?: number[]}>): DisplayableExpensifyCards {
     return {
         cards: cards.map(({cardID, lastFourPAN}) => createMock<Card>({cardID, lastFourPAN})),
-        cardIDsByCardID: cards.reduce<Record<number, number[]>>((acc, {cardID, comboCardIDs}) => {
+        cardIDsByShownCardID: cards.reduce<Record<number, number[]>>((acc, {cardID, comboCardIDs}) => {
             acc[cardID] = comboCardIDs ?? [cardID];
             return acc;
         }, {}),
@@ -290,7 +290,7 @@ beforeEach(() => {
 
     mockedUseNetwork.mockReturnValue(networkState(false));
     mockedUseCurrentUserPersonalDetails.mockReturnValue({accountID: ACCOUNT_ID, login: `${ACCOUNT_ID}@test.com`} as CurrentUserPersonalDetails);
-    mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByCardID: {}});
+    mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByShownCardID: {}});
     mockedGetDisplayableThirdPartyCards.mockReturnValue([]);
     mockedIsPaidGroupPolicy.mockReturnValue(false);
 
@@ -399,7 +399,7 @@ describe('useYourSpendData — paymentRowState', () => {
 
 describe('useYourSpendData — cardRows', () => {
     it('returns an empty array when there are no displayable cards', () => {
-        mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByCardID: {}});
+        mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByShownCardID: {}});
         const {result} = renderHook(() => useYourSpendData());
         expect(result.current.cardRows).toEqual([]);
     });
@@ -620,7 +620,7 @@ describe('useYourSpendData — search dispatch', () => {
     it('fires no card search when the account has no displayable cards', () => {
         // Given an account with no displayable cards and no paid group workspace
         mockedIsPaidGroupPolicy.mockReturnValue(false);
-        mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByCardID: {}});
+        mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByShownCardID: {}});
         mockedGetDisplayableThirdPartyCards.mockReturnValue([]);
 
         // When Home renders focused and online

--- a/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
+++ b/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
@@ -495,9 +495,7 @@ describe('useYourSpendData — cardRows', () => {
 
         const {result} = renderHook(() => useYourSpendData());
 
-        expect(result.current.cardRows).toEqual([
-            expect.objectContaining({cardID: CARD_ID_1, lastFour: CARD_LAST_FOUR_1, total: 1500, currency: 'USD', query: CARD_QUERY_1}),
-        ]);
+        expect(result.current.cardRows).toEqual([expect.objectContaining({cardID: CARD_ID_1, lastFour: CARD_LAST_FOUR_1, total: 1500, currency: 'USD', query: CARD_QUERY_1})]);
     });
 
     it('shows the combo card row when only the virtual half of the duo has spend', () => {

--- a/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
+++ b/tests/unit/HomePage/YourSpendSection/useYourSpendDataTest.ts
@@ -21,6 +21,7 @@ import useNetwork from '@hooks/useNetwork';
 
 import {search} from '@libs/actions/Search';
 import {WRITE_COMMANDS} from '@libs/API/types';
+import type {DisplayableExpensifyCards} from '@libs/CardUtils';
 import {getDisplayableExpensifyCards, getDisplayableThirdPartyCards} from '@libs/CardUtils';
 import {isPaidGroupPolicy} from '@libs/PolicyUtils';
 import {buildSearchQueryJSON} from '@libs/SearchQueryUtils';
@@ -97,7 +98,7 @@ jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
 
 jest.mock('@libs/CardUtils', () => ({
     ...jest.requireActual<Record<string, unknown>>('@libs/CardUtils'),
-    getDisplayableExpensifyCards: jest.fn(() => []),
+    getDisplayableExpensifyCards: jest.fn(() => ({cards: [], cardIDsByCardID: {}})),
     getDisplayableThirdPartyCards: jest.fn(() => []),
 }));
 
@@ -250,9 +251,15 @@ function networkState(isOffline: boolean): ReturnType<typeof useNetwork> {
     return {isOffline};
 }
 
-/** Builds a `Card[]` payload for `getDisplayableExpensifyCards.mockReturnValue`. */
-function makeDisplayableCards(cards: Array<{cardID: number; lastFourPAN: string}>): Card[] {
-    return cards.map((card) => createMock<Card>(card));
+/** Builds a `DisplayableExpensifyCards` payload for `getDisplayableExpensifyCards.mockReturnValue`. */
+function makeDisplayableCards(cards: Array<{cardID: number; lastFourPAN: string; comboCardIDs?: number[]}>): DisplayableExpensifyCards {
+    return {
+        cards: cards.map(({cardID, lastFourPAN}) => createMock<Card>({cardID, lastFourPAN})),
+        cardIDsByCardID: cards.reduce<Record<number, number[]>>((acc, {cardID, comboCardIDs}) => {
+            acc[cardID] = comboCardIDs ?? [cardID];
+            return acc;
+        }, {}),
+    };
 }
 
 // Common beforeEach
@@ -266,8 +273,8 @@ beforeEach(() => {
 
     mockedBuildAwaitingApprovalQuery.mockReturnValue(APPROVAL_QUERY);
     mockedBuildRepaidLast30DaysQuery.mockReturnValue(PAYMENT_QUERY);
-    mockedBuildRecentCardTransactionsQuery.mockImplementation((_accountID: number, cardID: number) => {
-        switch (cardID) {
+    mockedBuildRecentCardTransactionsQuery.mockImplementation((_accountID: number, cardIDs: number[]) => {
+        switch (cardIDs.at(0)) {
             case CARD_ID_1:
                 return CARD_QUERY_1;
             case CARD_ID_2:
@@ -283,7 +290,7 @@ beforeEach(() => {
 
     mockedUseNetwork.mockReturnValue(networkState(false));
     mockedUseCurrentUserPersonalDetails.mockReturnValue({accountID: ACCOUNT_ID, login: `${ACCOUNT_ID}@test.com`} as CurrentUserPersonalDetails);
-    mockedGetDisplayableExpensifyCards.mockReturnValue([]);
+    mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByCardID: {}});
     mockedGetDisplayableThirdPartyCards.mockReturnValue([]);
     mockedIsPaidGroupPolicy.mockReturnValue(false);
 
@@ -392,7 +399,7 @@ describe('useYourSpendData — paymentRowState', () => {
 
 describe('useYourSpendData — cardRows', () => {
     it('returns an empty array when there are no displayable cards', () => {
-        mockedGetDisplayableExpensifyCards.mockReturnValue([]);
+        mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByCardID: {}});
         const {result} = renderHook(() => useYourSpendData());
         expect(result.current.cardRows).toEqual([]);
     });
@@ -478,6 +485,39 @@ describe('useYourSpendData — cardRows', () => {
             expect.objectContaining({cardID: CARD_ID_2, total: 700, currency: 'USD', query: CARD_QUERY_2}),
         ]);
     });
+
+    it('sums both halves of a combo card duo into the single row', () => {
+        mockedGetDisplayableExpensifyCards.mockReturnValue(makeDisplayableCards([{cardID: CARD_ID_1, lastFourPAN: CARD_LAST_FOUR_1, comboCardIDs: [CARD_ID_1, CARD_ID_2]}]));
+        setupCardGroups([
+            {cardID: CARD_ID_1, count: 3, total: 1000, currency: 'USD'},
+            {cardID: CARD_ID_2, count: 2, total: 500, currency: 'USD'},
+        ]);
+
+        const {result} = renderHook(() => useYourSpendData());
+
+        expect(result.current.cardRows).toEqual([
+            expect.objectContaining({cardID: CARD_ID_1, lastFour: CARD_LAST_FOUR_1, total: 1500, currency: 'USD', query: CARD_QUERY_1}),
+        ]);
+    });
+
+    it('shows the combo card row when only the virtual half of the duo has spend', () => {
+        // The row is keyed by the physical card, so its own cardID has no group at all here.
+        mockedGetDisplayableExpensifyCards.mockReturnValue(makeDisplayableCards([{cardID: CARD_ID_1, lastFourPAN: CARD_LAST_FOUR_1, comboCardIDs: [CARD_ID_1, CARD_ID_2]}]));
+        setupCardGroups([{cardID: CARD_ID_2, count: 2, total: 500, currency: 'USD'}]);
+
+        const {result} = renderHook(() => useYourSpendData());
+
+        expect(result.current.cardRows).toEqual([expect.objectContaining({cardID: CARD_ID_1, total: 500, currency: 'USD'})]);
+    });
+
+    it('excludes a combo card duo when neither half has a group', () => {
+        mockedGetDisplayableExpensifyCards.mockReturnValue(makeDisplayableCards([{cardID: CARD_ID_1, lastFourPAN: CARD_LAST_FOUR_1, comboCardIDs: [CARD_ID_1, CARD_ID_2]}]));
+        setupCardGroups([]);
+
+        const {result} = renderHook(() => useYourSpendData());
+
+        expect(result.current.cardRows).toHaveLength(0);
+    });
 });
 
 // query builder integration
@@ -515,7 +555,13 @@ describe('useYourSpendData — query builder integration', () => {
     it('calls buildRecentCardTransactionsQuery with accountID and the card cardID', () => {
         mockedGetDisplayableExpensifyCards.mockReturnValue(makeDisplayableCards([{cardID: CARD_ID_1, lastFourPAN: CARD_LAST_FOUR_1}]));
         renderHook(() => useYourSpendData());
-        expect(buildRecentCardTransactionsQuery).toHaveBeenCalledWith(ACCOUNT_ID, CARD_ID_1);
+        expect(buildRecentCardTransactionsQuery).toHaveBeenCalledWith(ACCOUNT_ID, [CARD_ID_1]);
+    });
+
+    it('calls buildRecentCardTransactionsQuery with both cardIDs of a combo card duo', () => {
+        mockedGetDisplayableExpensifyCards.mockReturnValue(makeDisplayableCards([{cardID: CARD_ID_1, lastFourPAN: CARD_LAST_FOUR_1, comboCardIDs: [CARD_ID_1, CARD_ID_2]}]));
+        renderHook(() => useYourSpendData());
+        expect(buildRecentCardTransactionsQuery).toHaveBeenCalledWith(ACCOUNT_ID, [CARD_ID_1, CARD_ID_2]);
     });
 
     it('exposes awaitingApprovalQuery from the builder return value', () => {
@@ -576,7 +622,7 @@ describe('useYourSpendData — search dispatch', () => {
     it('fires no card search when the account has no displayable cards', () => {
         // Given an account with no displayable cards and no paid group workspace
         mockedIsPaidGroupPolicy.mockReturnValue(false);
-        mockedGetDisplayableExpensifyCards.mockReturnValue([]);
+        mockedGetDisplayableExpensifyCards.mockReturnValue({cards: [], cardIDsByCardID: {}});
         mockedGetDisplayableThirdPartyCards.mockReturnValue([]);
 
         // When Home renders focused and online

--- a/tests/unit/Search/yourSpendQueryBuildersTest.ts
+++ b/tests/unit/Search/yourSpendQueryBuildersTest.ts
@@ -13,6 +13,7 @@ import {buildSearchQueryJSON, getFilterFromQuery} from '@src/libs/SearchQueryUti
 
 const ACCOUNT_ID = 12345;
 const CARD_ID = 67890;
+const SECOND_CARD_ID = 67891;
 
 // Helpers
 
@@ -169,7 +170,7 @@ describe('buildRecentCardTransactionsQuery', () => {
     let queryString: string;
 
     beforeEach(() => {
-        queryString = buildRecentCardTransactionsQuery(ACCOUNT_ID, CARD_ID);
+        queryString = buildRecentCardTransactionsQuery(ACCOUNT_ID, [CARD_ID]);
     });
 
     it('returns a non-empty query string', () => {
@@ -212,6 +213,34 @@ describe('buildRecentCardTransactionsQuery', () => {
         const diffDays = (today.getTime() - parsedDate.getTime()) / (1000 * 60 * 60 * 24);
         expect(diffDays).toBeGreaterThanOrEqual(29);
         expect(diffDays).toBeLessThanOrEqual(31);
+    });
+
+    it('includes every cardID of a combo card duo', () => {
+        const comboQueryString = buildRecentCardTransactionsQuery(ACCOUNT_ID, [CARD_ID, SECOND_CARD_ID]);
+        const cardFilters = getRawFiltersForKey(comboQueryString, CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID);
+        const values = cardFilters.flatMap((f) => (Array.isArray(f.value) ? f.value : [f.value]));
+        expect(values).toContain(String(CARD_ID));
+        expect(values).toContain(String(SECOND_CARD_ID));
+    });
+
+    it('joins a combo card duo into a single comma-separated card filter', () => {
+        const comboQueryString = buildRecentCardTransactionsQuery(ACCOUNT_ID, [CARD_ID, SECOND_CARD_ID]);
+        expect(comboQueryString).toContain(`${CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID}:${CARD_ID},${SECOND_CARD_ID}`);
+    });
+
+    it('emits a single cardID without a comma', () => {
+        expect(queryString).toContain(`${CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID}:${CARD_ID}`);
+        expect(queryString).not.toContain(`${CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID}:${CARD_ID},`);
+    });
+
+    it('keeps the other filters intact for a combo card duo', () => {
+        const comboQueryString = buildRecentCardTransactionsQuery(ACCOUNT_ID, [CARD_ID, SECOND_CARD_ID]);
+        const queryJSON = buildSearchQueryJSON(comboQueryString);
+        expect(queryJSON?.type).toBe(CONST.SEARCH.DATA_TYPES.EXPENSE);
+        expect(comboQueryString).toMatch(/date>[0-9]{4}-[0-9]{2}-[0-9]{2}/);
+        const fromFilters = getRawFiltersForKey(comboQueryString, CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM);
+        const fromValues = fromFilters.flatMap((f) => (Array.isArray(f.value) ? f.value : [f.value]));
+        expect(fromValues).toContain(String(ACCOUNT_ID));
     });
 });
 


### PR DESCRIPTION
### Explanation of Change

The `Your spend` widget hid an Expensify Card row whenever the card's recent spend sat on the virtual half of a combo card duo.

A combo card is a physical + virtual pair on one domain, and `getDisplayableExpensifyCards` collapses the duo to a single row keyed by the physical card. Card totals come from one grouped search, `buildCardGroupQuery`, which reports one entry per cardID. The row looked its total up under the physical cardID alone, so when only the virtual half had spent, the row found no entry and was dropped.

The dedupe loop already knew which half it was hiding, so it now records that cardID under the shown card instead of discarding it:

- `getDisplayableExpensifyCards` returns `{cards, cardIDsByShownCardID}`. The map holds every cardID a shown card stands for, which is both halves for a combo card and just itself for anything else. Keeping the grouping in the same loop as the dedupe means the two rules cannot drift apart.
- `useYourSpendData` collects the grouped entries for every cardID the row stands for and adds them up, so the row appears when either half has spend and its total covers the whole duo. This is the visibility fix.
- `buildRecentCardTransactionsQuery` takes `cardIDs: number[]`, so the Search page the row links to lists the transactions of both halves. Multiple values serialize as `card:a,b`, which the Search filter treats as OR. This is a second, separate improvement — the link query never gated whether the row showed.

Third-party cards are never part of a duo and stand only for themselves.

The row still shows the physical card's last four, and `spentFraction` still reads the physical card's `availableSpend`. Both are unchanged and out of scope here.

### Fixed Issues
$ https://github.com/Expensify/App/issues/100272
PROPOSAL:

### Tests

1. Sign in as a user with an Expensify combo card, meaning a physical and a virtual card on the same domain.
2. Make sure the account has at least one expense in the last 30 days made on the **virtual** half of the duo, and none on the physical half.
3. Open the home page and find the `Your spend` widget.
4. Verify a card row appears for the card, labelled `Recent transactions • <last four of the physical card>`.
5. Verify the row's amount matches the total of the last 30 days of expenses across both halves of the duo.
6. Tap the row and verify the Search page opens with a `card:` filter listing both cards of the duo, and that the results include the virtual card's expenses.
7. Add an expense on the physical half of the duo, return to the home page, and verify the row's total grows to include it.
8. Sign in as a user with a single Expensify Card that is not part of a duo, and verify its row still appears with its own transactions only.
9. Sign in as a user with a third-party company card, and verify its row still appears with its own transactions only.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Open the home page while online and let the `Your spend` widget load the combo card row.
2. Turn off the network connection.
3. Verify the card row stays visible with the total it last loaded, and does not flip to a skeleton or disappear.
4. Turn the network connection back on and verify the row refreshes without flicker.

### QA Steps

1. Sign in as a user with an Expensify combo card, meaning a physical and a virtual card on the same domain.
2. Make sure the account has at least one expense in the last 30 days made on the **virtual** half of the duo, and none on the physical half.
3. Open the home page and find the `Your spend` widget.
4. Verify a card row appears for the card, labelled `Recent transactions • <last four of the physical card>`.
5. Verify the row's amount matches the total of the last 30 days of expenses across both halves of the duo.
6. Tap the row and verify the Search page opens and its results include the virtual card's expenses.
7. Sign in as a user with a single Expensify Card that is not part of a duo, and verify its row still appears with its own transactions only.
8. Sign in as a user with a third-party company card, and verify its row still appears with its own transactions only.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not yet tested — needs manual QA.

</details>