### PR TITLE
[No QA] Fix live Onyx hook references

### DIFF
--- a/src/hooks/useTransactionInlineEdit.ts
+++ b/src/hooks/useTransactionInlineEdit.ts
@@ -95,9 +95,9 @@ function useTransactionInlineEdit({transactionID, hash, linkedReportAction}: Use
     const effectiveParentReport = isUnreported ? selfDMReport : parentReport;
     const effectiveParentReportID = effectiveParentReport?.reportID;
 
-    const [liveParentReport] = originalUseOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
+    const [liveParentReport] = useOnyxWithoutSnapshots(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
     const [selfDMReportID] = useOnyx(ONYXKEYS.SELF_DM_REPORT_ID);
-    const [liveSelfDMReport] = originalUseOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(selfDMReportID)}`);
+    const [liveSelfDMReport] = useOnyxWithoutSnapshots(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(selfDMReportID)}`);
     const parentReportForAction = isUnreported ? (liveSelfDMReport ?? selfDMReport) : (effectiveParentReport ?? liveParentReport);
 
     const linkedReportActionID = linkedReportAction?.reportActionID;
@@ -129,7 +129,7 @@ function useTransactionInlineEdit({transactionID, hash, linkedReportAction}: Use
     });
 
     const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(transactionThreadReportID)}`);
-    const [liveTransactionThreadReport] = originalUseOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(transactionThreadReportID)}`);
+    const [liveTransactionThreadReport] = useOnyxWithoutSnapshots(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(transactionThreadReportID)}`);
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${getNonEmptyStringOnyxID(policyID)}`);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${getNonEmptyStringOnyxID(policyID)}`);
     const [reportPolicyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${getNonEmptyStringOnyxID(reportPolicyID)}`);


### PR DESCRIPTION
### Explanation of Change

Replace three references to the undefined `originalUseOnyx` identifier with the existing `useOnyxWithoutSnapshots` alias.

This fixes the TypeScript and ESLint failures introduced by #99279. The ESLint errors were secondary type-safety errors caused by the unresolved identifier.

[No QA] because this is a compile-time identifier correction with no intended behavior change.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100310
$ https://github.com/Expensify/App/issues/100311

### Tests

1. Run `npm run lint-changed` and verify it passes.
2. Run `npm run typecheck` and verify it passes without `TS2304` errors.
3. Run `npm run react-compiler-compliance-check check-changed` and verify it passes.
4. Run `npm run spell-changed` and verify it passes.

### Offline tests

N/A — compile-time identifier correction only.

### QA Steps

N/A

### PR Author Checklist

- [x] I wrote clear testing steps that cover the changes made in this PR.
- [x] I followed proper code patterns and the review guidelines.
- [x] I verified that no new copy, assets, styles, or runtime behavior were introduced.
- [x] I ran the required lint, typecheck, React Compiler, and spelling checks.

### Screenshots/Videos

N/A
