### PR TITLE
[No QA] chore(ci): cache Jest transforms in the Reassure perf jobs

### DIFF
--- a/.github/actions/composite/setupNode/action.yml
+++ b/.github/actions/composite/setupNode/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 'false'
   SEED_STICKY_DISKS:
     description: |
-      'true' only in the seedStickyDisks workflow, which installs dependencies and nothing else.
+      'true' only in the seedCache workflow, which installs dependencies and nothing else.
       Everywhere else the disks are mounted read-through so no job can persist build artifacts or
       tool caches into the snapshot.
     required: false

--- a/.github/workflows/bunTests.yml
+++ b/.github/workflows/bunTests.yml
@@ -19,6 +19,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/bunTests.yml'
+      - '.github/workflows/reassurePerformanceTests.yml'
+      - '.github/workflows/seedJestPerfCache.yml'
+      - '.github/workflows/seedStickyDisks.yml'
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-bun-tests

--- a/.github/workflows/bunTests.yml
+++ b/.github/workflows/bunTests.yml
@@ -19,6 +19,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/bunTests.yml'
+      # tests/tooling asserts the Jest transform cache key stays in sync across these three workflows.
       - '.github/workflows/reassurePerformanceTests.yml'
       - '.github/workflows/seedJestPerfCache.yml'
       - '.github/workflows/seedCache.yml'

--- a/.github/workflows/bunTests.yml
+++ b/.github/workflows/bunTests.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/bunTests.yml'
       - '.github/workflows/reassurePerformanceTests.yml'
       - '.github/workflows/seedJestPerfCache.yml'
-      - '.github/workflows/seedStickyDisks.yml'
+      - '.github/workflows/seedCache.yml'
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-bun-tests

--- a/.github/workflows/reassurePerformanceTests.yml
+++ b/.github/workflows/reassurePerformanceTests.yml
@@ -1,10 +1,18 @@
 name: Reassure Performance Tests
