### PR TITLE
[No QA] Ignore the Convert script's duplicate-key IndexedDB rejection in Sentry

### DIFF
--- a/src/setup/telemetry/setupSentry.ts
+++ b/src/setup/telemetry/setupSentry.ts
@@ -64,6 +64,10 @@ function setupSentry(): void {
             // They carry no stack frames for thirdPartyErrorFilterIntegration to tag; the prefix limits this to the
             // browser SDK's rejection wording, so a real Error carrying the same text still reports.
             /^Non-Error promise rejection captured with value: No data found for key/,
+            // Uncaught IndexedDB rejection from the same Convert script, which inserts into its own database with
+            // `add()` instead of `put()` and fails whenever the key is already there. Onyx never calls `add()`, so a
+            // real Onyx write cannot produce this, and the DOMException carries no frames to tag as third-party.
+            /^ConstraintError: Key already exists in the object store/,
         ],
         denyUrls: EXTENSION_DENY_URLS,
         beforeSendTransaction: processBeforeSendTransactions,

--- a/tests/unit/setupSentryTest.ts
+++ b/tests/unit/setupSentryTest.ts
@@ -43,4 +43,31 @@ describe('setupSentry', () => {
     it('keeps a thrown Error carrying the same text, which unlike a bare rejection has a stack to act on', () => {
         expect(isIgnored('No data found for key reportActions_123')).toBe(false);
     });
+
+    it('drops the ConstraintError the Convert Experiments script emits when it re-inserts an existing key', () => {
+        // Given the message Sentry builds from a DOMException, as `type: value`
+        const message = 'ConstraintError: Key already exists in the object store.';
+
+        // When the registered patterns are matched against it
+        // Then it is ignored, because only `add()` produces it and Onyx never calls `add()`
+        expect(isIgnored(message)).toBe(true);
+    });
+
+    it('keeps the other IndexedDB failures Onyx reports, so a real storage problem still surfaces', () => {
+        // Given a storage error Onyx does raise on its own write path
+        const message = 'AbortError: IDB write transaction aborted without an error';
+
+        // When the registered patterns are matched against it
+        // Then it still reports
+        expect(isIgnored(message)).toBe(false);
+    });
+
+    it('keeps a ConstraintError with different wording, which does not come from that third-party insert', () => {
+        // Given a ConstraintError about a unique index rather than a duplicate key
+        const message = "ConstraintError: Unable to add key to index 'byName': at least one key does not satisfy the uniqueness requirements.";
+
+        // When the registered patterns are matched against it
+        // Then it still reports
+        expect(isIgnored(message)).toBe(false);
+    });
 });


### PR DESCRIPTION
### Explanation of Change

`ConstraintError: Key already exists in the object store.` is one of the top unhandled crashes in our Sentry project ([APP-E0](https://expensify.sentry.io/issues/APP-E0), 103 users). It was filed as an Onyx storage bug, but it does not come from Onyx.

It comes from the Convert Experiences A/B testing tag we load on every web page in `web/index.html`. Their SDK keeps its own IndexedDB database and inserts rows with `add()` instead of `put()`:

```js
let t = await get({key: 1, store: 'config'});
t ? await put({key: 1, data})   // row there -> overwrite
  : await add({key: 1, data});  // row missing -> insert
```

`add()` rejects when the key already exists; `put()` overwrites. Nothing reserves the key between the read and the write, so two runs at once (two tabs, or two calls in one tab) both take the `add()` branch and the second one rejects. That rejection is never caught, so it reaches `window.onunhandledrejection` — our Sentry handler — and is filed against us.

Why this cannot be ours:

- Onyx's IndexedDB provider only calls `put`, `delete`, `get` and `clear`. There is no `add()` in `react-native-onyx` or in `idb-keyval`.
- Chromium prints that exact wording only for `add()`. Confirmed in a browser: `add()` on an existing key gives the message, `put()` on the same key succeeds, and the resulting `DOMException` has no stack — which matches the missing stacktrace and `DOMException.code: 0` on every Sentry event.
- Zero occurrences of "ConstraintError" in our client logs over 7 days, while `AbortError` and the other storage errors log normally. So it never went through Onyx's storage retry path.
- Sentry shows Chrome and Edge only (0 Safari, 0 Firefox), spread evenly across `/home`, `/search`, `/r/*` and `/attachment`. Not tied to any app flow.

So this adds an `ignoreErrors` pattern, matching the sibling rejection from the same script that we already drop (`No data found for key`). `thirdPartyErrorFilterIntegration` cannot handle either one, because the `DOMException` carries no stack frames to tag as third-party — `ignoreErrors` is the only filter that can match it.

The pattern is anchored at the start and keeps the full sentence, so a differently worded `ConstraintError` (a unique-index violation, say) still reports.

The `add()` → `put()` change itself lives in vendor code, so it needs a ticket to Convert. That is tracked separately from this PR.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100047
PROPOSAL:

### Automated Tests

`tests/unit/setupSentryTest.ts`, in the existing `describe('setupSentry')` block. Three cases added, running Sentry's own `stringMatchesSomePattern` over the registered patterns:

- drops `ConstraintError: Key already exists in the object store.`
- keeps `AbortError: IDB write transaction aborted without an error`, so real Onyx storage failures still report
- keeps a `ConstraintError` with different wording, so the filter stays narrow

### Tests

This changes Sentry filtering only, so it has no user-visible behaviour. To verify the filter locally:

1. Run the app on web
2. Go to Settings → Troubleshoot and turn on "Log Sentry requests to console"
3. Turn off "Send data to Sentry" so nothing leaves your machine
4. In the browser console, run `Promise.reject(new DOMException('Key already exists in the object store.', 'ConstraintError'))`
5. Verify no Sentry envelope is logged for it
6. In the console, run `Promise.reject(new Error('sentry filter smoke test'))`
7. Verify an envelope **is** logged for that one, confirming the transport is live and only the Convert rejection is filtered
8. Run `npx jest tests/unit/setupSentryTest.ts` and verify all cases pass

- [x] Verify that no errors appear in the JS console

### Offline tests

Not applicable. The change only decides whether an error event is sent to Sentry; it does not read or write any data and behaves the same in every network state.

### QA Steps

None — Sentry-side filtering with no user-visible behaviour, so the title carries `[No QA]`. Verification is the automated tests above, plus watching APP-E0 stop taking new events once this is on production.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
