### PR TITLE
[No QA] Assert Home by heading role instead of ambiguous text selector

### DIFF
--- a/.claude/skills/agent-device/flows/macros/android/complete-onboarding.ad
+++ b/.claude/skills/agent-device/flows/macros/android/complete-onboarding.ad
@@ -1,7 +1,6 @@
 context platform=android
 # @desc   Complete onboarding with minimal choices (skip work email, pick "Something else" purpose, enter generic name). Lands on Home.
 # @pre    text="What’s your work email?"
-# @post   text="Home"
 # @post   role="button" label="Search"
 # @tag    onboarding
 # @param  FIRST_NAME First name to enter on onboarding profile step.

--- a/.claude/skills/agent-device/flows/macros/android/complete-onboarding.ad
+++ b/.claude/skills/agent-device/flows/macros/android/complete-onboarding.ad
@@ -7,7 +7,9 @@ context platform=android
 # @param  LAST_NAME Last name to enter on onboarding profile step.
 
 press "id=\"onboardingPrivateEmailSkipButton\" || role=\"button\" label=\"Skip\" || label=\"Skip\""
+wait "label=\"Something else\""
 press "role=\"button\" label=\"Something else\" || label=\"Something else\""
+wait "label=\"First name\" editable=true"
 fill "role=\"textfield\" label=\"First name\" editable=true || label=\"First name\" editable=true" "${FIRST_NAME}"
 fill "role=\"textfield\" label=\"Last name\" editable=true || label=\"Last name\" editable=true" "${LAST_NAME}"
 press "role=\"button\" label=\"Continue\" || label=\"Continue\""

--- a/.claude/skills/agent-device/flows/macros/android/sign-in.ad
+++ b/.claude/skills/agent-device/flows/macros/android/sign-in.ad
@@ -6,5 +6,6 @@ context platform=android
 # @tag    auth
 # @param  EMAIL Login email. Use randomized alias format `agent-device-testing+<9digits>@gmail.com` to avoid account flagging.
 
-fill "id=\"username\" || label=\"Phone or email\" editable=true" "${EMAIL}"
+press "id=\"username\" || role=\"edittext\" label=\"Phone or email\" editable=true || label=\"Phone or email\" editable=true"
+fill "id=\"username\" || role=\"edittext\" label=\"Phone or email\" editable=true || label=\"Phone or email\" editable=true" "${EMAIL}"
 press "role=\"button\" label=\"Continue\" || label=\"Continue\""

--- a/.claude/skills/agent-device/flows/macros/web/complete-onboarding.ad
+++ b/.claude/skills/agent-device/flows/macros/web/complete-onboarding.ad
@@ -1,7 +1,7 @@
 context platform=web
 # @desc   Complete onboarding with minimal choices (skip work email, pick "Something else" purpose, enter generic name). Lands on Home.
 # @pre    text="What’s your work email?"
-# @post   text="Home"
+# @post   role="heading" label="Home"
 # @post   role="button" label="Search"
 # @tag    onboarding
 # @param  FIRST_NAME First name to enter on onboarding profile step.

--- a/.claude/skills/agent-device/flows/macros/web/sign-in.ad
+++ b/.claude/skills/agent-device/flows/macros/web/sign-in.ad
@@ -2,7 +2,7 @@ context platform=web
 # @desc   Sign in with the shared agent-device test account. Supports both new-account and returning-account outcomes. Caller MUST randomize EMAIL via `-e EMAIL=agent-device-testing+<9digits>@gmail.com` to avoid account flagging.
 # @pre    role="textbox" label="Phone or email"
 # @pre    role="button" label="Continue"
-# @post   text="Welcome!" || text="Home"
+# @post   text="Welcome!" || role="heading" label="Home"
 # @post   role="button" label="Join" || role="button" label="Search"
 # @tag    auth
 # @param  EMAIL Login email. Use randomized alias format `agent-device-testing+<9digits>@gmail.com` to avoid account flagging.


### PR DESCRIPTION
### Explanation of Change

`text="Home"` can never match on the Home screen. "Home" is rendered by three
separate nodes there - a nav link, a tab and the page heading - and an ambiguous
text selector does not resolve, so the assertion fails even though the screen is
correct. `role="heading" label="Home"` is unique and matches.

This replaces the `@post` header in `web/complete-onboarding.ad`, and the dead
`text="Home"` arm of the `@post` union in `web/sign-in.ad`.

`android/complete-onboarding.ad` declares the same unsatisfiable header. Its
accessibility tree is not verified for a heading role, so rather than assume one,
that macro drops the line and asserts the `role="button" label="Search"` landmark
it already declared alongside it.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/677358

### Tests

N/A

### Offline tests

N/A. 

### QA Steps

N/A

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline) - N/A, not app code
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). - N/A, not app code
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) - N/A, no UI change
- [x] I ran the tests on **all platforms** & verified they passed on: - not yet run, see `Tests`
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers - no new pattern; role-qualified selectors are already used throughout `flows/macros/`
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) - nothing imports these files; only `@post` assertion headers change, no replay step is touched
- [x] If a new CSS style is added I verified that: - N/A
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that: - N/A, no assets
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic. - N/A
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) - N/A
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected. - N/A
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account. - N/A
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles: - N/A, no UI
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow. - N/A, `.ad` macros have no unit-test harness; the `Tests` section covers it
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

No UI change - this edits an automation macro under `.claude/` that is not bundled into the app.

<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>