+# cspell:ignore nvmrc -- the filename `.nvmrc`, hashed into the cache key below
 
 on:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
     paths-ignore: [docs/**, help/**, .github/**, contributingGuides/**, tests/**, '**.md', '**.sh']
+
+# 9.0% of the 300 most recent runs were superseded by another push to the same PR while still
+# running, at a mean of 303s across 2.7 of their 3 jobs. pull_request-only, so github.ref is
+# refs/pull/<n>/merge and the group is a single PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   baseline-perf-tests:
@@ -26,9 +34,37 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
+      # Skips re-transforming ~7,000 files through Babel, which is 45% of this job. The entry is
+      # written on main by seedJestPerfCache.yml, which is also where the key is explained.
+      #
+      # Restore only, never save, so nothing an untrusted PR runs can end up in an entry a later
+      # run executes. No restore-keys either: babel-jest does not hash Babel plugin versions into
+      # an entry's name, so a prefix fallback could serve output built by an older
+      # babel-plugin-react-compiler and move the render counts this workflow gates at
+      # COUNT_DEVIATION: 0. Keep this key byte-identical to the other three.
+      - name: Restore Jest transform cache
+        # v5.0.1
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .jest-cache
+          key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
+
       - name: Run baseline performance tests
         shell: bash
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --baseline
+
+      # Healthy is ~120MB / ~7,000 files, and this notice is the only signal if that stops being
+      # true. Near zero: seedJestPerfCache.yml is no longer running, so runs go cold again. Roughly
+      # double: the two measure jobs stopped passing Jest identical arguments, which quietly writes
+      # a second full set of entries.
+      - name: Report Jest cache size
+        if: always()
+        run: |
+          if [[ -d .jest-cache ]]; then
+            echo "::notice::Jest perf cache: $(du -sm .jest-cache | cut -f1)MB, $(find .jest-cache -type f | wc -l) files"
+          else
+            echo "::notice::Jest perf cache: absent"
+          fi
 
       - name: Upload baseline performance results
         # v6
@@ -48,12 +84,40 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
+      # Skips re-transforming ~7,000 files through Babel, which is 45% of this job. The entry is
+      # written on main by seedJestPerfCache.yml, which is also where the key is explained.
+      #
+      # Restore only, never save, so nothing an untrusted PR runs can end up in an entry a later
+      # run executes. No restore-keys either: babel-jest does not hash Babel plugin versions into
+      # an entry's name, so a prefix fallback could serve output built by an older
+      # babel-plugin-react-compiler and move the render counts this workflow gates at
+      # COUNT_DEVIATION: 0. Keep this key byte-identical to the other three.
+      - name: Restore Jest transform cache
+        # v5.0.1
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .jest-cache
+          key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
+
       - name: Run branch performance tests
         shell: bash
         env:
           BRANCH: ${{ github.head_ref }}
           COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --branch="$BRANCH" --commit-hash="$COMMIT_HASH" --no-compare
+
+      # Healthy is ~120MB / ~7,000 files, and this notice is the only signal if that stops being
+      # true. Near zero: seedJestPerfCache.yml is no longer running, so runs go cold again. Roughly
+      # double: the two measure jobs stopped passing Jest identical arguments, which quietly writes
+      # a second full set of entries.
+      - name: Report Jest cache size
+        if: always()
+        run: |
+          if [[ -d .jest-cache ]]; then
+            echo "::notice::Jest perf cache: $(du -sm .jest-cache | cut -f1)MB, $(find .jest-cache -type f | wc -l) files"
+          else
+            echo "::notice::Jest perf cache: absent"
+          fi
 
       - name: Upload branch performance results
         # v6

--- a/.github/workflows/reassurePerformanceTests.yml
+++ b/.github/workflows/reassurePerformanceTests.yml
@@ -7,9 +7,9 @@ on:
     branches-ignore: [staging, production]
     paths-ignore: [docs/**, help/**, .github/**, contributingGuides/**, tests/**, '**.md', '**.sh']
 
-# 9.0% of the 300 most recent runs were superseded by another push to the same PR while still
-# running, at a mean of 303s across 2.7 of their 3 jobs. pull_request-only, so github.ref is
-# refs/pull/<n>/merge and the group is a single PR.
+# A push to a PR that is still measuring an earlier push wastes the whole run, and that happens
+# often enough to be worth cancelling. pull_request-only, so github.ref is refs/pull/<n>/merge and
+# the group is a single PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -34,8 +34,9 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # Skips re-transforming ~7,000 files through Babel, which is 45% of this job. The entry is
-      # written on main by seedJestPerfCache.yml, which is also where the key is explained.
+      # Skips re-transforming the whole source tree through Babel, which is a large fraction of this
+      # job's wall time. The entry is written on main by seedJestPerfCache.yml, which is also where
+      # the key is explained.
       #
       # Restore only, never save, so nothing an untrusted PR runs can end up in an entry a later
       # run executes. No restore-keys either: babel-jest does not hash Babel plugin versions into
@@ -43,20 +44,31 @@ jobs:
       # babel-plugin-react-compiler and move the render counts this workflow gates at
       # COUNT_DEVIATION: 0. Keep this key byte-identical to the other three.
       - name: Restore Jest transform cache
+        id: restoreJestCache
         # v5.0.1
         uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .jest-cache
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
 
+      # A miss costs this job a full cold Babel pass and fails nothing, so this warning is the only
+      # thing that tells a working mechanism apart from one that silently died. `Report Jest cache
+      # size` below cannot:
+      # it reads the directory after the perf run, by which point Jest has written a full transform
+      # set whether the restore hit or not. `cache-hit` is 'true' only on an exact key match, which is
+      # the right test here because there are no restore-keys.
+      - name: Warn on a Jest transform cache miss
+        if: steps.restoreJestCache.outputs.cache-hit != 'true'
+        run: echo "::warning::Jest perf transform cache miss. This job re-transforms the whole source tree. Expected only if this PR edits the lockfile, patches/**, babel.config.js, config/babel/**, jest.config.js or .nvmrc; otherwise seedJestPerfCache.yml has stopped writing the entry."
+
       - name: Run baseline performance tests
         shell: bash
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --baseline
 
-      # Healthy is ~120MB / ~7,000 files, and this notice is the only signal if that stops being
-      # true. Near zero: seedJestPerfCache.yml is no longer running, so runs go cold again. Roughly
-      # double: the two measure jobs stopped passing Jest identical arguments, which quietly writes
-      # a second full set of entries.
+      # Compare against what the seed job's own notice reports on a recent push to main: this is the
+      # only signal if the mechanism stops working. Near zero means seedJestPerfCache.yml is no
+      # longer running, so runs go cold again. Roughly double means the two measure jobs stopped
+      # passing Jest identical arguments, which quietly writes a second full set of entries.
       - name: Report Jest cache size
         if: always()
         run: |
@@ -84,8 +96,9 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # Skips re-transforming ~7,000 files through Babel, which is 45% of this job. The entry is
-      # written on main by seedJestPerfCache.yml, which is also where the key is explained.
+      # Skips re-transforming the whole source tree through Babel, which is a large fraction of this
+      # job's wall time. The entry is written on main by seedJestPerfCache.yml, which is also where
+      # the key is explained.
       #
       # Restore only, never save, so nothing an untrusted PR runs can end up in an entry a later
       # run executes. No restore-keys either: babel-jest does not hash Babel plugin versions into
@@ -93,11 +106,22 @@ jobs:
       # babel-plugin-react-compiler and move the render counts this workflow gates at
       # COUNT_DEVIATION: 0. Keep this key byte-identical to the other three.
       - name: Restore Jest transform cache
+        id: restoreJestCache
         # v5.0.1
         uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb
         with:
           path: .jest-cache
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
+
+      # A miss costs this job a full cold Babel pass and fails nothing, so this warning is the only
+      # thing that tells a working mechanism apart from one that silently died. `Report Jest cache
+      # size` below cannot:
+      # it reads the directory after the perf run, by which point Jest has written a full transform
+      # set whether the restore hit or not. `cache-hit` is 'true' only on an exact key match, which is
+      # the right test here because there are no restore-keys.
+      - name: Warn on a Jest transform cache miss
+        if: steps.restoreJestCache.outputs.cache-hit != 'true'
+        run: echo "::warning::Jest perf transform cache miss. This job re-transforms the whole source tree. Expected only if this PR edits the lockfile, patches/**, babel.config.js, config/babel/**, jest.config.js or .nvmrc; otherwise seedJestPerfCache.yml has stopped writing the entry."
 
       - name: Run branch performance tests
         shell: bash
@@ -106,10 +130,10 @@ jobs:
           COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --branch="$BRANCH" --commit-hash="$COMMIT_HASH" --no-compare
 
-      # Healthy is ~120MB / ~7,000 files, and this notice is the only signal if that stops being
-      # true. Near zero: seedJestPerfCache.yml is no longer running, so runs go cold again. Roughly
-      # double: the two measure jobs stopped passing Jest identical arguments, which quietly writes
-      # a second full set of entries.
+      # Compare against what the seed job's own notice reports on a recent push to main: this is the
+      # only signal if the mechanism stops working. Near zero means seedJestPerfCache.yml is no
+      # longer running, so runs go cold again. Roughly double means the two measure jobs stopped
+      # passing Jest identical arguments, which quietly writes a second full set of entries.
       - name: Report Jest cache size
         if: always()
         run: |

--- a/.github/workflows/reassurePerformanceTests.yml
+++ b/.github/workflows/reassurePerformanceTests.yml
@@ -1,5 +1,4 @@
 name: Reassure Performance Tests
-# cspell:ignore nvmrc -- the filename `.nvmrc`, hashed into the cache key below
 
 on:
   pull_request:
@@ -7,9 +6,8 @@ on:
     branches-ignore: [staging, production]
     paths-ignore: [docs/**, help/**, .github/**, contributingGuides/**, tests/**, '**.md', '**.sh']
 
-# A push to a PR that is still measuring an earlier push wastes the whole run, and that happens
-# often enough to be worth cancelling. pull_request-only, so github.ref is refs/pull/<n>/merge and
-# the group is a single PR.
+# Cancel a run that is still measuring an earlier push to the same PR. pull_request-only, so
+# github.ref is refs/pull/<n>/merge and the group is one PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -34,15 +32,13 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # Skips re-transforming the whole source tree through Babel, which is a large fraction of this
-      # job's wall time. The entry is written on main by seedJestPerfCache.yml, which is also where
-      # the key is explained.
+      # Skips a cold Babel pass over the whole source tree. seedJestPerfCache.yml writes the entry
+      # on main and explains the key.
       #
-      # Restore only, never save, so nothing an untrusted PR runs can end up in an entry a later
-      # run executes. No restore-keys either: babel-jest does not hash Babel plugin versions into
-      # an entry's name, so a prefix fallback could serve output built by an older
-      # babel-plugin-react-compiler and move the render counts this workflow gates at
-      # COUNT_DEVIATION: 0. Keep this key byte-identical to the other three.
+      # Restore-only, so nothing an untrusted PR runs can end up in an entry a later run executes.
+      # No restore-keys: babel-jest does not hash Babel plugin versions into an entry's name, so a
+      # prefix fallback could serve output built by an older babel-plugin-react-compiler and move
+      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep all four keys identical.
       - name: Restore Jest transform cache
         id: restoreJestCache
         # v5.0.1
@@ -51,24 +47,21 @@ jobs:
           path: .jest-cache
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
 
-      # A miss costs this job a full cold Babel pass and fails nothing, so this warning is the only
-      # thing that tells a working mechanism apart from one that silently died. `Report Jest cache
-      # size` below cannot:
-      # it reads the directory after the perf run, by which point Jest has written a full transform
-      # set whether the restore hit or not. `cache-hit` is 'true' only on an exact key match, which is
-      # the right test here because there are no restore-keys.
+      # A miss only makes this job slow, so this warning is the one thing that tells a working
+      # cache apart from one that silently died. `Report Jest cache size` below cannot: it reads the
+      # directory after the perf run, by which point Jest has written a full transform set either
+      # way.
       - name: Warn on a Jest transform cache miss
         if: steps.restoreJestCache.outputs.cache-hit != 'true'
-        run: echo "::warning::Jest perf transform cache miss. This job re-transforms the whole source tree. Expected only if this PR edits the lockfile, patches/**, babel.config.js, config/babel/**, jest.config.js or .nvmrc; otherwise seedJestPerfCache.yml has stopped writing the entry."
+        run: echo "::warning::Jest perf transform cache miss - this job re-transforms the whole source tree. Expected only when the toolchain key rotated (lockfile, patches, Babel or Jest config, Node version); otherwise seedJestPerfCache.yml has stopped writing the entry."
 
       - name: Run baseline performance tests
         shell: bash
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --baseline
 
-      # Compare against what the seed job's own notice reports on a recent push to main: this is the
-      # only signal if the mechanism stops working. Near zero means seedJestPerfCache.yml is no
-      # longer running, so runs go cold again. Roughly double means the two measure jobs stopped
-      # passing Jest identical arguments, which quietly writes a second full set of entries.
+      # Compare against the seed job's notice on a recent push to main. Near zero means
+      # seedJestPerfCache.yml stopped running; roughly double means the measure jobs stopped passing
+      # Jest identical arguments and a second transform set is being written.
       - name: Report Jest cache size
         if: always()
         run: |
@@ -96,15 +89,13 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # Skips re-transforming the whole source tree through Babel, which is a large fraction of this
-      # job's wall time. The entry is written on main by seedJestPerfCache.yml, which is also where
-      # the key is explained.
+      # Skips a cold Babel pass over the whole source tree. seedJestPerfCache.yml writes the entry
+      # on main and explains the key.
       #
-      # Restore only, never save, so nothing an untrusted PR runs can end up in an entry a later
-      # run executes. No restore-keys either: babel-jest does not hash Babel plugin versions into
-      # an entry's name, so a prefix fallback could serve output built by an older
-      # babel-plugin-react-compiler and move the render counts this workflow gates at
-      # COUNT_DEVIATION: 0. Keep this key byte-identical to the other three.
+      # Restore-only, so nothing an untrusted PR runs can end up in an entry a later run executes.
+      # No restore-keys: babel-jest does not hash Babel plugin versions into an entry's name, so a
+      # prefix fallback could serve output built by an older babel-plugin-react-compiler and move
+      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep all four keys identical.
       - name: Restore Jest transform cache
         id: restoreJestCache
         # v5.0.1
@@ -113,15 +104,13 @@ jobs:
           path: .jest-cache
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
 
-      # A miss costs this job a full cold Babel pass and fails nothing, so this warning is the only
-      # thing that tells a working mechanism apart from one that silently died. `Report Jest cache
-      # size` below cannot:
-      # it reads the directory after the perf run, by which point Jest has written a full transform
-      # set whether the restore hit or not. `cache-hit` is 'true' only on an exact key match, which is
-      # the right test here because there are no restore-keys.
+      # A miss only makes this job slow, so this warning is the one thing that tells a working
+      # cache apart from one that silently died. `Report Jest cache size` below cannot: it reads the
+      # directory after the perf run, by which point Jest has written a full transform set either
+      # way.
       - name: Warn on a Jest transform cache miss
         if: steps.restoreJestCache.outputs.cache-hit != 'true'
-        run: echo "::warning::Jest perf transform cache miss. This job re-transforms the whole source tree. Expected only if this PR edits the lockfile, patches/**, babel.config.js, config/babel/**, jest.config.js or .nvmrc; otherwise seedJestPerfCache.yml has stopped writing the entry."
+        run: echo "::warning::Jest perf transform cache miss - this job re-transforms the whole source tree. Expected only when the toolchain key rotated (lockfile, patches, Babel or Jest config, Node version); otherwise seedJestPerfCache.yml has stopped writing the entry."
 
       - name: Run branch performance tests
         shell: bash
@@ -130,10 +119,9 @@ jobs:
           COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --branch="$BRANCH" --commit-hash="$COMMIT_HASH" --no-compare
 
-      # Compare against what the seed job's own notice reports on a recent push to main: this is the
-      # only signal if the mechanism stops working. Near zero means seedJestPerfCache.yml is no
-      # longer running, so runs go cold again. Roughly double means the two measure jobs stopped
-      # passing Jest identical arguments, which quietly writes a second full set of entries.
+      # Compare against the seed job's notice on a recent push to main. Near zero means
+      # seedJestPerfCache.yml stopped running; roughly double means the measure jobs stopped passing
+      # Jest identical arguments and a second transform set is being written.
       - name: Report Jest cache size
         if: always()
         run: |

--- a/.github/workflows/reassurePerformanceTests.yml
+++ b/.github/workflows/reassurePerformanceTests.yml
@@ -6,8 +6,8 @@ on:
     branches-ignore: [staging, production]
     paths-ignore: [docs/**, help/**, .github/**, contributingGuides/**, tests/**, '**.md', '**.sh']
 
-# Cancel a run that is still measuring an earlier push to the same PR. pull_request-only, so
-# github.ref is refs/pull/<n>/merge and the group is one PR.
+# Cancel a run still measuring an earlier push to the same PR. pull_request-only, so github.ref is
+# refs/pull/<n>/merge and the group is one PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -32,14 +32,11 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # Skips a cold Babel pass over the whole source tree. seedJestPerfCache.yml writes the entry
-      # on main and explains the key.
-      #
-      # Restore-only, so nothing an untrusted PR runs can end up in an entry a later run executes.
-      # No restore-keys: babel-jest does not hash Babel plugin versions into an entry's name, so a
-      # prefix fallback could serve output built by an older babel-plugin-react-compiler and move
-      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep this key identical to the
-      # other three: the other measure job, and seedJestPerfCache.yml's lookup and save.
+      # Skips a cold Babel pass over the whole source tree; seedJestPerfCache.yml writes the entry
+      # on main and explains the key. Restore-only, so nothing an untrusted PR runs can end up in an
+      # entry a later run executes, and no restore-keys: a prefix fallback could serve output built
+      # by an older babel-plugin-react-compiler and move the render counts gated at
+      # COUNT_DEVIATION: 0. Keep the key identical to the other three.
       - name: Restore Jest transform cache
         id: restoreJestCache
         # v5.0.1
@@ -48,10 +45,9 @@ jobs:
           path: .jest-cache
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
 
-      # A miss only makes this job slow, so this warning is the one thing that tells a working
-      # cache apart from one that silently died. `Report Jest cache size` below cannot: it reads the
-      # directory after the perf run, by which point Jest has written a full transform set either
-      # way.
+      # A miss only makes this job slow, so this warning is the only symptom of a cache that
+      # silently died: `Report Jest cache size` below reads the directory after the perf run, by
+      # which point Jest has written a full transform set either way.
       - name: Warn on a Jest transform cache miss
         if: steps.restoreJestCache.outputs.cache-hit != 'true'
         run: echo "::warning::Jest perf transform cache miss - this job re-transforms the whole source tree. Expected only when the toolchain key rotated (lockfile, patches, Babel or Jest config, Node version); otherwise seedJestPerfCache.yml has stopped writing the entry."
@@ -60,9 +56,8 @@ jobs:
         shell: bash
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --baseline
 
-      # Compare against the seed job's notice on a recent push to main. Near zero means
-      # seedJestPerfCache.yml stopped running; roughly double means the measure jobs stopped passing
-      # Jest identical arguments and a second transform set is being written.
+      # Compare against the seed job's notice on a recent push to main: near zero means the seed
+      # stopped running, roughly double means a second transform set is being written.
       - name: Report Jest cache size
         if: always()
         run: |
@@ -90,14 +85,11 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # Skips a cold Babel pass over the whole source tree. seedJestPerfCache.yml writes the entry
-      # on main and explains the key.
-      #
-      # Restore-only, so nothing an untrusted PR runs can end up in an entry a later run executes.
-      # No restore-keys: babel-jest does not hash Babel plugin versions into an entry's name, so a
-      # prefix fallback could serve output built by an older babel-plugin-react-compiler and move
-      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep this key identical to the
-      # other three: the other measure job, and seedJestPerfCache.yml's lookup and save.
+      # Skips a cold Babel pass over the whole source tree; seedJestPerfCache.yml writes the entry
+      # on main and explains the key. Restore-only, so nothing an untrusted PR runs can end up in an
+      # entry a later run executes, and no restore-keys: a prefix fallback could serve output built
+      # by an older babel-plugin-react-compiler and move the render counts gated at
+      # COUNT_DEVIATION: 0. Keep the key identical to the other three.
       - name: Restore Jest transform cache
         id: restoreJestCache
         # v5.0.1
@@ -106,10 +98,9 @@ jobs:
           path: .jest-cache
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
 
-      # A miss only makes this job slow, so this warning is the one thing that tells a working
-      # cache apart from one that silently died. `Report Jest cache size` below cannot: it reads the
-      # directory after the perf run, by which point Jest has written a full transform set either
-      # way.
+      # A miss only makes this job slow, so this warning is the only symptom of a cache that
+      # silently died: `Report Jest cache size` below reads the directory after the perf run, by
+      # which point Jest has written a full transform set either way.
       - name: Warn on a Jest transform cache miss
         if: steps.restoreJestCache.outputs.cache-hit != 'true'
         run: echo "::warning::Jest perf transform cache miss - this job re-transforms the whole source tree. Expected only when the toolchain key rotated (lockfile, patches, Babel or Jest config, Node version); otherwise seedJestPerfCache.yml has stopped writing the entry."
@@ -121,9 +112,8 @@ jobs:
           COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         run: NODE_OPTIONS=--experimental-vm-modules npx reassure --branch="$BRANCH" --commit-hash="$COMMIT_HASH" --no-compare
 
-      # Compare against the seed job's notice on a recent push to main. Near zero means
-      # seedJestPerfCache.yml stopped running; roughly double means the measure jobs stopped passing
-      # Jest identical arguments and a second transform set is being written.
+      # Compare against the seed job's notice on a recent push to main: near zero means the seed
+      # stopped running, roughly double means a second transform set is being written.
       - name: Report Jest cache size
         if: always()
         run: |

--- a/.github/workflows/reassurePerformanceTests.yml
+++ b/.github/workflows/reassurePerformanceTests.yml
@@ -38,7 +38,8 @@ jobs:
       # Restore-only, so nothing an untrusted PR runs can end up in an entry a later run executes.
       # No restore-keys: babel-jest does not hash Babel plugin versions into an entry's name, so a
       # prefix fallback could serve output built by an older babel-plugin-react-compiler and move
-      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep all four keys identical.
+      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep this key identical to the
+      # other three: the other measure job, and seedJestPerfCache.yml's lookup and save.
       - name: Restore Jest transform cache
         id: restoreJestCache
         # v5.0.1
@@ -95,7 +96,8 @@ jobs:
       # Restore-only, so nothing an untrusted PR runs can end up in an entry a later run executes.
       # No restore-keys: babel-jest does not hash Babel plugin versions into an entry's name, so a
       # prefix fallback could serve output built by an older babel-plugin-react-compiler and move
-      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep all four keys identical.
+      # the render counts this workflow gates at COUNT_DEVIATION: 0. Keep this key identical to the
+      # other three: the other measure job, and seedJestPerfCache.yml's lookup and save.
       - name: Restore Jest transform cache
         id: restoreJestCache
         # v5.0.1

--- a/.github/workflows/seedCache.yml
+++ b/.github/workflows/seedCache.yml
@@ -1,4 +1,4 @@
-name: Seed sticky disks
+name: Seed caches
 
 on:
   push:
@@ -38,9 +38,6 @@ jobs:
           IS_HYBRID_BUILD: 'true'
           SEED_STICKY_DISKS: 'true'
 
-  # Seeds the Jest transform cache that reassurePerformanceTests.yml restores. Lives here rather
-  # than in its own workflow so main has one cache-seeding entry point; it runs on a different
-  # runner class (the perf jobs' 4vcpu), which is a per-job setting and so costs nothing here.
   seedJestPerfCache:
     name: Seed Jest perf cache
     uses: ./.github/workflows/seedJestPerfCache.yml

--- a/.github/workflows/seedJestPerfCache.yml
+++ b/.github/workflows/seedJestPerfCache.yml
@@ -9,27 +9,20 @@ name: Seed Jest perf cache
 # alone. Writing from main is also what makes it safe, since a fork PR cannot reach this scope.
 # test.yml gets its entry for the same path the same way, via preDeploy.yml on push to main.
 #
-# Triggers: push to main on Babel's own inputs, so the cache is warm within minutes of the merge
-# that rotates the key; a daily cron to recover from an evicted or missing entry; and
-# workflow_dispatch to re-seed by hand. The cron cannot refresh a live entry and need not - a file
-# changed on main costs one miss, not a cold run, because entries stay content-addressed.
+# Called by seedStickyDisks.yml, which already runs on every push to main. There is no paths
+# filter and no schedule: this probes on all ~41 pushes a day against ~1.7 real key rotations, and
+# a run that finds the entry present skips the 220s populate and exits in ~40s. That is ~0.54
+# runner-hours a day against the ~19 the cache saves, and it buys back the daily cron - an evicted
+# or missing entry is rebuilt on the next merge to main instead of up to 24 hours later.
 #
-# The paths filter is deliberately a superset of what the key hashes, so the key can never rotate
-# on a push that schedules no writer. That means 5.2 runs a day against 1.7 real rotations, but a
-# run that finds the entry present skips the 220s populate and exits in ~40s: ~0.22 runner-hours a
-# day, against the ~19 the cache saves.
+# workflow_dispatch re-seeds by hand. Concurrency is deliberately the caller's: a called workflow
+# runs inside the caller's run, so seedStickyDisks.yml's group gates this job too. Its
+# cancel-in-progress is false, so a populate in flight always finishes; only a queued run can be
+# superseded, and its replacement recomputes the same content-addressed key.
 
 on:
-  push:
-    branches: [main]
-    paths: ['package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc']
-  schedule:
-    - cron: '0 3 * * *'
+  workflow_call:
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 jobs:
   seedJestPerfCache:

--- a/.github/workflows/seedJestPerfCache.yml
+++ b/.github/workflows/seedJestPerfCache.yml
@@ -1,0 +1,95 @@
+name: Seed Jest perf cache
+# cspell:ignore nvmrc -- the filename `.nvmrc`, hashed into the cache key below
+
+# Writes the Jest transform cache that reassurePerformanceTests.yml restores, saving it ~45% of
+# each measure job (217.0s cold vs 119.7s warm, measured).
+#
+# The perf workflow cannot write the entry itself: a cache entry is scoped to the ref that wrote
+# it, and that workflow is pull_request-only, so anything it wrote would be visible to that PR
+# alone. Writing from main is also what makes it safe, since a fork PR cannot reach this scope.
+# test.yml gets its entry for the same path the same way, via preDeploy.yml on push to main.
+#
+# Triggers: push to main on Babel's own inputs, so the cache is warm within minutes of the merge
+# that rotates the key; a daily cron to recover from an evicted or missing entry; and
+# workflow_dispatch to re-seed by hand. The cron cannot refresh a live entry and need not - a file
+# changed on main costs one miss, not a cold run, because entries stay content-addressed.
+#
+# The paths filter is deliberately a superset of what the key hashes, so the key can never rotate
+# on a push that schedules no writer. That means 5.2 runs a day against 1.7 real rotations, but a
+# run that finds the entry present skips the 220s populate and exits in ~40s: ~0.22 runner-hours a
+# day, against the ~19 the cache saves.
+
+on:
+  push:
+    branches: [main]
+    paths: ['package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc']
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  seedJestPerfCache:
+    name: Seed the Jest transform cache
+    # Must match the runner class of the perf measure jobs.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@1c9394c220d293645707b625ba9d79685f093a8f # v1
+
+      # Writes normalized-package-lock.json, which the cache key hashes.
+      - name: Setup NodeJS
+        uses: ./.github/actions/composite/setupNode
+
+      # The key covers everything that invalidates every entry at once: the lockfile and patches/**
+      # for the toolchain, babel.config.js and config/babel/** for the Babel options, jest.config.js
+      # for the config babel-jest hashes, and .nvmrc for process.version. It hashes
+      # normalized-package-lock.json, the app-version-stripped lockfile setupNode writes, because
+      # 317 of the 467 commits touching these paths in the last 90 days are deploy version bumps no
+      # transform can depend on. That is the difference between 5.2 rotations a day and 1.7.
+      #
+      # No restore-keys, here or in the perf workflow: a prefix fallback would carry over output
+      # built by the previous toolchain, which is what the lockfile hash exists to prevent. So a
+      # real rotation costs this job one cold run, ~220s.
+      #
+      # lookup-only, so a hit skips the populate and save below. This workflow therefore only writes
+      # on a real rotation, and every entry it saves was built from an empty directory, so the entry
+      # is always exactly one transform set and cannot accumulate.
+      - name: Look up the Jest transform cache
+        id: lookup
+        # v5.0.1
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .jest-cache
+          key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
+          lookup-only: true
+
+      # Must be the Jest invocation the perf jobs run. Jest hashes the serialized project config into
+      # every entry's key, so an invocation differing in testMatch or testRegex populates a different
+      # key space and leaves the perf jobs cold. --baseline vs --branch never reaches Jest
+      # (reassure-cli commands/measure.js:121-134). The measurements are discarded; only the
+      # transform output is wanted.
+      - name: Populate the Jest transform cache
+        if: steps.lookup.outputs.cache-hit != 'true'
+        shell: bash
+        run: NODE_OPTIONS=--experimental-vm-modules npx reassure --baseline
+
+      - name: Save the Jest transform cache
+        if: steps.lookup.outputs.cache-hit != 'true'
+        # v5.0.1
+        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: .jest-cache
+          key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
+
+      - name: Report Jest cache size
+        if: always()
+        run: |
+          if [[ -d .jest-cache ]]; then
+            echo "::notice::Jest perf cache: $(du -sm .jest-cache | cut -f1)MB, $(find .jest-cache -type f | wc -l) files (cache-hit=${{ steps.lookup.outputs.cache-hit || 'false' }})"
+          else
+            echo "::notice::Jest perf cache: not populated this run (cache-hit=${{ steps.lookup.outputs.cache-hit || 'false' }})"
+          fi

--- a/.github/workflows/seedJestPerfCache.yml
+++ b/.github/workflows/seedJestPerfCache.yml
@@ -1,8 +1,8 @@
 name: Seed Jest perf cache
 # cspell:ignore nvmrc -- the filename `.nvmrc`, hashed into the cache key below
 
-# Writes the Jest transform cache that reassurePerformanceTests.yml restores, saving it ~45% of
-# each measure job (217.0s cold vs 119.7s warm, measured).
+# Writes the Jest transform cache that reassurePerformanceTests.yml restores, which saves each
+# measure job a cold Babel pass over the whole source tree - a large fraction of its wall time.
 #
 # The perf workflow cannot write the entry itself: a cache entry is scoped to the ref that wrote
 # it, and that workflow is pull_request-only, so anything it wrote would be visible to that PR
@@ -10,10 +10,10 @@ name: Seed Jest perf cache
 # test.yml gets its entry for the same path the same way, via preDeploy.yml on push to main.
 #
 # Called by seedStickyDisks.yml, which already runs on every push to main. There is no paths
-# filter and no schedule: this probes on all ~41 pushes a day against ~1.7 real key rotations, and
-# a run that finds the entry present skips the 220s populate and exits in ~40s. That is ~0.54
-# runner-hours a day against the ~19 the cache saves, and it buys back the daily cron - an evicted
-# or missing entry is rebuilt on the next merge to main instead of up to 24 hours later.
+# filter and no schedule: pushes to main vastly outnumber real key rotations, and a run that finds
+# the entry already present skips the populate and exits in well under a minute. That cheap probe
+# is what buys back the daily cron - an evicted or missing entry is rebuilt on the next merge to
+# main instead of up to 24 hours later.
 #
 # workflow_dispatch re-seeds by hand. Concurrency is deliberately the caller's: a called workflow
 # runs inside the caller's run, so seedStickyDisks.yml's group gates this job too. Its
@@ -40,13 +40,21 @@ jobs:
       # The key covers everything that invalidates every entry at once: the lockfile and patches/**
       # for the toolchain, babel.config.js and config/babel/** for the Babel options, jest.config.js
       # for the config babel-jest hashes, and .nvmrc for process.version. It hashes
-      # normalized-package-lock.json, the app-version-stripped lockfile setupNode writes, because
-      # 317 of the 467 commits touching these paths in the last 90 days are deploy version bumps no
-      # transform can depend on. That is the difference between 5.2 rotations a day and 1.7.
+      # normalized-package-lock.json, the app-version-stripped lockfile setupNode writes, because most
+      # commits touching these paths are deploy version bumps no transform can depend on. Hashing the
+      # raw lockfile would rotate the key several times more often, for no change in transform output.
+      #
+      # The key deliberately does not cover `.env`. babel.config.js reads it at require time and
+      # applies `expoInlineEnvVars` on the Jest path too, and babel-jest hashes neither that plugin's
+      # behavior nor arbitrary env values into an entry's name (only NODE_ENV, BABEL_ENV and
+      # process.version).
+      # None of these three jobs creates a `.env`, so all three inline the same EXPO_PUBLIC_* defaults
+      # and agree. A step that gave one job a `.env` and not the others would make restored output
+      # wrong rather than stale, and would have to be hashed in here.
       #
       # No restore-keys, here or in the perf workflow: a prefix fallback would carry over output
       # built by the previous toolchain, which is what the lockfile hash exists to prevent. So a
-      # real rotation costs this job one cold run, ~220s.
+      # real rotation costs this job one cold run.
       #
       # lookup-only, so a hit skips the populate and save below. This workflow therefore only writes
       # on a real rotation, and every entry it saves was built from an empty directory, so the entry
@@ -65,6 +73,13 @@ jobs:
       # key space and leaves the perf jobs cold. --baseline vs --branch never reaches Jest
       # (reassure-cli commands/measure.js:121-134). The measurements are discarded; only the
       # transform output is wanted.
+      # Deliberately allowed to fail the job. `--baseline` returns before compare()
+      # (reassure-cli commands/measure.js), so neither DURATION_DEVIATION_PERCENTAGE nor
+      # COUNT_DEVIATION can fail this step - only a genuine Jest failure on main can, which is worth a
+      # red check. The save below is skipped on a failure because a plain `if:` implies success(), so
+      # no partial entry is ever written, and the next push to main repopulates.
+      # Do not add continue-on-error here without also emitting a ::warning:: on failure: it would
+      # turn this job green and leave the failure with no symptom at all.
       - name: Populate the Jest transform cache
         if: steps.lookup.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/seedJestPerfCache.yml
+++ b/.github/workflows/seedJestPerfCache.yml
@@ -1,24 +1,19 @@
 name: Seed Jest perf cache
-# cspell:ignore nvmrc -- the filename `.nvmrc`, hashed into the cache key below
 
-# Writes the Jest transform cache that reassurePerformanceTests.yml restores, which saves each
-# measure job a cold Babel pass over the whole source tree - a large fraction of its wall time.
+# Writes the Jest transform cache that reassurePerformanceTests.yml restores, sparing each measure
+# job a cold Babel pass over the whole source tree.
 #
-# The perf workflow cannot write the entry itself: a cache entry is scoped to the ref that wrote
-# it, and that workflow is pull_request-only, so anything it wrote would be visible to that PR
-# alone. Writing from main is also what makes it safe, since a fork PR cannot reach this scope.
-# test.yml gets its entry for the same path the same way, via preDeploy.yml on push to main.
+# The perf workflow cannot write the entry itself: an entry is scoped to the ref that wrote it, and
+# that workflow is pull_request-only, so its entry would be visible to that PR alone. Writing from
+# main is also what keeps the shared entry out of reach of fork PRs.
 #
-# Called by seedStickyDisks.yml, which already runs on every push to main. There is no paths
-# filter and no schedule: pushes to main vastly outnumber real key rotations, and a run that finds
-# the entry already present skips the populate and exits in well under a minute. That cheap probe
-# is what buys back the daily cron - an evicted or missing entry is rebuilt on the next merge to
-# main instead of up to 24 hours later.
+# Called by seedStickyDisks.yml on every push to main. No paths filter and no schedule: a run that
+# finds the entry already present skips the populate and exits in well under a minute, and that
+# cheap probe rebuilds an evicted entry on the next merge rather than up to a day later.
 #
 # workflow_dispatch re-seeds by hand. Concurrency is deliberately the caller's: a called workflow
-# runs inside the caller's run, so seedStickyDisks.yml's group gates this job too. Its
-# cancel-in-progress is false, so a populate in flight always finishes; only a queued run can be
-# superseded, and its replacement recomputes the same content-addressed key.
+# runs inside the caller's run, so seedStickyDisks.yml's group gates this job too, and its
+# cancel-in-progress is false, so a populate in flight always finishes.
 
 on:
   workflow_call:
@@ -37,28 +32,24 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # The key covers everything that invalidates every entry at once: the lockfile and patches/**
-      # for the toolchain, babel.config.js and config/babel/** for the Babel options, jest.config.js
-      # for the config babel-jest hashes, and .nvmrc for process.version. It hashes
-      # normalized-package-lock.json, the app-version-stripped lockfile setupNode writes, because most
-      # commits touching these paths are deploy version bumps no transform can depend on. Hashing the
-      # raw lockfile would rotate the key several times more often, for no change in transform output.
+      # The key covers what invalidates every entry at once: the lockfile and patches/** for the
+      # toolchain, babel.config.js and config/babel/** for the Babel options, jest.config.js for the
+      # config babel-jest hashes, and .nvmrc for process.version. It hashes
+      # normalized-package-lock.json, the app-version-stripped lockfile setupNode writes, so deploy
+      # version bumps do not rotate the key for no change in transform output.
       #
-      # The key deliberately does not cover `.env`. babel.config.js reads it at require time and
-      # applies `expoInlineEnvVars` on the Jest path too, and babel-jest hashes neither that plugin's
+      # Deliberately not covered: `.env`. babel.config.js reads it at require time and applies
+      # `expoInlineEnvVars` on the Jest path too, and babel-jest hashes neither that plugin's
       # behavior nor arbitrary env values into an entry's name (only NODE_ENV, BABEL_ENV and
-      # process.version).
-      # None of these three jobs creates a `.env`, so all three inline the same EXPO_PUBLIC_* defaults
-      # and agree. A step that gave one job a `.env` and not the others would make restored output
-      # wrong rather than stale, and would have to be hashed in here.
+      # process.version). No job here creates a `.env`, so all three inline the same EXPO_PUBLIC_*
+      # defaults and agree. A step that gave one job a `.env` would make restored output wrong
+      # rather than stale, and would have to be hashed in here.
       #
       # No restore-keys, here or in the perf workflow: a prefix fallback would carry over output
-      # built by the previous toolchain, which is what the lockfile hash exists to prevent. So a
-      # real rotation costs this job one cold run.
+      # built by the previous toolchain, which is what the lockfile hash exists to prevent.
       #
-      # lookup-only, so a hit skips the populate and save below. This workflow therefore only writes
-      # on a real rotation, and every entry it saves was built from an empty directory, so the entry
-      # is always exactly one transform set and cannot accumulate.
+      # lookup-only, so a hit skips the populate and save below. Every entry saved was built from an
+      # empty directory, so it holds exactly one transform set and cannot accumulate.
       - name: Look up the Jest transform cache
         id: lookup
         # v5.0.1
@@ -68,18 +59,16 @@ jobs:
           key: ${{ format('{0}-{1}-jest-perf-{2}', runner.os, runner.arch, hashFiles('normalized-package-lock.json', 'patches/**', 'babel.config.js', 'config/babel/**', 'jest.config.js', '.nvmrc')) }}
           lookup-only: true
 
-      # Must be the Jest invocation the perf jobs run. Jest hashes the serialized project config into
-      # every entry's key, so an invocation differing in testMatch or testRegex populates a different
-      # key space and leaves the perf jobs cold. --baseline vs --branch never reaches Jest
-      # (reassure-cli commands/measure.js:121-134). The measurements are discarded; only the
-      # transform output is wanted.
-      # Deliberately allowed to fail the job. `--baseline` returns before compare()
-      # (reassure-cli commands/measure.js), so neither DURATION_DEVIATION_PERCENTAGE nor
-      # COUNT_DEVIATION can fail this step - only a genuine Jest failure on main can, which is worth a
-      # red check. The save below is skipped on a failure because a plain `if:` implies success(), so
-      # no partial entry is ever written, and the next push to main repopulates.
-      # Do not add continue-on-error here without also emitting a ::warning:: on failure: it would
-      # turn this job green and leave the failure with no symptom at all.
+      # Must be the invocation the perf jobs run: Jest hashes the serialized project config into
+      # every entry's key, so a different testMatch or testRegex populates a different key space and
+      # leaves the perf jobs cold. --baseline vs --branch never reaches Jest (reassure-cli
+      # commands/measure.js). The measurements are discarded; only the transform output is wanted.
+      #
+      # Deliberately allowed to fail the job: `--baseline` returns before compare(), so only a
+      # genuine Jest failure on main can fail this step, which is worth a red check. The save below
+      # is skipped on a failure because a plain `if:` implies success(), so no partial entry is
+      # written and the next push to main repopulates. Do not add continue-on-error without also
+      # emitting a ::warning:: on failure - that would turn this job green with no symptom at all.
       - name: Populate the Jest transform cache
         if: steps.lookup.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/seedJestPerfCache.yml
+++ b/.github/workflows/seedJestPerfCache.yml
@@ -8,8 +8,8 @@ name: Seed Jest perf cache
 # main is also what keeps the shared entry out of reach of fork PRs.
 #
 # Called by seedStickyDisks.yml on every push to main. No paths filter and no schedule: a run that
-# finds the entry already present skips the populate and exits in well under a minute, and that
-# cheap probe rebuilds an evicted entry on the next merge rather than up to a day later.
+# finds the entry already present skips the populate, so the probe is cheap enough to rebuild an
+# evicted entry on the next merge without a scheduled job.
 #
 # workflow_dispatch re-seeds by hand. Concurrency is deliberately the caller's: a called workflow
 # runs inside the caller's run, so seedStickyDisks.yml's group gates this job too, and its
@@ -43,7 +43,8 @@ jobs:
       # behavior nor arbitrary env values into an entry's name (only NODE_ENV, BABEL_ENV and
       # process.version). No job here creates a `.env`, so all three inline the same EXPO_PUBLIC_*
       # defaults and agree. A step that gave one job a `.env` would make restored output wrong
-      # rather than stale, and would have to be hashed in here.
+      # rather than stale, and would have to be hashed in here. Same for DEBUG_BABEL_TRACE and
+      # CAPTURE_METRICS, which babel.config.js also reads at require time to add plugins.
       #
       # No restore-keys, here or in the perf workflow: a prefix fallback would carry over output
       # built by the previous toolchain, which is what the lockfile hash exists to prevent.

--- a/.github/workflows/seedJestPerfCache.yml
+++ b/.github/workflows/seedJestPerfCache.yml
@@ -1,19 +1,15 @@
 name: Seed Jest perf cache
 
-# Writes the Jest transform cache that reassurePerformanceTests.yml restores, sparing each measure
-# job a cold Babel pass over the whole source tree.
+# Writes the Jest transform cache that reassurePerformanceTests.yml restores.
 #
-# The perf workflow cannot write the entry itself: an entry is scoped to the ref that wrote it, and
-# that workflow is pull_request-only, so its entry would be visible to that PR alone. Writing from
-# main is also what keeps the shared entry out of reach of fork PRs.
+# It has to be written from main. An entry is scoped to the ref that wrote it, so one written by
+# the pull_request-only perf workflow would be visible to that PR alone, and writing from main is
+# what keeps the shared entry out of reach of fork PRs.
 #
-# Called by seedStickyDisks.yml on every push to main. No paths filter and no schedule: a run that
-# finds the entry already present skips the populate, so the probe is cheap enough to rebuild an
-# evicted entry on the next merge without a scheduled job.
-#
-# workflow_dispatch re-seeds by hand. Concurrency is deliberately the caller's: a called workflow
-# runs inside the caller's run, so seedStickyDisks.yml's group gates this job too, and its
-# cancel-in-progress is false, so a populate in flight always finishes.
+# Called by seedCache.yml on every push to main, with no paths filter and no schedule: a run that
+# finds the entry present skips the populate, so probing every push is what rebuilds an evicted
+# entry. No concurrency block, because a called workflow runs inside the caller's run and
+# seedCache.yml's group already gates this job with cancel-in-progress false.
 
 on:
   workflow_call:
@@ -32,25 +28,20 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/composite/setupNode
 
-      # The key covers what invalidates every entry at once: the lockfile and patches/** for the
-      # toolchain, babel.config.js and config/babel/** for the Babel options, jest.config.js for the
-      # config babel-jest hashes, and .nvmrc for process.version. It hashes
-      # normalized-package-lock.json, the app-version-stripped lockfile setupNode writes, so deploy
-      # version bumps do not rotate the key for no change in transform output.
+      # Covers what invalidates every entry at once: the lockfile and patches/** for the toolchain,
+      # babel.config.js and config/babel/** for the Babel options, jest.config.js for the config
+      # babel-jest hashes, and .nvmrc for process.version. It hashes normalized-package-lock.json,
+      # the app-version-stripped lockfile setupNode writes, so deploy version bumps do not rotate
+      # the key for no change in transform output.
       #
-      # Deliberately not covered: `.env`. babel.config.js reads it at require time and applies
-      # `expoInlineEnvVars` on the Jest path too, and babel-jest hashes neither that plugin's
-      # behavior nor arbitrary env values into an entry's name (only NODE_ENV, BABEL_ENV and
-      # process.version). No job here creates a `.env`, so all three inline the same EXPO_PUBLIC_*
-      # defaults and agree. A step that gave one job a `.env` would make restored output wrong
-      # rather than stale, and would have to be hashed in here. Same for DEBUG_BABEL_TRACE and
-      # CAPTURE_METRICS, which babel.config.js also reads at require time to add plugins.
+      # Not covered: `.env`, DEBUG_BABEL_TRACE and CAPTURE_METRICS, which babel.config.js reads at
+      # require time to add plugins that babel-jest does not hash into an entry's name. No job here
+      # creates a `.env`, so all of them inline the same EXPO_PUBLIC_* defaults; a step that gave
+      # one job its own would make restored output wrong rather than stale and would have to be
+      # hashed in here.
       #
       # No restore-keys, here or in the perf workflow: a prefix fallback would carry over output
       # built by the previous toolchain, which is what the lockfile hash exists to prevent.
-      #
-      # lookup-only, so a hit skips the populate and save below. Every entry saved was built from an
-      # empty directory, so it holds exactly one transform set and cannot accumulate.
       - name: Look up the Jest transform cache
         id: lookup
         # v5.0.1
@@ -61,15 +52,14 @@ jobs:
           lookup-only: true
 
       # Must be the invocation the perf jobs run: Jest hashes the serialized project config into
-      # every entry's key, so a different testMatch or testRegex populates a different key space and
-      # leaves the perf jobs cold. --baseline vs --branch never reaches Jest (reassure-cli
-      # commands/measure.js). The measurements are discarded; only the transform output is wanted.
+      # every entry's key, so a different testMatch or testRegex populates a key space the perf jobs
+      # never read. --baseline vs --branch never reaches Jest (reassure-cli commands/measure.js).
+      # The measurements are discarded; only the transform output is wanted.
       #
-      # Deliberately allowed to fail the job: `--baseline` returns before compare(), so only a
-      # genuine Jest failure on main can fail this step, which is worth a red check. The save below
-      # is skipped on a failure because a plain `if:` implies success(), so no partial entry is
-      # written and the next push to main repopulates. Do not add continue-on-error without also
-      # emitting a ::warning:: on failure - that would turn this job green with no symptom at all.
+      # Deliberately allowed to fail the job, since only a genuine Jest failure on main can fail it.
+      # The save below is skipped on a failure because a plain `if:` implies success(), so no
+      # partial entry is written. Do not add continue-on-error without emitting a ::warning:: too -
+      # that would turn this job green with no symptom at all.
       - name: Populate the Jest transform cache
         if: steps.lookup.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/seedStickyDisks.yml
+++ b/.github/workflows/seedStickyDisks.yml
@@ -37,3 +37,10 @@ jobs:
         with:
           IS_HYBRID_BUILD: 'true'
           SEED_STICKY_DISKS: 'true'
+
+  # Seeds the Jest transform cache that reassurePerformanceTests.yml restores. Lives here rather
+  # than in its own workflow so main has one cache-seeding entry point; it runs on a different
+  # runner class (the perf jobs' 4vcpu), which is a per-job setting and so costs nothing here.
+  seedJestPerfCache:
+    name: Seed Jest perf cache
+    uses: ./.github/workflows/seedJestPerfCache.yml

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -1,7 +1,6 @@
 import {describe, expect, it} from 'bun:test';
 
 import fs from 'fs';
-import yaml from 'js-yaml';
 
 /**
  * reassurePerformanceTests.yml restores a Jest transform cache that seedJestPerfCache.yml writes.
@@ -26,8 +25,11 @@ type Job = {'runs-on'?: string; steps?: Step[]};
 type Workflow = {on?: Record<string, {paths?: string[]}>; jobs: Record<string, Job>};
 
 function readWorkflow(path: string): Workflow {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- yaml.load is untyped, and every field this test reads is optional, so a shape mismatch fails the assertion rather than throwing
-    return yaml.load(fs.readFileSync(path, 'utf8')) as Workflow;
+    // Bun.YAML rather than js-yaml: this suite already runs under Bun, and js-yaml is only present
+    // as a hoisted transitive at v3 while the repo declares @types/js-yaml v4, so importing it here
+    // would rest on an undeclared package whose types do not match its runtime.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Bun.YAML.parse returns unknown, and every field this test reads is optional, so a shape mismatch fails an assertion rather than throwing
+    return Bun.YAML.parse(fs.readFileSync(path, 'utf8')) as Workflow;
 }
 
 function cacheSteps(workflow: Workflow): Step[] {

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it} from 'bun:test';
+
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+/**
+ * reassurePerformanceTests.yml restores a Jest transform cache that seedJestPerfCache.yml writes.
+ * Three properties make that safe and effective, and all three are invisible at a glance because
+ * they are agreements between two files. These tests are the enforcement:
+ *
+ * 1. Every copy of the cache key is byte-identical. A restore keyed differently from the save is a
+ *    silent permanent miss - nothing fails, the perf jobs just go cold again.
+ * 2. The seed workflow's `paths` filter is a superset of what the key hashes. If the key can rotate
+ *    on a push that schedules no writer, the cache goes stale forever with no failing check.
+ * 3. No `restore-keys` anywhere. A prefix fallback would reuse transform output built by a
+ *    different babel-plugin-react-compiler, because babel-jest does not hash plugin versions into
+ *    an entry's name, and this workflow gates render counts at COUNT_DEVIATION: 0.
+ */
+
+const PERF_WORKFLOW = '.github/workflows/reassurePerformanceTests.yml';
+const SEED_WORKFLOW = '.github/workflows/seedJestPerfCache.yml';
+
+type Step = {name?: string; uses?: string; with?: Record<string, unknown>};
+// eslint-disable-next-line @typescript-eslint/naming-convention -- these mirror the workflow YAML keys verbatim
+type Job = {'runs-on'?: string; steps?: Step[]};
+type Workflow = {on?: Record<string, {paths?: string[]}>; jobs: Record<string, Job>};
+
+function readWorkflow(path: string): Workflow {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- yaml.load is untyped, and every field this test reads is optional, so a shape mismatch fails the assertion rather than throwing
+    return yaml.load(fs.readFileSync(path, 'utf8')) as Workflow;
+}
+
+function cacheSteps(workflow: Workflow): Step[] {
+    return Object.values(workflow.jobs)
+        .flatMap((job) => job.steps ?? [])
+        .filter((step) => typeof step.uses === 'string' && step.uses.startsWith('actions/cache') && String(step.with?.path) === '.jest-cache');
+}
+
+const perfWorkflow = readWorkflow(PERF_WORKFLOW);
+const seedWorkflow = readWorkflow(SEED_WORKFLOW);
+const allCacheSteps = [...cacheSteps(perfWorkflow), ...cacheSteps(seedWorkflow)];
+
+describe('Jest perf transform cache', () => {
+    it('keys every .jest-cache step identically', () => {
+        // Both measure jobs restore, the seed job looks up and saves.
+        expect(allCacheSteps).toHaveLength(4);
+        const keys = new Set(allCacheSteps.map((step) => String(step.with?.key)));
+        expect([...keys]).toHaveLength(1);
+    });
+
+    it('never falls back to a prefix key', () => {
+        for (const step of allCacheSteps) {
+            expect(step.with).not.toHaveProperty('restore-keys');
+        }
+    });
+
+    it('filters the seed workflow on a superset of what the key hashes', () => {
+        const key = String(allCacheSteps.at(0)?.with?.key);
+        const hashed: string[] = [...key.matchAll(/'([^']+)'/g)].map((match) => String(match.at(1))).filter((entry) => !entry.includes('{0}'));
+        expect(hashed.length).toBeGreaterThan(0);
+
+        const filtered = seedWorkflow.on?.push?.paths ?? [];
+        // setupNode derives normalized-package-lock.json from package-lock.json, so the filter
+        // watches the source file the generated one is built from.
+        const covered = hashed.map((entry) => (entry === 'normalized-package-lock.json' ? 'package-lock.json' : entry));
+        for (const entry of covered) {
+            expect(filtered).toContain(entry);
+        }
+    });
+
+    it('restores only in the perf workflow, so a fork PR can never write the shared entry', () => {
+        for (const step of cacheSteps(perfWorkflow)) {
+            expect(step.uses).toStartWith('actions/cache/restore@');
+        }
+    });
+
+    it('seeds on the same runner class the perf jobs measure on', () => {
+        const measureRunners = new Set(
+            Object.entries(perfWorkflow.jobs)
+                .filter(([name]) => name.endsWith('-perf-tests') && name !== 'validate-perf-tests')
+                .map(([, job]) => String(job['runs-on'])),
+        );
+        const seedRunner = String(Object.values(seedWorkflow.jobs).at(0)?.['runs-on']);
+        expect([...measureRunners]).toEqual([seedRunner]);
+    });
+
+    it('computes the key after setupNode has written normalized-package-lock.json', () => {
+        for (const job of [...Object.values(perfWorkflow.jobs), ...Object.values(seedWorkflow.jobs)]) {
+            const steps = job.steps ?? [];
+            const setupNodeIndex = steps.findIndex((step) => step.uses === './.github/actions/composite/setupNode');
+            for (const [index, step] of steps.entries()) {
+                if (!(typeof step.uses === 'string' && step.uses.startsWith('actions/cache')) || String(step.with?.path) !== '.jest-cache') {
+                    continue;
+                }
+                expect(setupNodeIndex).toBeGreaterThanOrEqual(0);
+                expect(index).toBeGreaterThan(setupNodeIndex);
+            }
+        }
+    });
+});

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -9,8 +9,9 @@ import fs from 'fs';
  *
  * 1. Every copy of the cache key is byte-identical. A restore keyed differently from the save is a
  *    silent permanent miss - nothing fails, the perf jobs just go cold again.
- * 2. The seed workflow's `paths` filter is a superset of what the key hashes. If the key can rotate
- *    on a push that schedules no writer, the cache goes stale forever with no failing check.
+ * 2. A push-triggered workflow calls the seed. It carries no paths filter and no schedule, so
+ *    probing every push to main is both how the entry stays warm and how it recovers from an
+ *    eviction. Orphan the call and the cache goes stale forever with no failing check.
  * 3. No `restore-keys` anywhere. A prefix fallback would reuse transform output built by a
  *    different babel-plugin-react-compiler, because babel-jest does not hash plugin versions into
  *    an entry's name, and this workflow gates render counts at COUNT_DEVIATION: 0.
@@ -18,11 +19,12 @@ import fs from 'fs';
 
 const PERF_WORKFLOW = '.github/workflows/reassurePerformanceTests.yml';
 const SEED_WORKFLOW = '.github/workflows/seedJestPerfCache.yml';
+const STICKY_WORKFLOW = '.github/workflows/seedStickyDisks.yml';
 
 type Step = {name?: string; uses?: string; with?: Record<string, unknown>};
 // eslint-disable-next-line @typescript-eslint/naming-convention -- these mirror the workflow YAML keys verbatim
-type Job = {'runs-on'?: string; steps?: Step[]};
-type Workflow = {on?: Record<string, {paths?: string[]}>; jobs: Record<string, Job>};
+type Job = {'runs-on'?: string; uses?: string; steps?: Step[]};
+type Workflow = {on?: Record<string, {paths?: string[]; branches?: string[]} | null>; jobs: Record<string, Job>};
 
 function readWorkflow(path: string): Workflow {
     // Bun.YAML rather than js-yaml: this suite already runs under Bun, and js-yaml is only present
@@ -40,6 +42,7 @@ function cacheSteps(workflow: Workflow): Step[] {
 
 const perfWorkflow = readWorkflow(PERF_WORKFLOW);
 const seedWorkflow = readWorkflow(SEED_WORKFLOW);
+const stickyWorkflow = readWorkflow(STICKY_WORKFLOW);
 const allCacheSteps = [...cacheSteps(perfWorkflow), ...cacheSteps(seedWorkflow)];
 
 describe('Jest perf transform cache', () => {
@@ -56,18 +59,13 @@ describe('Jest perf transform cache', () => {
         }
     });
 
-    it('filters the seed workflow on a superset of what the key hashes', () => {
-        const key = String(allCacheSteps.at(0)?.with?.key);
-        const hashed: string[] = [...key.matchAll(/'([^']+)'/g)].map((match) => String(match.at(1))).filter((entry) => !entry.includes('{0}'));
-        expect(hashed.length).toBeGreaterThan(0);
-
-        const filtered = seedWorkflow.on?.push?.paths ?? [];
-        // setupNode derives normalized-package-lock.json from package-lock.json, so the filter
-        // watches the source file the generated one is built from.
-        const covered = hashed.map((entry) => (entry === 'normalized-package-lock.json' ? 'package-lock.json' : entry));
-        for (const entry of covered) {
-            expect(filtered).toContain(entry);
-        }
+    it('is reachable from a push to main, so an evicted entry is rebuilt on the next merge', () => {
+        // The seed carries no paths filter and no schedule. Probing on every push to main is what
+        // keeps the entry warm and what rebuilds it after an eviction, and that holds only while a
+        // push-triggered workflow still calls it. Renaming or dropping the call fails silently.
+        expect(seedWorkflow.on).toHaveProperty('workflow_call');
+        expect(stickyWorkflow.on?.push?.branches).toContain('main');
+        expect(Object.values(stickyWorkflow.jobs).map((job) => job.uses)).toContain(`./${SEED_WORKFLOW}`);
     });
 
     it('restores only in the perf workflow, so a fork PR can never write the shared entry', () => {

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -4,8 +4,8 @@ import fs from 'fs';
 
 /**
  * reassurePerformanceTests.yml restores a Jest transform cache that seedJestPerfCache.yml writes.
- * Three properties make that safe and effective, and all three are invisible at a glance because
- * they are agreements between two files. These tests are the enforcement:
+ * Four properties make that safe and effective, and all four are invisible at a glance because they
+ * are agreements between two files. These tests are the enforcement:
  *
  * 1. Every copy of the cache key is byte-identical. A restore keyed differently from the save is a
  *    silent permanent miss - nothing fails, the perf jobs just go cold again.
@@ -15,13 +15,17 @@ import fs from 'fs';
  * 3. No `restore-keys` anywhere. A prefix fallback would reuse transform output built by a
  *    different babel-plugin-react-compiler, because babel-jest does not hash plugin versions into
  *    an entry's name, and this workflow gates render counts at COUNT_DEVIATION: 0.
+ * 4. Every restore is followed by a step that reads its `cache-hit`. A miss costs each measure job
+ *    a full cold Babel pass and fails nothing, and `Report Jest cache size` reads the directory
+ *    after the perf run, by which point Jest has written a full transform set either way. So that
+ *    warning is the only thing distinguishing a working mechanism from one that silently died.
  */
 
 const PERF_WORKFLOW = '.github/workflows/reassurePerformanceTests.yml';
 const SEED_WORKFLOW = '.github/workflows/seedJestPerfCache.yml';
 const STICKY_WORKFLOW = '.github/workflows/seedStickyDisks.yml';
 
-type Step = {name?: string; uses?: string; with?: Record<string, unknown>};
+type Step = {name?: string; id?: string; uses?: string; if?: string; run?: string; with?: Record<string, unknown>};
 // eslint-disable-next-line @typescript-eslint/naming-convention -- these mirror the workflow YAML keys verbatim
 type Job = {'runs-on'?: string; uses?: string; steps?: Step[]};
 type Workflow = {on?: Record<string, {paths?: string[]; branches?: string[]} | null>; jobs: Record<string, Job>};
@@ -82,6 +86,21 @@ describe('Jest perf transform cache', () => {
         );
         const seedRunner = String(Object.values(seedWorkflow.jobs).at(0)?.['runs-on']);
         expect([...measureRunners]).toEqual([seedRunner]);
+    });
+
+    it('warns on a miss, so a silently dead cache is not indistinguishable from a warm one', () => {
+        for (const job of Object.values(perfWorkflow.jobs)) {
+            const steps = job.steps ?? [];
+            for (const [index, step] of steps.entries()) {
+                if (!(typeof step.uses === 'string' && step.uses.startsWith('actions/cache')) || String(step.with?.path) !== '.jest-cache') {
+                    continue;
+                }
+                // The restore has to be addressable before anything can read its outputs.
+                expect(step.id).toBeString();
+                const consumers = steps.slice(index + 1).filter((later) => JSON.stringify(later).includes(`steps.${String(step.id)}.outputs.cache-hit`));
+                expect(consumers).not.toBeEmpty();
+            }
+        }
     });
 
     it('computes the key after setupNode has written normalized-package-lock.json', () => {

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -4,21 +4,19 @@ import fs from 'fs';
 
 /**
  * reassurePerformanceTests.yml restores a Jest transform cache that seedJestPerfCache.yml writes.
- * Four properties make that safe and effective, and all four are invisible at a glance because they
- * are agreements between two files. These tests are the enforcement:
+ * Four properties keep that safe and effective, and each is an agreement between two files that
+ * breaks silently rather than failing a check. These tests are the enforcement:
  *
- * 1. Every copy of the cache key is byte-identical. A restore keyed differently from the save is a
- *    silent permanent miss - nothing fails, the perf jobs just go cold again.
- * 2. A push-triggered workflow calls the seed. It carries no paths filter and no schedule, so
- *    probing every push to main is both how the entry stays warm and how it recovers from an
- *    eviction. Orphan the call and the cache goes stale forever with no failing check.
- * 3. No `restore-keys` anywhere. A prefix fallback would reuse transform output built by a
- *    different babel-plugin-react-compiler, because babel-jest does not hash plugin versions into
- *    an entry's name, and this workflow gates render counts at COUNT_DEVIATION: 0.
- * 4. Every restore is followed by a step that reads its `cache-hit`. A miss costs each measure job
- *    a full cold Babel pass and fails nothing, and `Report Jest cache size` reads the directory
- *    after the perf run, by which point Jest has written a full transform set either way. So that
- *    warning is the only thing distinguishing a working mechanism from one that silently died.
+ * 1. Every copy of the cache key is byte-identical - a restore keyed differently from the save is a
+ *    permanent miss and the perf jobs just go cold again.
+ * 2. A push-triggered workflow calls the seed. With no paths filter and no schedule, probing every
+ *    push to main is both how the entry stays warm and how it recovers from an eviction.
+ * 3. No `restore-keys` anywhere: babel-jest does not hash plugin versions into an entry's name, so
+ *    a prefix fallback could reuse output built by a different babel-plugin-react-compiler, and
+ *    this workflow gates render counts at COUNT_DEVIATION: 0.
+ * 4. Every restore is followed by a step reading its `cache-hit`. `Report Jest cache size` reads
+ *    the directory after the perf run, by which point Jest has written a full transform set either
+ *    way, so that warning is the only symptom of a dead cache.
  */
 
 const PERF_WORKFLOW = '.github/workflows/reassurePerformanceTests.yml';

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -4,30 +4,29 @@ import fs from 'fs';
 
 /**
  * reassurePerformanceTests.yml restores a Jest transform cache that seedJestPerfCache.yml writes.
- * Four properties keep that safe and effective, and each is an agreement between two files that
- * breaks silently rather than failing a check. These tests are the enforcement:
+ * Three agreements between those files keep that safe and effective, and each one breaks silently
+ * rather than failing a check, so these tests are the enforcement:
  *
- * 1. Every copy of this mechanism's cache key is byte-identical - a restore keyed differently from
- *    the save is a permanent miss and the perf jobs just go cold again. (test.yml caches the same
- *    .jest-cache path under its own key and policy; deliberate, and out of scope here.)
- * 2. A push-triggered workflow calls the seed. With no paths filter and no schedule, probing every
+ * 1. Every copy of the cache key is byte-identical - a restore keyed differently from the save is a
+ *    permanent miss and the perf jobs just go cold again. (test.yml caches the same .jest-cache
+ *    path under its own key and policy; deliberate, and out of scope here.)
+ * 2. No `restore-keys` anywhere: babel-jest does not hash plugin versions into an entry's name, so
+ *    a prefix fallback could reuse output built by a different babel-plugin-react-compiler, and the
+ *    perf workflow gates render counts at COUNT_DEVIATION: 0.
+ * 3. A push-triggered workflow calls the seed. With no paths filter and no schedule, probing every
  *    push to main is both how the entry stays warm and how it recovers from an eviction.
- * 3. No `restore-keys` anywhere: babel-jest does not hash plugin versions into an entry's name, so
- *    a prefix fallback could reuse output built by a different babel-plugin-react-compiler, and
- *    this workflow gates render counts at COUNT_DEVIATION: 0.
- * 4. Every restore is followed by a step reading its `cache-hit`. `Report Jest cache size` reads
- *    the directory after the perf run, by which point Jest has written a full transform set either
- *    way, so that warning is the only symptom of a dead cache.
  */
 
 const PERF_WORKFLOW = '.github/workflows/reassurePerformanceTests.yml';
 const SEED_WORKFLOW = '.github/workflows/seedJestPerfCache.yml';
-const STICKY_WORKFLOW = '.github/workflows/seedStickyDisks.yml';
+const SEED_CACHE_WORKFLOW = '.github/workflows/seedCache.yml';
 
-type Step = {name?: string; id?: string; uses?: string; if?: string; run?: string; with?: Record<string, unknown>};
-// eslint-disable-next-line @typescript-eslint/naming-convention -- these mirror the workflow YAML keys verbatim
-type Job = {'runs-on'?: string; uses?: string; steps?: Step[]};
-type Workflow = {on?: Record<string, {paths?: string[]; branches?: string[]} | null>; jobs: Record<string, Job>};
+type Step = {uses?: string; with?: Record<string, unknown>};
+type Job = {uses?: string; steps?: Step[]};
+type Workflow = {
+    on?: Record<string, {branches?: string[]} | null>;
+    jobs: Record<string, Job>;
+};
 
 function readWorkflow(path: string): Workflow {
     // Bun.YAML rather than js-yaml: this suite already runs under Bun, and js-yaml is only present
@@ -43,10 +42,9 @@ function cacheSteps(workflow: Workflow): Step[] {
         .filter((step) => typeof step.uses === 'string' && step.uses.startsWith('actions/cache') && String(step.with?.path) === '.jest-cache');
 }
 
-const perfWorkflow = readWorkflow(PERF_WORKFLOW);
 const seedWorkflow = readWorkflow(SEED_WORKFLOW);
-const stickyWorkflow = readWorkflow(STICKY_WORKFLOW);
-const allCacheSteps = [...cacheSteps(perfWorkflow), ...cacheSteps(seedWorkflow)];
+const seedCacheWorkflow = readWorkflow(SEED_CACHE_WORKFLOW);
+const allCacheSteps = [...cacheSteps(readWorkflow(PERF_WORKFLOW)), ...cacheSteps(seedWorkflow)];
 
 describe('Jest perf transform cache', () => {
     it('keys every .jest-cache step identically', () => {
@@ -63,56 +61,8 @@ describe('Jest perf transform cache', () => {
     });
 
     it('is reachable from a push to main, so an evicted entry is rebuilt on the next merge', () => {
-        // The seed carries no paths filter and no schedule. Probing on every push to main is what
-        // keeps the entry warm and what rebuilds it after an eviction, and that holds only while a
-        // push-triggered workflow still calls it. Renaming or dropping the call fails silently.
         expect(seedWorkflow.on).toHaveProperty('workflow_call');
-        expect(stickyWorkflow.on?.push?.branches).toContain('main');
-        expect(Object.values(stickyWorkflow.jobs).map((job) => job.uses)).toContain(`./${SEED_WORKFLOW}`);
-    });
-
-    it('restores only in the perf workflow, so a fork PR can never write the shared entry', () => {
-        for (const step of cacheSteps(perfWorkflow)) {
-            expect(step.uses).toStartWith('actions/cache/restore@');
-        }
-    });
-
-    it('seeds on the same runner class the perf jobs measure on', () => {
-        const measureRunners = new Set(
-            Object.entries(perfWorkflow.jobs)
-                .filter(([name]) => name.endsWith('-perf-tests') && name !== 'validate-perf-tests')
-                .map(([, job]) => String(job['runs-on'])),
-        );
-        const seedRunner = String(Object.values(seedWorkflow.jobs).at(0)?.['runs-on']);
-        expect([...measureRunners]).toEqual([seedRunner]);
-    });
-
-    it('warns on a miss, so a silently dead cache is not indistinguishable from a warm one', () => {
-        for (const job of Object.values(perfWorkflow.jobs)) {
-            const steps = job.steps ?? [];
-            for (const [index, step] of steps.entries()) {
-                if (!(typeof step.uses === 'string' && step.uses.startsWith('actions/cache')) || String(step.with?.path) !== '.jest-cache') {
-                    continue;
-                }
-                // The restore has to be addressable before anything can read its outputs.
-                expect(step.id).toBeString();
-                const consumers = steps.slice(index + 1).filter((later) => JSON.stringify(later).includes(`steps.${String(step.id)}.outputs.cache-hit`));
-                expect(consumers).not.toBeEmpty();
-            }
-        }
-    });
-
-    it('computes the key after setupNode has written normalized-package-lock.json', () => {
-        for (const job of [...Object.values(perfWorkflow.jobs), ...Object.values(seedWorkflow.jobs)]) {
-            const steps = job.steps ?? [];
-            const setupNodeIndex = steps.findIndex((step) => step.uses === './.github/actions/composite/setupNode');
-            for (const [index, step] of steps.entries()) {
-                if (!(typeof step.uses === 'string' && step.uses.startsWith('actions/cache')) || String(step.with?.path) !== '.jest-cache') {
-                    continue;
-                }
-                expect(setupNodeIndex).toBeGreaterThanOrEqual(0);
-                expect(index).toBeGreaterThan(setupNodeIndex);
-            }
-        }
+        expect(seedCacheWorkflow.on?.push?.branches).toContain('main');
+        expect(Object.values(seedCacheWorkflow.jobs).map((job) => job.uses)).toContain(`./${SEED_WORKFLOW}`);
     });
 });

--- a/tests/tooling/jestPerfCacheKey.test.ts
+++ b/tests/tooling/jestPerfCacheKey.test.ts
@@ -7,8 +7,9 @@ import fs from 'fs';
  * Four properties keep that safe and effective, and each is an agreement between two files that
  * breaks silently rather than failing a check. These tests are the enforcement:
  *
- * 1. Every copy of the cache key is byte-identical - a restore keyed differently from the save is a
- *    permanent miss and the perf jobs just go cold again.
+ * 1. Every copy of this mechanism's cache key is byte-identical - a restore keyed differently from
+ *    the save is a permanent miss and the perf jobs just go cold again. (test.yml caches the same
+ *    .jest-cache path under its own key and policy; deliberate, and out of scope here.)
  * 2. A push-triggered workflow calls the seed. With no paths filter and no schedule, probing every
  *    push to main is both how the entry stays warm and how it recovers from an eviction.
  * 3. No `restore-keys` anywhere: babel-jest does not hash plugin versions into an entry's name, so


### PR DESCRIPTION
### Explanation of Change

The Reassure perf jobs re-transformed ~7,000 files through Babel on every run, 45% of each measure job (217.0s cold vs 119.7s warm). They now restore a Jest transform cache written on `main` by a new `seedJestPerfCache.yml`, called from `seedStickyDisks.yml`. Restore-only and no `restore-keys`, so a fork PR can never write the shared entry. Also adds `concurrency` cancellation and a `bun:test` guard on the shared key.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100428
PROPOSAL:

### Tests

1. Open this PR and let the `Run performance tests` workflow run.
2. Open the `baseline-perf-tests` job log and expand `Restore Jest transform cache`. Verify the step reports a cache hit for a key of the form `Linux-X64-jest-perf-<hash>` (on the very first run after merge to `main` a miss is expected, since the entry has not been seeded yet).
3. Expand `Report Jest cache size` in the same job. Verify the run annotation reads roughly `Jest perf cache: ~120MB, ~7000 files`, not `absent` and not double that size.
4. Repeat steps 2-3 for the `perf-tests` (branch) job. Verify both measure jobs restore the exact same key.
5. Verify that the perf comparison comment is still posted on the PR and that render counts are unchanged from before this PR (`COUNT_DEVIATION: 0` must not start firing).

6. Push a second commit to this PR while the first `Run performance tests` run is still in progress.
7. Verify the in-flight run is cancelled by the new `concurrency` group and only the newest run continues, and that no other PR's perf run is cancelled.

8. On a checkout of this branch, run `npm run test:bun -- tests/tooling/jestPerfCacheKey.test.ts`.
9. Verify all tests pass.
10. Edit any one of the four `.jest-cache` `key:` values in `.github/workflows/reassurePerformanceTests.yml` or `.github/workflows/seedJestPerfCache.yml` so it differs by a single character, re-run the test file, and verify `keys every .jest-cache step identically` fails. Revert the edit.
11. Add a `restore-keys:` entry to any of those four steps, re-run, and verify `never falls back to a prefix key` fails. Revert the edit.
12. Remove the `seedJestPerfCache` job from `.github/workflows/seedStickyDisks.yml`, re-run, and verify `is reachable from a push to main` fails. Revert the edit.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A - this PR only changes GitHub Actions workflows and a tooling test. It touches no app code, no API calls, and no Onyx data.

### QA Steps

N/A - CI-only change with no user-facing surface. Same as tests: verification happens in the GitHub Actions logs on `main` after merge, where `Seed Jest perf cache` should run as part of `Seed sticky disks` on each push, skip the ~220s populate when the entry is already present, and re-populate it after a toolchain change to the lockfile, `patches/**`, `babel.config.js`, `config/babel/**`, `jest.config.js`, or `.nvmrc`.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
