### PR TITLE
patch for 10-bit heic in expo

### DIFF
--- a/patches/expo-image-manipulator/details.md
+++ b/patches/expo-image-manipulator/details.md
@@ -11,3 +11,20 @@
 - Upstream PR/issue: 🛑, there's no upstream PR/issue found. There's a related comment from App PR https://github.com/Expensify/App/pull/45448#issuecomment-2263252274
 - E/App issue: https://github.com/Expensify/App/issues/44084
 - PR introducing patch: https://github.com/Expensify/App/pull/45448
+
+
+### [expo-image-manipulator+57.0.6+002+fix-orientation-bit-depth.patch](expo-image-manipulator+57.0.6+002+fix-orientation-bit-depth.patch)
+
+- Reason:
+  
+    ```
+    `ImageFixOrientationTransformer` builds its `CGContext` with `bitsPerComponent` from the source image but
+    `bitmapInfo` hardcoded to `premultipliedLast`. Only 8-bit RGB is always valid with that flag, so a 10-bit HDR
+    HEIC (the default capture and screenshot format on recent iPhones) makes `CGContext` return nil and the
+    transformer throw `ImageContextLostException` every time. This patch clamps the context to 8-bit RGB and skips
+    the redraw for already-upright images.
+    ```
+  
+- Upstream PR/issue: 🛑, not filed yet.
+- E/App issue: https://github.com/Expensify/App/issues/100133
+- PR introducing patch: 🛑, not opened yet.

--- a/patches/expo-image-manipulator/expo-image-manipulator+57.0.6+002+fix-orientation-bit-depth.patch
+++ b/patches/expo-image-manipulator/expo-image-manipulator+57.0.6+002+fix-orientation-bit-depth.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/expo-image-manipulator/ios/Transformers/ImageFixOrientationTransformer.swift b/node_modules/expo-image-manipulator/ios/Transformers/ImageFixOrientationTransformer.swift
+index c3e3b66..719ff9c 100644
+--- a/node_modules/expo-image-manipulator/ios/Transformers/ImageFixOrientationTransformer.swift
++++ b/node_modules/expo-image-manipulator/ios/Transformers/ImageFixOrientationTransformer.swift
+@@ -9,6 +9,13 @@ internal struct ImageFixOrientationTransformer: ImageTransformer {
+     guard let cgImage = image.cgImage else {
+       throw ImageNotFoundException()
+     }
++
++    // The transform below is the identity for an upright image, so skip building a full-resolution bitmap to
++    // redraw it into unchanged.
++    if image.imageOrientation == .up {
++      return image
++    }
++
+     guard var colorSpace = cgImage.colorSpace else {
+       // That should never happen as `colorSpace` is empty only when the image is a mask.
+       throw ImageColorSpaceNotFoundException()
+@@ -44,13 +51,20 @@ internal struct ImageFixOrientationTransformer: ImageTransformer {
+       break
+     }
+ 
++    // `CGBitmapContext` accepts a fixed table of pixel formats. `bitmapInfo` below is hardcoded to
++    // `premultipliedLast`, and 8 bits per component in RGB is the only depth always valid with it, so taking the
++    // depth from a 10-bit HDR HEIC returns nil and throws `ImageContextLostException` on every attempt, whatever
++    // memory is free. Clamping costs nothing: the manipulator encodes to JPEG next, which is 8-bit.
++    let isSupportedPixelFormat = cgImage.bitsPerComponent == 8 && colorSpace.model == .rgb
++    let contextColorSpace = isSupportedPixelFormat ? colorSpace : CGColorSpaceCreateDeviceRGB()
++
+     let context = CGContext(
+       data: nil,
+       width: Int(image.size.width),
+       height: Int(image.size.height),
+-      bitsPerComponent: cgImage.bitsPerComponent,
++      bitsPerComponent: isSupportedPixelFormat ? cgImage.bitsPerComponent : 8,
+       bytesPerRow: 0,
+-      space: colorSpace,
++      space: contextColorSpace,
+       bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+     )
+ 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/100133
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
