### PR TITLE
WIP: Extract ReportDetailsMenuItems from DynamicReportDetailsPage

### DIFF
--- a/src/pages/DynamicReportDetailsPage.tsx
+++ b/src/pages/DynamicReportDetailsPage.tsx
@@ -3,7 +3,6 @@ import AvatarWithImagePicker from '@components/AvatarWithImagePicker';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MentionReportContext from '@components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/MentionReportContext';
-import MenuItem from '@components/MenuItem';
 import MenuItemAction from '@components/MenuItem/presets/MenuItemAction';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import {ModalActions} from '@components/Modal/Global/ModalContext';
@@ -18,7 +17,6 @@ import ScrollView from '@components/ScrollView';
 import {useSearchSelectionActions} from '@components/Search/SearchContext';
 import {SUPER_WIDE_RIGHT_MODALS} from '@components/WideRHPContextProvider/WIDE_RIGHT_MODALS';
 
-import useActivePolicy from '@hooks/useActivePolicy';
 import useAncestors from '@hooks/useAncestors';
 import useConfirmModal from '@hooks/useConfirmModal';
 import {useCurrencyListActions} from '@hooks/useCurrencyList';
@@ -28,32 +26,27 @@ import useDuplicateTransactionsAndViolations from '@hooks/useDuplicateTransactio
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useGetIOUReportFromReportAction from '@hooks/useGetIOUReportFromReportAction';
 import useHasOutstandingChildTask from '@hooks/useHasOutstandingChildTask';
-import useLastWorkspaceNumber from '@hooks/useLastWorkspaceNumber';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import useParentReportAction from '@hooks/useParentReportAction';
-import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import {useDerivedReportNamesByReportIDs} from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
-import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {generateDefaultWorkspaceName} from '@libs/actions/Policy/Policy';
 import getBase62ReportID from '@libs/getBase62ReportID';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
-import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 import type {ReportDetailsNavigatorParamList, RightModalNavigatorParamList} from '@libs/Navigation/types';
 import Parser from '@libs/Parser';
 import Permissions from '@libs/Permissions';
-import {isPolicyAdmin as isPolicyAdminUtil, isPolicyEmployee as isPolicyEmployeeUtil, shouldShowPolicy} from '@libs/PolicyUtils';
-import {getOneTransactionThreadReportID, getOriginalMessage, getTrackExpenseActionableWhisper, isDeletedAction, isMoneyRequestAction, isTrackExpenseAction} from '@libs/ReportActionsUtils';
+import {isPolicyAdmin as isPolicyAdminUtil, isPolicyEmployee as isPolicyEmployeeUtil} from '@libs/PolicyUtils';
+import {getOneTransactionThreadReportID, getOriginalMessage, isDeletedAction, isMoneyRequestAction, isTrackExpenseAction} from '@libs/ReportActionsUtils';
 import {getReportNameFromNames} from '@libs/ReportAttributesUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {
@@ -62,15 +55,12 @@ import {
     canEditReportDescription as canEditReportDescriptionUtil,
     canEditReportTitle,
     canJoinChat,
-    canLeaveChat,
     canWriteInReport,
-    createDraftTransactionAndNavigateToParticipantSelector,
     getAvailableReportFields,
     getChatRoomSubtitle,
     getIcons,
     getOriginalReportID,
     getParentNavigationSubtitle,
-    getParticipantsAccountIDsForDisplay,
     getParticipantsList,
     getPolicyName,
     getReportDescription,
@@ -81,19 +71,15 @@ import {
     isChatRoom as isChatRoomUtil,
     isChatThread as isChatThreadUtil,
     isClosedReport,
-    isCompletedTaskReport,
-    isConciergeChatReport,
     isDefaultRoom as isDefaultRoomUtil,
     isExpenseReport as isExpenseReportUtil,
     isFinancialReportsForBusinesses as isFinancialReportsForBusinessesUtil,
     isGroupChat as isGroupChatUtil,
-    isHiddenForCurrentUser,
     isInvoiceReport as isInvoiceReportUtil,
     isInvoiceRoom as isInvoiceRoomUtil,
     isMoneyRequestReport as isMoneyRequestReportUtil,
     isMoneyRequest as isMoneyRequestUtil,
     isPolicyExpenseChat as isPolicyExpenseChatUtil,
-    isPublicRoom as isPublicRoomUtil,
     isReportFieldDisabled,
     isReportFieldOfTypeTitle,
     isRootGroupChat as isRootGroupChatUtil,
@@ -104,9 +90,7 @@ import {
     isTrackExpenseReportNew as isTrackExpenseReportUtil,
     isUserCreatedPolicyRoom as isUserCreatedPolicyRoomUtil,
     isWorkspaceChat as isWorkspaceChatUtil,
-    isWorkspaceMemberLeavingWorkspaceRoom as isWorkspaceMemberLeavingWorkspaceRoomUtil,
     navigateBackOnDeleteTransaction,
-    navigateToPrivateNotes,
     shouldDisableRename as shouldDisableRenameUtil,
 } from '@libs/ReportUtils';
 import StringUtils from '@libs/StringUtils';
@@ -115,58 +99,30 @@ import {getAccountIDFromAvatarID} from '@libs/UserAvatarUtils';
 
 import {getNavigationUrlOnMoneyRequestDelete} from '@userActions/IOU/DeleteMoneyRequest';
 import {deleteTrackExpense, getNavigationUrlAfterTrackExpenseDelete} from '@userActions/IOU/TrackExpense';
-import {
-    clearAvatarErrors,
-    clearPolicyRoomNameErrors,
-    getReportPrivateNote,
-    hasErrorInPrivateNotes,
-    leaveGroupChat,
-    leaveRoom,
-    setDeleteTransactionNavigateBackUrl,
-    updateGroupChatAvatar,
-} from '@userActions/Report';
-import {callFunctionIfActionIsAllowed} from '@userActions/Session';
-import {canActionTask, canModifyTask, deleteTask, reopenTask} from '@userActions/Task';
+import {clearAvatarErrors, clearPolicyRoomNameErrors, getReportPrivateNote, setDeleteTransactionNavigateBackUrl, updateGroupChatAvatar} from '@userActions/Report';
+import {canActionTask, canModifyTask, deleteTask} from '@userActions/Task';
 
 import CONST from '@src/CONST';
-import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
 import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import {pendingDeleteMemberAccountIDsSelector} from '@src/selectors/ReportMetaData';
 import type * as OnyxTypes from '@src/types/onyx';
-import type DeepValueOf from '@src/types/utils/DeepValueOf';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
-import type IconAsset from '@src/types/utils/IconAsset';
 
-import type {StyleProp, ViewStyle} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 
-import {StackActions, useFocusEffect} from '@react-navigation/native';
+import {StackActions} from '@react-navigation/native';
 import {delegateEmailSelector} from '@selectors/Account';
-import {hasSeenTourSelector} from '@selectors/Onboarding';
-import {createFilteredPoliciesInfoSelector, createHasWorkspaceToSubmitToSelector} from '@selectors/Policy';
-import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo} from 'react';
 import {View} from 'react-native';
 
 import type {WithReportOrNotFoundProps} from './inbox/report/withReportOrNotFound';
 
+import ReportDetailsMenuItems from './inbox/report/ReportDetailsMenuItems';
 import withReportOrNotFound from './inbox/report/withReportOrNotFound';
-
-type DynamicReportDetailsPageMenuItem = {
-    key: DeepValueOf<typeof CONST.REPORT_DETAILS_MENU_ITEM>;
-    translationKey: TranslationPaths;
-    icon: IconAsset;
-    isAnonymousAction: boolean;
-    action: () => void;
-    brickRoadIndicator?: ValueOf<typeof CONST.BRICK_ROAD_INDICATOR_STATUS>;
-    subtitle?: number;
-    shouldShowRightIcon?: boolean;
-    subtitleStyle?: StyleProp<ViewStyle>;
-};
 
 type DynamicReportDetailsPageProps = WithReportOrNotFoundProps & PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>;
 
@@ -181,35 +137,13 @@ type CaseID = ValueOf<typeof CASES>;
 function DynamicReportDetailsPage({policy, report, route, reportMetadata, reportLoadingState}: DynamicReportDetailsPageProps) {
     const {translate, formatPhoneNumber} = useLocalize();
     const {isOffline} = useNetwork();
-    const {isRestrictedToPreferredPolicy, preferredPolicyID} = usePreferredPolicy();
-    const activePolicy = useActivePolicy();
-    const lastWorkspaceNumber = useLastWorkspaceNumber();
     const styles = useThemeStyles();
-    const expensifyIcons = useMemoizedLazyExpensifyIcons([
-        'Users',
-        'Gear',
-        'Send',
-        'Folder',
-        'UserPlus',
-        'Pencil',
-        'Checkmark',
-        'Building',
-        'Exit',
-        'Bug',
-        'Camera',
-        'Trashcan',
-        'ArrowSplit',
-        'Hashtag',
-    ]);
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Camera', 'Trashcan', 'ArrowSplit']);
     const navigateBackFromReportDetailsPath = useDynamicBackPath(DYNAMIC_ROUTES.REPORT_DETAILS.path);
     const taskDeleteBackTo = Navigation.getTopmostSearchReportRouteParams()?.backTo;
 
-    const [userBillingGracePeriodEnds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_USER_BILLING_GRACE_PERIOD_END);
-    const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
-    const [ownerBillingGracePeriodEnd] = useOnyx(ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END);
     const [parentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`);
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report.chatReportID}`);
-    const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
 
     const parentReportAction = useParentReportAction(report);
     const hasOutstandingChildTask = useHasOutstandingChildTask(report);
@@ -220,30 +154,20 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
 
     const {reportActions} = usePaginatedReportActions(report.reportID);
     const [reportActionsForOriginalReportID] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.reportID}`);
-    // The report from which a tracked expense would be submitted/categorized/shared, and its actions -
-    // createDraftTransactionAndNavigateToParticipantSelector uses them to find the linked track-expense action
+    // The report from which a tracked expense would be submitted/categorized/shared -
+    // ReportDetailsMenuItems reads its actions to find the linked track-expense action
     const actionReportID = getOriginalReportID(report.reportID, parentReportAction, reportActionsForOriginalReportID);
-    const [actionReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${actionReportID}`);
 
     const {removeTransaction} = useSearchSelectionActions();
 
     const transactionThreadReportID = useMemo(() => getOneTransactionThreadReportID(report, chatReport, reportActions ?? [], isOffline), [reportActions, isOffline, report, chatReport]);
-    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-    const {isSmallScreenWidth} = useResponsiveLayout();
 
     const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(transactionThreadReportID)}`);
-    const [isDebugModeEnabled = false] = useOnyx(ONYXKEYS.IS_DEBUG_MODE_ENABLED);
     const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
-    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
-    const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: hasSeenTourSelector});
-    const [betas] = useOnyx(ONYXKEYS.BETAS);
-    const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
     const [allTransactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
     const [delegateEmail] = useOnyx(ONYXKEYS.ACCOUNT, {selector: delegateEmailSelector});
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const {getCurrencyDecimals} = useCurrencyListActions();
-    const filteredPoliciesInfoSelector = useMemo(() => createFilteredPoliciesInfoSelector(currentUserPersonalDetails?.email), [currentUserPersonalDetails?.email]);
-    const [filteredPoliciesInfo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: filteredPoliciesInfoSelector});
     const {showConfirmModal} = useConfirmModal();
     const reportForHeader = useMemo(() => getReportForHeader(report, parentReport), [report, parentReport]);
     const derivedReportNames = useDerivedReportNamesByReportIDs([report?.parentReportID, reportForHeader?.reportID]);
@@ -311,16 +235,6 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
         caseID = CASES.DEFAULT;
     }
 
-    // Get the active chat members by filtering out the pending members with delete action
-    const activeChatMembers = participants.flatMap((accountID) => {
-        const pendingMember = reportMetadata?.pendingChatMembers?.findLast((member) => member.accountID === accountID.toString());
-        const detail = personalDetails?.[accountID];
-        if (!detail) {
-            return [];
-        }
-        return pendingMember?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE ? accountID : [];
-    });
-
     const isPrivateNotesFetchTriggered = reportLoadingState?.isLoadingPrivateNotes !== undefined;
     const requestParentReportAction = useMemo(() => {
         // 2. MoneyReport case
@@ -363,8 +277,6 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
     const iouTransactionID = isMoneyRequestAction(requestParentReportAction) ? getOriginalMessage(requestParentReportAction)?.IOUTransactionID : undefined;
     const [iouTransaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(iouTransactionID)}`);
     const [iouOriginalTransaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(iouTransaction?.comment?.originalTransactionID)}`);
-    const hasWorkspaceToSubmitToSelector = useMemo(() => createHasWorkspaceToSubmitToSelector(currentUserPersonalDetails.login), [currentUserPersonalDetails.login]);
-    const [hasWorkspaceToSubmitTo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: hasWorkspaceToSubmitToSelector});
     const {duplicateTransactions, duplicateTransactionViolations} = useDuplicateTransactionsAndViolations(iouTransactionID ? [iouTransactionID] : []);
     const {deleteTransactions, shouldOpenSplitExpenseEditFlowOnDelete} = useDeleteTransactions({
         report: parentReport,
@@ -391,61 +303,6 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
         getReportPrivateNote(report?.reportID);
     }, [report?.reportID, isOffline, isPrivateNotesFetchTriggered, isSelfDM]);
 
-    const leaveChat = useCallback(() => {
-        if (isRootGroupChat) {
-            leaveGroupChat(
-                report,
-                quickAction?.chatReportID?.toString() === report.reportID,
-                currentUserPersonalDetails.accountID,
-                conciergeReportID,
-                introSelected,
-                isSelfTourViewed,
-                betas,
-            );
-            return;
-        }
-
-        const isWorkspaceMemberLeavingWorkspaceRoom = isWorkspaceMemberLeavingWorkspaceRoomUtil(report, isPolicyEmployee, isPolicyAdmin);
-        leaveRoom(report, currentUserPersonalDetails.accountID, conciergeReportID, introSelected, isSelfTourViewed, betas, isWorkspaceMemberLeavingWorkspaceRoom);
-    }, [
-        isRootGroupChat,
-        isPolicyEmployee,
-        isPolicyAdmin,
-        quickAction?.chatReportID,
-        report,
-        currentUserPersonalDetails.accountID,
-        conciergeReportID,
-        introSelected,
-        isSelfTourViewed,
-        betas,
-    ]);
-
-    const showLastMemberLeavingModal = useCallback(async () => {
-        const {action} = await showConfirmModal({
-            title: translate('groupChat.lastMemberTitle'),
-            prompt: translate('groupChat.lastMemberWarning'),
-            confirmText: translate('common.leave'),
-            cancelText: translate('common.cancel'),
-            buttonVariant: CONST.BUTTON_VARIANT.DANGER,
-            shouldHandleNavigationBack: false,
-        });
-        if (action !== ModalActions.CONFIRM) {
-            return;
-        }
-        leaveChat();
-    }, [showConfirmModal, translate, leaveChat]);
-
-    const shouldShowLeaveButton = canLeaveChat(report, policy, currentUserPersonalDetails?.accountID, !!reportNameValuePairs?.private_isArchived);
-
-    // Snapshot on focus whether the room is the screen behind the Details page, so the row doesn't flip while the page
-    // is closing after it's tapped, yet still reflects the correct screen on later visits.
-    const [isRoomCurrentlyOpen, setIsRoomCurrentlyOpen] = useState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
-    useFocusEffect(() => {
-        setIsRoomCurrentlyOpen(isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
-    });
-    const shouldShowGoToRoom = (isChatRoom || isPolicyExpenseChat) && !isRoomCurrentlyOpen;
-    const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending && !shouldShowGoToRoom;
-
     const shouldParseFullTitle = parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat;
     const rawReportName = getReportName(reportForHeader, derivedHeaderReportName);
     const reportName = shouldParseFullTitle ? Parser.htmlToText(rawReportName) : rawReportName;
@@ -459,363 +316,6 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
     } else {
         roomDescription = translate('newRoomPage.roomName');
     }
-
-    const shouldShowNotificationPref = !isMoneyRequestReport && !isHiddenForCurrentUser(report);
-    const shouldShowWriteCapability = !isMoneyRequestReport;
-    const shouldShowMenuItem = shouldShowNotificationPref || shouldShowWriteCapability || (!!report?.visibility && report.chatType !== CONST.REPORT.CHAT_TYPE.INVOICE);
-
-    const menuItems: DynamicReportDetailsPageMenuItem[] = useMemo(() => {
-        const items: DynamicReportDetailsPageMenuItem[] = [];
-
-        if (isSelfDM) {
-            return [];
-        }
-
-        if (isArchivedRoom) {
-            return items;
-        }
-
-        if (shouldShowGoToRoom) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.GO_TO_ROOM,
-                translationKey: 'reportDetailsPage.goToRoom',
-                icon: expensifyIcons.Hashtag,
-                isAnonymousAction: false,
-                shouldShowRightIcon: true,
-                action: () => {
-                    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report?.reportID));
-                },
-            });
-        }
-
-        // The Members page is only shown when:
-        // - The report is a thread in a chat report
-        // - The report is not a user created room with participants to show i.e. DM, Group Chat, etc
-        // - The report is a user created room and the room and the current user is a workspace member i.e. non-workspace members should not see this option.
-        if (
-            (isGroupChat ||
-                (isDefaultRoom && isChatThread && isPolicyEmployee) ||
-                (!isUserCreatedPolicyRoom && participants.length) ||
-                (isUserCreatedPolicyRoom && (isPolicyEmployee || (isChatThread && !isPublicRoomUtil(report))))) &&
-            !isConciergeChatReport(report, conciergeReportID) &&
-            !isSystemChat &&
-            activeChatMembers.length > 0
-        ) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.MEMBERS,
-                translationKey: 'common.members',
-                icon: expensifyIcons.Users,
-                subtitle: activeChatMembers.length,
-                subtitleStyle: [styles.ph2],
-                isAnonymousAction: false,
-                shouldShowRightIcon: true,
-                action: () => {
-                    if (shouldOpenRoomMembersPage) {
-                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.ROOM_MEMBERS.path));
-                    } else {
-                        Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.REPORT_PARTICIPANTS.path));
-                    }
-                },
-            });
-        } else if ((isUserCreatedPolicyRoom && (!participants.length || !isPolicyEmployee)) || ((isDefaultRoom || isPolicyExpenseChat) && isChatThread && !isPolicyEmployee)) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.INVITE,
-                translationKey: 'common.invite',
-                icon: expensifyIcons.Users,
-                isAnonymousAction: false,
-                shouldShowRightIcon: true,
-                action: () => {
-                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.ROOM_INVITE.path));
-                },
-            });
-        }
-
-        if (shouldShowMenuItem) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.SETTINGS,
-                translationKey: 'common.settings',
-                icon: expensifyIcons.Gear,
-                isAnonymousAction: false,
-                shouldShowRightIcon: true,
-                action: () => {
-                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.REPORT_SETTINGS.path));
-                },
-            });
-        }
-
-        if (isTrackExpenseReport && !isDeletedParentAction) {
-            const whisperAction = getTrackExpenseActionableWhisper(iouTransactionID, moneyRequestReport?.reportID, moneyRequestReportActions);
-            const actionableWhisperReportActionID = whisperAction?.reportActionID;
-            const currentUserLocalCurrency = currentUserPersonalDetails.localCurrencyCode ?? CONST.CURRENCY.USD;
-            const {isExpenseSplit: isSelfDMExpenseSplit} = getOriginalTransactionWithSplitInfo(iouTransaction, iouOriginalTransaction);
-
-            // Hide the "Submit it to someone" option for self-DM split expenses when the user isn't a member of any workspace.
-            if (!isSelfDMExpenseSplit || hasWorkspaceToSubmitTo) {
-                const baseSubmitParams = {
-                    reportID: actionReportID,
-                    reportActions: actionReportActions,
-                    reportActionID: actionableWhisperReportActionID,
-                    introSelected,
-                    draftTransactionIDs,
-                    activePolicy,
-                    userBillingGracePeriodEnds,
-                    amountOwed,
-                    ownerBillingGracePeriodEnd,
-                    isRestrictedToPreferredPolicy,
-                    preferredPolicyID,
-                    transaction: iouTransaction,
-                    currentUserAccountID: currentUserPersonalDetails.accountID,
-                    currentUserEmail: currentUserPersonalDetails.email ?? '',
-                    currentUserLocalCurrency,
-                    filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
-                    firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
-                };
-                // "Submit to someone" splits into two destinations here too, matching the track-expense whisper:
-                // submit to an individual ("a friend") or a submit-enabled workspace ("my employer").
-                const defaultWorkspaceName = generateDefaultWorkspaceName(currentUserPersonalDetails.email ?? '', lastWorkspaceNumber, translate, currentUserPersonalDetails.displayName);
-
-                // Self-DM split expenses can only be submitted to a workspace, so the "a friend" destination is omitted here
-                // just like it is on the track-expense whisper.
-                if (!isSelfDMExpenseSplit) {
-                    items.push({
-                        key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.SUBMIT_TO_FRIEND,
-                        translationKey: 'actionableMentionTrackExpense.submitToFriend',
-                        icon: expensifyIcons.Send,
-                        isAnonymousAction: false,
-                        shouldShowRightIcon: true,
-                        action: () => {
-                            createDraftTransactionAndNavigateToParticipantSelector({
-                                ...baseSubmitParams,
-                                actionName: CONST.IOU.ACTION.SUBMIT,
-                                submitDestination: CONST.IOU.SUBMIT_DESTINATION.FRIEND,
-                                defaultWorkspaceName,
-                            });
-                        },
-                    });
-                }
-                items.push({
-                    key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.SUBMIT_TO_EMPLOYER,
-                    translationKey: 'actionableMentionTrackExpense.submitToEmployer',
-                    icon: expensifyIcons.Send,
-                    isAnonymousAction: false,
-                    shouldShowRightIcon: true,
-                    action: () => {
-                        createDraftTransactionAndNavigateToParticipantSelector({
-                            ...baseSubmitParams,
-                            actionName: CONST.IOU.ACTION.SUBMIT,
-                            submitDestination: CONST.IOU.SUBMIT_DESTINATION.EMPLOYER,
-                            defaultWorkspaceName,
-                        });
-                    },
-                });
-            }
-            if (Permissions.canUseTrackFlows()) {
-                items.push({
-                    key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.CATEGORIZE,
-                    translationKey: 'actionableMentionTrackExpense.categorize',
-                    icon: expensifyIcons.Folder,
-                    isAnonymousAction: false,
-                    shouldShowRightIcon: true,
-                    action: () => {
-                        createDraftTransactionAndNavigateToParticipantSelector({
-                            reportID: actionReportID,
-                            reportActions: actionReportActions,
-                            actionName: CONST.IOU.ACTION.CATEGORIZE,
-                            reportActionID: actionableWhisperReportActionID,
-                            introSelected,
-                            draftTransactionIDs,
-                            activePolicy,
-                            userBillingGracePeriodEnds,
-                            amountOwed,
-                            ownerBillingGracePeriodEnd,
-                            transaction: iouTransaction,
-                            currentUserAccountID: currentUserPersonalDetails.accountID,
-                            currentUserEmail: currentUserPersonalDetails.email ?? '',
-                            currentUserLocalCurrency,
-                            filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
-                            firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
-                        });
-                    },
-                });
-                items.push({
-                    key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.SHARE,
-                    translationKey: 'actionableMentionTrackExpense.share',
-                    icon: expensifyIcons.UserPlus,
-                    isAnonymousAction: false,
-                    shouldShowRightIcon: true,
-                    action: () => {
-                        createDraftTransactionAndNavigateToParticipantSelector({
-                            reportID: actionReportID,
-                            reportActions: actionReportActions,
-                            actionName: CONST.IOU.ACTION.SHARE,
-                            reportActionID: actionableWhisperReportActionID,
-                            introSelected,
-                            draftTransactionIDs,
-                            activePolicy,
-                            userBillingGracePeriodEnds,
-                            amountOwed,
-                            ownerBillingGracePeriodEnd,
-                            transaction: iouTransaction,
-                            currentUserAccountID: currentUserPersonalDetails.accountID,
-                            currentUserEmail: currentUserPersonalDetails.email ?? '',
-                            currentUserLocalCurrency,
-                            filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
-                            firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
-                        });
-                    },
-                });
-            }
-        }
-
-        // Prevent displaying private notes option for threads and task reports, or when the feature is disabled
-        if (Permissions.canUsePrivateNotes() && !isChatThread && !isMoneyRequestReport && !isInvoiceReport && !isTaskReport) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.PRIVATE_NOTES,
-                translationKey: 'privateNotes.title',
-                icon: expensifyIcons.Pencil,
-                isAnonymousAction: false,
-                shouldShowRightIcon: true,
-                action: () => navigateToPrivateNotes(report, currentUserPersonalDetails.accountID),
-                brickRoadIndicator: hasErrorInPrivateNotes(report) ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined,
-            });
-        }
-
-        // Show actions related to Task Reports
-        if (isTaskReport && !isCanceledTaskReport) {
-            if (isCompletedTaskReport(report) && isTaskActionable) {
-                items.push({
-                    key: CONST.REPORT_DETAILS_MENU_ITEM.MARK_AS_INCOMPLETE,
-                    icon: expensifyIcons.Checkmark,
-                    translationKey: 'task.markAsIncomplete',
-                    isAnonymousAction: false,
-                    action: callFunctionIfActionIsAllowed(() => {
-                        Navigation.goBack(navigateBackFromReportDetailsPath);
-                        reopenTask(report, parentReport, currentUserPersonalDetails?.accountID, delegateEmail);
-                    }),
-                });
-            }
-        }
-
-        if (shouldShowGoToWorkspace) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.GO_TO_WORKSPACE,
-                translationKey: 'workspace.common.goToWorkspace',
-                icon: expensifyIcons.Building,
-                action: () => {
-                    if (!report?.policyID) {
-                        return;
-                    }
-                    if (isSmallScreenWidth) {
-                        Navigation.navigate(ROUTES.WORKSPACE_INITIAL.getRoute(report?.policyID, Navigation.getActiveRoute()));
-                    } else {
-                        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW.getRoute(report?.policyID));
-                    }
-                },
-                isAnonymousAction: false,
-                shouldShowRightIcon: true,
-            });
-        }
-
-        if (shouldShowLeaveButton) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.LEAVE_ROOM,
-                translationKey: 'common.leave',
-                icon: expensifyIcons.Exit,
-                isAnonymousAction: true,
-                action: () => {
-                    if (getParticipantsAccountIDsForDisplay(report, false, true).length === 1 && isRootGroupChat) {
-                        showLastMemberLeavingModal();
-                        return;
-                    }
-
-                    leaveChat();
-                },
-            });
-        }
-
-        if (report?.reportID && isDebugModeEnabled) {
-            items.push({
-                key: CONST.REPORT_DETAILS_MENU_ITEM.DEBUG,
-                translationKey: 'debug.debug',
-                icon: expensifyIcons.Bug,
-                action: () => Navigation.navigate(ROUTES.DEBUG_REPORT.getRoute(report.reportID)),
-                isAnonymousAction: true,
-                shouldShowRightIcon: true,
-            });
-        }
-
-        return items;
-    }, [
-        isSelfDM,
-        isArchivedRoom,
-        shouldShowGoToRoom,
-        isGroupChat,
-        isDefaultRoom,
-        isChatThread,
-        isPolicyEmployee,
-        isUserCreatedPolicyRoom,
-        participants.length,
-        report,
-        isSystemChat,
-        activeChatMembers.length,
-        isPolicyExpenseChat,
-        shouldShowMenuItem,
-        isTrackExpenseReport,
-        isDeletedParentAction,
-        isMoneyRequestReport,
-        isInvoiceReport,
-        isTaskReport,
-        isCanceledTaskReport,
-        shouldShowGoToWorkspace,
-        shouldShowLeaveButton,
-        isDebugModeEnabled,
-        expensifyIcons.Users,
-        expensifyIcons.Gear,
-        expensifyIcons.Send,
-        expensifyIcons.Folder,
-        expensifyIcons.UserPlus,
-        expensifyIcons.Pencil,
-        expensifyIcons.Checkmark,
-        expensifyIcons.Building,
-        expensifyIcons.Exit,
-        expensifyIcons.Bug,
-        expensifyIcons.Hashtag,
-        styles.ph2,
-        shouldOpenRoomMembersPage,
-        navigateBackFromReportDetailsPath,
-        actionReportID,
-        actionReportActions,
-        iouTransactionID,
-        moneyRequestReport?.reportID,
-        moneyRequestReportActions,
-        currentUserPersonalDetails.accountID,
-        currentUserPersonalDetails.email,
-        currentUserPersonalDetails.localCurrencyCode,
-        isTaskActionable,
-        isRootGroupChat,
-        leaveChat,
-        showLastMemberLeavingModal,
-        isSmallScreenWidth,
-        isRestrictedToPreferredPolicy,
-        preferredPolicyID,
-        introSelected,
-        draftTransactionIDs,
-        activePolicy,
-        userBillingGracePeriodEnds,
-        amountOwed,
-        ownerBillingGracePeriodEnd,
-        iouTransaction,
-        iouOriginalTransaction,
-        hasWorkspaceToSubmitTo,
-        filteredPoliciesInfo?.filteredPoliciesCount,
-        filteredPoliciesInfo?.firstPolicyID,
-        parentReport,
-        delegateEmail,
-        conciergeReportID,
-        lastWorkspaceNumber,
-        translate,
-        currentUserPersonalDetails.displayName,
-    ]);
 
     const icons = useMemo(
         () => getIcons(report, formatPhoneNumber, translate, personalDetails, null, '', -1, policy, undefined, isReportArchived, pendingDeleteMemberAccountIDs),
@@ -1281,19 +781,44 @@ function DynamicReportDetailsPage({policy, report, route, reportMetadata, report
                         promotedActions={promotedActions}
                     />
 
-                    {menuItems.map((item) => (
-                        <MenuItem
-                            key={item.key}
-                            title={translate(item.translationKey)}
-                            subtitle={item.subtitle}
-                            icon={item.icon}
-                            onPress={item.action}
-                            isAnonymousAction={item.isAnonymousAction}
-                            shouldShowRightIcon={item.shouldShowRightIcon}
-                            brickRoadIndicator={item.brickRoadIndicator}
-                            subtitleStyle={item.subtitleStyle}
-                        />
-                    ))}
+                    <ReportDetailsMenuItems
+                        report={report}
+                        policy={policy}
+                        parentReport={parentReport}
+                        participants={participants}
+                        pendingChatMembers={reportMetadata?.pendingChatMembers}
+                        personalDetails={personalDetails}
+                        conciergeReportID={conciergeReportID}
+                        delegateEmail={delegateEmail}
+                        actionReportID={actionReportID}
+                        iouTransactionID={iouTransactionID}
+                        iouTransaction={iouTransaction}
+                        iouOriginalTransaction={iouOriginalTransaction}
+                        moneyRequestReportID={moneyRequestReport?.reportID}
+                        moneyRequestReportActions={moneyRequestReportActions}
+                        navigateBackFromReportDetailsPath={navigateBackFromReportDetailsPath}
+                        isReportArchived={isReportArchived}
+                        isArchivedRoom={isArchivedRoom}
+                        isSelfDM={isSelfDM}
+                        isChatRoom={isChatRoom}
+                        isGroupChat={isGroupChat}
+                        isRootGroupChat={isRootGroupChat}
+                        isDefaultRoom={isDefaultRoom}
+                        isChatThread={isChatThread}
+                        isSystemChat={isSystemChat}
+                        isPolicyAdmin={isPolicyAdmin}
+                        isPolicyEmployee={isPolicyEmployee}
+                        isPolicyExpenseChat={isPolicyExpenseChat}
+                        isUserCreatedPolicyRoom={isUserCreatedPolicyRoom}
+                        isTrackExpenseReport={isTrackExpenseReport}
+                        isDeletedParentAction={isDeletedParentAction}
+                        isMoneyRequestReport={isMoneyRequestReport}
+                        isInvoiceReport={isInvoiceReport}
+                        isTaskReport={isTaskReport}
+                        isCanceledTaskReport={isCanceledTaskReport}
+                        isTaskActionable={isTaskActionable}
+                        shouldOpenRoomMembersPage={shouldOpenRoomMembersPage}
+                    />
 
                     {shouldShowDeleteButton && (
                         <MenuItemAction

--- a/src/pages/inbox/report/ReportDetailsMenuItems.tsx
+++ b/src/pages/inbox/report/ReportDetailsMenuItems.tsx
@@ -1,0 +1,558 @@
+import MenuItem from '@components/MenuItem';
+import {ModalActions} from '@components/Modal/Global/ModalContext';
+
+import useActivePolicy from '@hooks/useActivePolicy';
+import useConfirmModal from '@hooks/useConfirmModal';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useLastWorkspaceNumber from '@hooks/useLastWorkspaceNumber';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
+import usePreferredPolicy from '@hooks/usePreferredPolicy';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import {generateDefaultWorkspaceName} from '@libs/actions/Policy/Policy';
+import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
+import Navigation from '@libs/Navigation/Navigation';
+import Permissions from '@libs/Permissions';
+import {shouldShowPolicy} from '@libs/PolicyUtils';
+import {getTrackExpenseActionableWhisper} from '@libs/ReportActionsUtils';
+import {
+    canLeaveChat,
+    createDraftTransactionAndNavigateToParticipantSelector,
+    getParticipantsAccountIDsForDisplay,
+    isCompletedTaskReport,
+    isConciergeChatReport,
+    isHiddenForCurrentUser,
+    isPublicRoom,
+    isWorkspaceMemberLeavingWorkspaceRoom as isWorkspaceMemberLeavingWorkspaceRoomUtil,
+    navigateToPrivateNotes,
+} from '@libs/ReportUtils';
+import {getOriginalTransactionWithSplitInfo} from '@libs/TransactionUtils';
+
+import {hasErrorInPrivateNotes, leaveGroupChat, leaveRoom} from '@userActions/Report';
+import {callFunctionIfActionIsAllowed} from '@userActions/Session';
+import {reopenTask} from '@userActions/Task';
+
+import CONST from '@src/CONST';
+import type {TranslationPaths} from '@src/languages/types';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Route} from '@src/ROUTES';
+import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+import type * as OnyxTypes from '@src/types/onyx';
+import type DeepValueOf from '@src/types/utils/DeepValueOf';
+import type IconAsset from '@src/types/utils/IconAsset';
+
+import type {StyleProp, ViewStyle} from 'react-native';
+import type {OnyxEntry} from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
+
+import {useFocusEffect} from '@react-navigation/native';
+import {hasSeenTourSelector} from '@selectors/Onboarding';
+import {createFilteredPoliciesInfoSelector, createHasWorkspaceToSubmitToSelector} from '@selectors/Policy';
+import {validTransactionDraftIDsSelector} from '@selectors/TransactionDraft';
+import React, {useState} from 'react';
+
+type ReportDetailsMenuItem = {
+    key: DeepValueOf<typeof CONST.REPORT_DETAILS_MENU_ITEM>;
+    translationKey: TranslationPaths;
+    icon: IconAsset;
+    isAnonymousAction: boolean;
+    action: () => void;
+    brickRoadIndicator?: ValueOf<typeof CONST.BRICK_ROAD_INDICATOR_STATUS>;
+    subtitle?: number;
+    shouldShowRightIcon?: boolean;
+    subtitleStyle?: StyleProp<ViewStyle>;
+};
+
+type ReportDetailsMenuItemsProps = {
+    /** The report whose details page is displayed */
+    report: OnyxTypes.Report;
+
+    /** The policy the report belongs to */
+    policy: OnyxEntry<OnyxTypes.Policy>;
+
+    /** The parent of the report */
+    parentReport: OnyxEntry<OnyxTypes.Report>;
+
+    /** Account IDs of the participants displayed on the page */
+    participants: number[];
+
+    /** Members with a pending add/remove action on the report */
+    pendingChatMembers: OnyxTypes.ReportMetadata['pendingChatMembers'];
+
+    /** Personal details of all known users */
+    personalDetails: OnyxEntry<OnyxTypes.PersonalDetailsList>;
+
+    /** ID of the Concierge chat */
+    conciergeReportID: string | undefined;
+
+    /** Email of the delegate acting on behalf of the current user */
+    delegateEmail: string | undefined;
+
+    /** Report the tracked expense would be submitted/categorized/shared from */
+    actionReportID: string | undefined;
+
+    /** ID of the transaction of the money request, if any */
+    iouTransactionID: string | undefined;
+
+    /** Transaction of the money request, if any */
+    iouTransaction: OnyxEntry<OnyxTypes.Transaction>;
+
+    /** Original transaction the money request transaction was split from, if any */
+    iouOriginalTransaction: OnyxEntry<OnyxTypes.Transaction>;
+
+    /** ID of the money request report the tracked expense lives on */
+    moneyRequestReportID: string | undefined;
+
+    /** Actions of the money request report */
+    moneyRequestReportActions: OnyxEntry<OnyxTypes.ReportActions>;
+
+    /** Where to navigate back to when leaving the details page */
+    navigateBackFromReportDetailsPath: Route;
+
+    /** Whether the report is archived */
+    isReportArchived: boolean;
+
+    /** Whether the report is an archived non-expense report */
+    isArchivedRoom: boolean;
+
+    isSelfDM: boolean;
+    isChatRoom: boolean;
+    isGroupChat: boolean;
+    isRootGroupChat: boolean;
+    isDefaultRoom: boolean;
+    isChatThread: boolean;
+    isSystemChat: boolean;
+    isPolicyAdmin: boolean;
+    isPolicyEmployee: boolean;
+    isPolicyExpenseChat: boolean;
+    isUserCreatedPolicyRoom: boolean;
+    isTrackExpenseReport: boolean;
+    isDeletedParentAction: boolean;
+    isMoneyRequestReport: boolean;
+    isInvoiceReport: boolean;
+    isTaskReport: boolean;
+    isCanceledTaskReport: boolean;
+    isTaskActionable: boolean;
+
+    /** Whether the Members row opens the room members page instead of the participants page */
+    shouldOpenRoomMembersPage: boolean;
+};
+
+function ReportDetailsMenuItems({
+    report,
+    policy,
+    parentReport,
+    participants,
+    pendingChatMembers,
+    personalDetails,
+    conciergeReportID,
+    delegateEmail,
+    actionReportID,
+    iouTransactionID,
+    iouTransaction,
+    iouOriginalTransaction,
+    moneyRequestReportID,
+    moneyRequestReportActions,
+    navigateBackFromReportDetailsPath,
+    isReportArchived,
+    isArchivedRoom,
+    isSelfDM,
+    isChatRoom,
+    isGroupChat,
+    isRootGroupChat,
+    isDefaultRoom,
+    isChatThread,
+    isSystemChat,
+    isPolicyAdmin,
+    isPolicyEmployee,
+    isPolicyExpenseChat,
+    isUserCreatedPolicyRoom,
+    isTrackExpenseReport,
+    isDeletedParentAction,
+    isMoneyRequestReport,
+    isInvoiceReport,
+    isTaskReport,
+    isCanceledTaskReport,
+    isTaskActionable,
+    shouldOpenRoomMembersPage,
+}: ReportDetailsMenuItemsProps) {
+    const {translate} = useLocalize();
+    const styles = useThemeStyles();
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Users', 'Gear', 'Send', 'Folder', 'UserPlus', 'Pencil', 'Checkmark', 'Building', 'Exit', 'Bug', 'Hashtag']);
+    const currentUserPersonalDetails = useCurrentUserPersonalDetails();
+    const {isRestrictedToPreferredPolicy, preferredPolicyID} = usePreferredPolicy();
+    const activePolicy = useActivePolicy();
+    const lastWorkspaceNumber = useLastWorkspaceNumber();
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {isSmallScreenWidth} = useResponsiveLayout();
+    const {showConfirmModal} = useConfirmModal();
+
+    const [userBillingGracePeriodEnds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_USER_BILLING_GRACE_PERIOD_END);
+    const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
+    const [ownerBillingGracePeriodEnd] = useOnyx(ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END);
+    const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
+    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
+    const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: hasSeenTourSelector});
+    const [betas] = useOnyx(ONYXKEYS.BETAS);
+    const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
+    const [isDebugModeEnabled = false] = useOnyx(ONYXKEYS.IS_DEBUG_MODE_ENABLED);
+    const [actionReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${actionReportID}`);
+    const filteredPoliciesInfoSelector = createFilteredPoliciesInfoSelector(currentUserPersonalDetails?.email);
+    const [filteredPoliciesInfo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: filteredPoliciesInfoSelector});
+    const hasWorkspaceToSubmitToSelector = createHasWorkspaceToSubmitToSelector(currentUserPersonalDetails.login);
+    const [hasWorkspaceToSubmitTo] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: hasWorkspaceToSubmitToSelector});
+
+    // Snapshot on focus whether the room is the screen behind the Details page, so the row doesn't flip while the page
+    // is closing after it's tapped, yet still reflects the correct screen on later visits.
+    const [isRoomCurrentlyOpen, setIsRoomCurrentlyOpen] = useState(() => isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    useFocusEffect(() => {
+        setIsRoomCurrentlyOpen(isReportTopmostSplitNavigator() && Navigation.getTopmostReportId() === report?.reportID);
+    });
+
+    const shouldShowGoToRoom = (isChatRoom || isPolicyExpenseChat) && !isRoomCurrentlyOpen;
+    const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending && !shouldShowGoToRoom;
+    const shouldShowLeaveButton = canLeaveChat(report, policy, currentUserPersonalDetails?.accountID, isReportArchived);
+
+    const shouldShowNotificationPref = !isMoneyRequestReport && !isHiddenForCurrentUser(report);
+    const shouldShowWriteCapability = !isMoneyRequestReport;
+    const shouldShowSettings = shouldShowNotificationPref || shouldShowWriteCapability || (!!report?.visibility && report.chatType !== CONST.REPORT.CHAT_TYPE.INVOICE);
+
+    // Get the active chat members by filtering out the pending members with delete action
+    const activeChatMembers = participants.flatMap((accountID) => {
+        const pendingMember = pendingChatMembers?.findLast((member) => member.accountID === accountID.toString());
+        const detail = personalDetails?.[accountID];
+        if (!detail) {
+            return [];
+        }
+        return pendingMember?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE ? accountID : [];
+    });
+
+    const leaveChat = () => {
+        if (isRootGroupChat) {
+            leaveGroupChat(
+                report,
+                quickAction?.chatReportID?.toString() === report.reportID,
+                currentUserPersonalDetails.accountID,
+                conciergeReportID,
+                introSelected,
+                isSelfTourViewed,
+                betas,
+            );
+            return;
+        }
+
+        const isWorkspaceMemberLeavingWorkspaceRoom = isWorkspaceMemberLeavingWorkspaceRoomUtil(report, isPolicyEmployee, isPolicyAdmin);
+        leaveRoom(report, currentUserPersonalDetails.accountID, conciergeReportID, introSelected, isSelfTourViewed, betas, isWorkspaceMemberLeavingWorkspaceRoom);
+    };
+
+    const showLastMemberLeavingModal = async () => {
+        const {action} = await showConfirmModal({
+            title: translate('groupChat.lastMemberTitle'),
+            prompt: translate('groupChat.lastMemberWarning'),
+            confirmText: translate('common.leave'),
+            cancelText: translate('common.cancel'),
+            buttonVariant: CONST.BUTTON_VARIANT.DANGER,
+            shouldHandleNavigationBack: false,
+        });
+        if (action !== ModalActions.CONFIRM) {
+            return;
+        }
+        leaveChat();
+    };
+
+    const items: ReportDetailsMenuItem[] = [];
+
+    if (isSelfDM || isArchivedRoom) {
+        return null;
+    }
+
+    if (shouldShowGoToRoom) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.GO_TO_ROOM,
+            translationKey: 'reportDetailsPage.goToRoom',
+            icon: expensifyIcons.Hashtag,
+            isAnonymousAction: false,
+            shouldShowRightIcon: true,
+            action: () => {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report?.reportID));
+            },
+        });
+    }
+
+    // The Members page is only shown when:
+    // - The report is a thread in a chat report
+    // - The report is not a user created room with participants to show i.e. DM, Group Chat, etc
+    // - The report is a user created room and the room and the current user is a workspace member i.e. non-workspace members should not see this option.
+    if (
+        (isGroupChat ||
+            (isDefaultRoom && isChatThread && isPolicyEmployee) ||
+            (!isUserCreatedPolicyRoom && participants.length) ||
+            (isUserCreatedPolicyRoom && (isPolicyEmployee || (isChatThread && !isPublicRoom(report))))) &&
+        !isConciergeChatReport(report, conciergeReportID) &&
+        !isSystemChat &&
+        activeChatMembers.length > 0
+    ) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.MEMBERS,
+            translationKey: 'common.members',
+            icon: expensifyIcons.Users,
+            subtitle: activeChatMembers.length,
+            subtitleStyle: [styles.ph2],
+            isAnonymousAction: false,
+            shouldShowRightIcon: true,
+            action: () => {
+                if (shouldOpenRoomMembersPage) {
+                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.ROOM_MEMBERS.path));
+                } else {
+                    Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.REPORT_PARTICIPANTS.path));
+                }
+            },
+        });
+    } else if ((isUserCreatedPolicyRoom && (!participants.length || !isPolicyEmployee)) || ((isDefaultRoom || isPolicyExpenseChat) && isChatThread && !isPolicyEmployee)) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.INVITE,
+            translationKey: 'common.invite',
+            icon: expensifyIcons.Users,
+            isAnonymousAction: false,
+            shouldShowRightIcon: true,
+            action: () => {
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.ROOM_INVITE.path));
+            },
+        });
+    }
+
+    if (shouldShowSettings) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.SETTINGS,
+            translationKey: 'common.settings',
+            icon: expensifyIcons.Gear,
+            isAnonymousAction: false,
+            shouldShowRightIcon: true,
+            action: () => {
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.REPORT_SETTINGS.path));
+            },
+        });
+    }
+
+    if (isTrackExpenseReport && !isDeletedParentAction) {
+        const whisperAction = getTrackExpenseActionableWhisper(iouTransactionID, moneyRequestReportID, moneyRequestReportActions);
+        const actionableWhisperReportActionID = whisperAction?.reportActionID;
+        const currentUserLocalCurrency = currentUserPersonalDetails.localCurrencyCode ?? CONST.CURRENCY.USD;
+        const {isExpenseSplit: isSelfDMExpenseSplit} = getOriginalTransactionWithSplitInfo(iouTransaction, iouOriginalTransaction);
+
+        // Hide the "Submit it to someone" option for self-DM split expenses when the user isn't a member of any workspace.
+        if (!isSelfDMExpenseSplit || hasWorkspaceToSubmitTo) {
+            const baseSubmitParams = {
+                reportID: actionReportID,
+                reportActions: actionReportActions,
+                reportActionID: actionableWhisperReportActionID,
+                introSelected,
+                draftTransactionIDs,
+                activePolicy,
+                userBillingGracePeriodEnds,
+                amountOwed,
+                ownerBillingGracePeriodEnd,
+                isRestrictedToPreferredPolicy,
+                preferredPolicyID,
+                transaction: iouTransaction,
+                currentUserAccountID: currentUserPersonalDetails.accountID,
+                currentUserEmail: currentUserPersonalDetails.email ?? '',
+                currentUserLocalCurrency,
+                filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
+                firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
+            };
+            // "Submit to someone" splits into two destinations here too, matching the track-expense whisper:
+            // submit to an individual ("a friend") or a submit-enabled workspace ("my employer").
+            const defaultWorkspaceName = generateDefaultWorkspaceName(currentUserPersonalDetails.email ?? '', lastWorkspaceNumber, translate, currentUserPersonalDetails.displayName);
+
+            // Self-DM split expenses can only be submitted to a workspace, so the "a friend" destination is omitted here
+            // just like it is on the track-expense whisper.
+            if (!isSelfDMExpenseSplit) {
+                items.push({
+                    key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.SUBMIT_TO_FRIEND,
+                    translationKey: 'actionableMentionTrackExpense.submitToFriend',
+                    icon: expensifyIcons.Send,
+                    isAnonymousAction: false,
+                    shouldShowRightIcon: true,
+                    action: () => {
+                        createDraftTransactionAndNavigateToParticipantSelector({
+                            ...baseSubmitParams,
+                            actionName: CONST.IOU.ACTION.SUBMIT,
+                            submitDestination: CONST.IOU.SUBMIT_DESTINATION.FRIEND,
+                            defaultWorkspaceName,
+                        });
+                    },
+                });
+            }
+            items.push({
+                key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.SUBMIT_TO_EMPLOYER,
+                translationKey: 'actionableMentionTrackExpense.submitToEmployer',
+                icon: expensifyIcons.Send,
+                isAnonymousAction: false,
+                shouldShowRightIcon: true,
+                action: () => {
+                    createDraftTransactionAndNavigateToParticipantSelector({
+                        ...baseSubmitParams,
+                        actionName: CONST.IOU.ACTION.SUBMIT,
+                        submitDestination: CONST.IOU.SUBMIT_DESTINATION.EMPLOYER,
+                        defaultWorkspaceName,
+                    });
+                },
+            });
+        }
+        if (Permissions.canUseTrackFlows()) {
+            items.push({
+                key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.CATEGORIZE,
+                translationKey: 'actionableMentionTrackExpense.categorize',
+                icon: expensifyIcons.Folder,
+                isAnonymousAction: false,
+                shouldShowRightIcon: true,
+                action: () => {
+                    createDraftTransactionAndNavigateToParticipantSelector({
+                        reportID: actionReportID,
+                        reportActions: actionReportActions,
+                        actionName: CONST.IOU.ACTION.CATEGORIZE,
+                        reportActionID: actionableWhisperReportActionID,
+                        introSelected,
+                        draftTransactionIDs,
+                        activePolicy,
+                        userBillingGracePeriodEnds,
+                        amountOwed,
+                        ownerBillingGracePeriodEnd,
+                        transaction: iouTransaction,
+                        currentUserAccountID: currentUserPersonalDetails.accountID,
+                        currentUserEmail: currentUserPersonalDetails.email ?? '',
+                        currentUserLocalCurrency,
+                        filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
+                        firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
+                    });
+                },
+            });
+            items.push({
+                key: CONST.REPORT_DETAILS_MENU_ITEM.TRACK.SHARE,
+                translationKey: 'actionableMentionTrackExpense.share',
+                icon: expensifyIcons.UserPlus,
+                isAnonymousAction: false,
+                shouldShowRightIcon: true,
+                action: () => {
+                    createDraftTransactionAndNavigateToParticipantSelector({
+                        reportID: actionReportID,
+                        reportActions: actionReportActions,
+                        actionName: CONST.IOU.ACTION.SHARE,
+                        reportActionID: actionableWhisperReportActionID,
+                        introSelected,
+                        draftTransactionIDs,
+                        activePolicy,
+                        userBillingGracePeriodEnds,
+                        amountOwed,
+                        ownerBillingGracePeriodEnd,
+                        transaction: iouTransaction,
+                        currentUserAccountID: currentUserPersonalDetails.accountID,
+                        currentUserEmail: currentUserPersonalDetails.email ?? '',
+                        currentUserLocalCurrency,
+                        filteredPoliciesCount: filteredPoliciesInfo?.filteredPoliciesCount ?? 0,
+                        firstPolicyID: filteredPoliciesInfo?.firstPolicyID,
+                    });
+                },
+            });
+        }
+    }
+
+    // Prevent displaying private notes option for threads and task reports, or when the feature is disabled
+    if (Permissions.canUsePrivateNotes() && !isChatThread && !isMoneyRequestReport && !isInvoiceReport && !isTaskReport) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.PRIVATE_NOTES,
+            translationKey: 'privateNotes.title',
+            icon: expensifyIcons.Pencil,
+            isAnonymousAction: false,
+            shouldShowRightIcon: true,
+            action: () => navigateToPrivateNotes(report, currentUserPersonalDetails.accountID),
+            brickRoadIndicator: hasErrorInPrivateNotes(report) ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined,
+        });
+    }
+
+    // Show actions related to Task Reports
+    if (isTaskReport && !isCanceledTaskReport && isCompletedTaskReport(report) && isTaskActionable) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.MARK_AS_INCOMPLETE,
+            icon: expensifyIcons.Checkmark,
+            translationKey: 'task.markAsIncomplete',
+            isAnonymousAction: false,
+            action: callFunctionIfActionIsAllowed(() => {
+                Navigation.goBack(navigateBackFromReportDetailsPath);
+                reopenTask(report, parentReport, currentUserPersonalDetails?.accountID, delegateEmail);
+            }),
+        });
+    }
+
+    if (shouldShowGoToWorkspace) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.GO_TO_WORKSPACE,
+            translationKey: 'workspace.common.goToWorkspace',
+            icon: expensifyIcons.Building,
+            action: () => {
+                if (!report?.policyID) {
+                    return;
+                }
+                if (isSmallScreenWidth) {
+                    Navigation.navigate(ROUTES.WORKSPACE_INITIAL.getRoute(report?.policyID, Navigation.getActiveRoute()));
+                } else {
+                    Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW.getRoute(report?.policyID));
+                }
+            },
+            isAnonymousAction: false,
+            shouldShowRightIcon: true,
+        });
+    }
+
+    if (shouldShowLeaveButton) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.LEAVE_ROOM,
+            translationKey: 'common.leave',
+            icon: expensifyIcons.Exit,
+            isAnonymousAction: true,
+            action: () => {
+                if (getParticipantsAccountIDsForDisplay(report, false, true).length === 1 && isRootGroupChat) {
+                    showLastMemberLeavingModal();
+                    return;
+                }
+
+                leaveChat();
+            },
+        });
+    }
+
+    if (report?.reportID && isDebugModeEnabled) {
+        items.push({
+            key: CONST.REPORT_DETAILS_MENU_ITEM.DEBUG,
+            translationKey: 'debug.debug',
+            icon: expensifyIcons.Bug,
+            action: () => Navigation.navigate(ROUTES.DEBUG_REPORT.getRoute(report.reportID)),
+            isAnonymousAction: true,
+            shouldShowRightIcon: true,
+        });
+    }
+
+    return items.map((item) => (
+        <MenuItem
+            key={item.key}
+            title={translate(item.translationKey)}
+            subtitle={item.subtitle}
+            icon={item.icon}
+            onPress={item.action}
+            isAnonymousAction={item.isAnonymousAction}
+            shouldShowRightIcon={item.shouldShowRightIcon}
+            brickRoadIndicator={item.brickRoadIndicator}
+            subtitleStyle={item.subtitleStyle}
+        />
+    ));
+}
+
+ReportDetailsMenuItems.displayName = 'ReportDetailsMenuItems';
+
+export default ReportDetailsMenuItems;
+export type {ReportDetailsMenuItemsProps};

--- a/tests/perf-test/DynamicReportDetailsPage.perf-test.tsx
+++ b/tests/perf-test/DynamicReportDetailsPage.perf-test.tsx
@@ -1,0 +1,277 @@
+import {act, render, screen} from '@testing-library/react-native';
+
+import {loadExpensifyIconsChunk} from '@components/Icon/ExpensifyIconLoader';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import type Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {ReportDetailsNavigatorParamList} from '@libs/Navigation/types';
+import {setHasRadio} from '@libs/NetworkState';
+import {buildParticipantsFromAccountIDs} from '@libs/ReportUtils';
+
+import DynamicReportDetailsPage from '@pages/DynamicReportDetailsPage';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type SCREENS from '@src/SCREENS';
+import type {PersonalDetailsList, Report, ReportAction, Transaction} from '@src/types/onyx';
+
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import {measureAsyncFunction, measureRenders} from 'reassure';
+
+import createRandomReportAction from '../utils/collections/reportActions';
+import createRandomTransaction from '../utils/collections/transaction';
+import createMock from '../utils/createMock';
+import * as LHNTestUtils from '../utils/LHNTestUtils';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
+
+jest.mock('@src/components/ConfirmedRoute.tsx');
+jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => jest.fn(() => false));
+jest.mock('@react-navigation/native', () => {
+    const actualNav = jest.requireActual<typeof Navigation>('@react-navigation/native');
+    return {
+        ...actualNav,
+        useFocusEffect: jest.fn(),
+        useIsFocused: () => true,
+        useRoute: jest.fn(),
+        usePreventRemove: jest.fn(),
+    };
+});
+
+const CURRENT_USER_ACCOUNT_ID = 1;
+const CURRENT_USER_LOGIN = 'user1@test.com';
+const MEMBER_COUNT = 50;
+const POLICY_ID = '1';
+const ROOM_REPORT_ID = '100';
+const SELF_DM_REPORT_ID = '200';
+const TRACK_EXPENSE_REPORT_ID = '201';
+const TRACK_EXPENSE_ACTION_ID = '202';
+const TRACK_TRANSACTION_ID = '203';
+
+const navigationMock = createMock<PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['navigation']>({});
+const getRouteMock = (reportID: string) => createMock<PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.DYNAMIC_ROOT>['route']>({params: {reportID}});
+
+const memberAccountIDs = Array.from({length: MEMBER_COUNT}, (_, index) => index + 1);
+const personalDetails: PersonalDetailsList = Object.fromEntries(
+    memberAccountIDs.map((accountID) => [
+        accountID,
+        {
+            accountID,
+            login: `user${accountID}@test.com`,
+            displayName: `User ${accountID}`,
+            avatar: 'none',
+        },
+    ]),
+);
+
+const policy = {
+    ...LHNTestUtils.getFakePolicy(POLICY_ID, 'Perf Workspace'),
+    owner: CURRENT_USER_LOGIN,
+    ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+    employeeList: {
+        [CURRENT_USER_LOGIN]: {email: CURRENT_USER_LOGIN, role: CONST.POLICY.ROLE.ADMIN},
+    },
+};
+
+// A user-created policy room with many members: shows "Go to room", "Members", "Settings" and "Leave".
+const policyRoom: Report = {
+    reportID: ROOM_REPORT_ID,
+    reportName: '#perf-room',
+    type: CONST.REPORT.TYPE.CHAT,
+    chatType: CONST.REPORT.CHAT_TYPE.POLICY_ROOM,
+    policyID: POLICY_ID,
+    visibility: CONST.REPORT.VISIBILITY.RESTRICTED,
+    writeCapability: CONST.REPORT.WRITE_CAPABILITIES.ALL,
+    participants: buildParticipantsFromAccountIDs(memberAccountIDs),
+    lastMessageText: 'hey',
+};
+
+// A tracked expense in the self DM: exercises the heaviest menu branch (submit-to-friend / submit-to-employer).
+const selfDMReport: Report = {
+    reportID: SELF_DM_REPORT_ID,
+    reportName: '',
+    type: CONST.REPORT.TYPE.CHAT,
+    chatType: CONST.REPORT.CHAT_TYPE.SELF_DM,
+    ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+    participants: buildParticipantsFromAccountIDs([CURRENT_USER_ACCOUNT_ID]),
+};
+const trackExpenseReport: Report = {
+    reportID: TRACK_EXPENSE_REPORT_ID,
+    reportName: 'Expense',
+    type: CONST.REPORT.TYPE.CHAT,
+    ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+    parentReportID: SELF_DM_REPORT_ID,
+    parentReportActionID: TRACK_EXPENSE_ACTION_ID,
+    participants: buildParticipantsFromAccountIDs([CURRENT_USER_ACCOUNT_ID]),
+};
+const trackExpenseAction = {
+    ...createRandomReportAction(Number(TRACK_EXPENSE_ACTION_ID)),
+    actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+    actorAccountID: CURRENT_USER_ACCOUNT_ID,
+    childReportID: TRACK_EXPENSE_REPORT_ID,
+    originalMessage: {
+        type: CONST.IOU.REPORT_ACTION_TYPE.TRACK,
+        IOUTransactionID: TRACK_TRANSACTION_ID,
+        amount: 1000,
+        currency: CONST.CURRENCY.USD,
+    },
+    pendingAction: null,
+} as ReportAction;
+const trackTransaction: Transaction = {
+    ...createRandomTransaction(Number(TRACK_TRANSACTION_ID)),
+    transactionID: TRACK_TRANSACTION_ID,
+    reportID: CONST.REPORT.UNREPORTED_REPORT_ID,
+    comment: {liabilityType: CONST.TRANSACTION.LIABILITY_TYPE.ALLOW},
+};
+
+const settledLoadingState = {
+    isLoadingInitialReportActions: false,
+    hasOnceLoadedReportActions: true,
+    isLoadingOlderReportActions: false,
+    isLoadingNewerReportActions: false,
+    // Marks the private notes fetch as already triggered so the page does not fire an API call on mount.
+    isLoadingPrivateNotes: false,
+};
+
+function renderDetailsPage(reportID: string, report: Report) {
+    return (
+        <OnyxListItemProvider>
+            <LocaleContextProvider>
+                <DynamicReportDetailsPage
+                    betas={[]}
+                    isLoadingReportData={false}
+                    navigation={navigationMock}
+                    policy={undefined}
+                    report={report}
+                    reportMetadata={undefined}
+                    reportLoadingState={undefined}
+                    route={getRouteMock(reportID)}
+                />
+            </LocaleContextProvider>
+        </OnyxListItemProvider>
+    );
+}
+
+async function seedPolicyRoom() {
+    await act(async () => {
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${ROOM_REPORT_ID}`, policyRoom);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${ROOM_REPORT_ID}`, settledLoadingState);
+        await waitForBatchedUpdates();
+    });
+}
+
+async function seedTrackExpense() {
+    await act(async () => {
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${SELF_DM_REPORT_ID}`, selfDMReport);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${TRACK_EXPENSE_REPORT_ID}`, trackExpenseReport);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${SELF_DM_REPORT_ID}`, {[TRACK_EXPENSE_ACTION_ID]: trackExpenseAction});
+        await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${TRACK_TRANSACTION_ID}`, trackTransaction);
+        await Onyx.set(`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${TRACK_EXPENSE_REPORT_ID}`, settledLoadingState);
+        await waitForBatchedUpdates();
+    });
+}
+
+describe('DynamicReportDetailsPage', () => {
+    beforeAll(async () => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            evictableKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        });
+        // Load the icon chunk once so the menu rows render their icons synchronously instead of after an async state update.
+        await loadExpensifyIconsChunk();
+    });
+
+    beforeEach(async () => {
+        global.fetch = TestHelper.getGlobalFetchMock();
+        wrapOnyxWithWaitForBatchedUpdates(Onyx);
+        setHasRadio(true);
+        await act(async () => {
+            TestHelper.signInWithTestUser(CURRENT_USER_ACCOUNT_ID, CURRENT_USER_LOGIN);
+            await waitForBatchedUpdates();
+            await Onyx.multiSet({
+                [ONYXKEYS.NVP_PREFERRED_LOCALE]: CONST.LOCALES.DEFAULT,
+                [ONYXKEYS.IS_LOADING_REPORT_DATA]: false,
+                [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: false,
+            });
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+            await waitForBatchedUpdates();
+        });
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+            await waitForBatchedUpdates();
+        });
+    });
+
+    test('[DynamicReportDetailsPage] should mount policy room details with 50 members', async () => {
+        await seedPolicyRoom();
+        const scenario = async () => {
+            await screen.findByText(TestHelper.translateLocal('common.settings'));
+        };
+        await measureRenders(renderDetailsPage(ROOM_REPORT_ID, policyRoom), {scenario});
+    });
+
+    test('[DynamicReportDetailsPage] should mount self-DM tracked expense details', async () => {
+        await seedTrackExpense();
+        const scenario = async () => {
+            await screen.findByText(TestHelper.translateLocal('actionableMentionTrackExpense.submitToEmployer'));
+        };
+        await measureRenders(renderDetailsPage(TRACK_EXPENSE_REPORT_ID, trackExpenseReport), {scenario});
+    });
+
+    test('[DynamicReportDetailsPage] should re-render mounted policy room details when the quick action changes', async () => {
+        await seedPolicyRoom();
+        render(renderDetailsPage(ROOM_REPORT_ID, policyRoom));
+        await waitForBatchedUpdatesWithAct();
+        await screen.findByText(TestHelper.translateLocal('common.settings'));
+
+        let iteration = 0;
+        await measureAsyncFunction(async () => {
+            iteration++;
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE, {action: CONST.QUICK_ACTIONS.REQUEST_MANUAL, chatReportID: `${iteration}`});
+                await waitForBatchedUpdates();
+            });
+        });
+    });
+
+    test('[DynamicReportDetailsPage] should re-render mounted policy room details when debug mode toggles', async () => {
+        await seedPolicyRoom();
+        render(renderDetailsPage(ROOM_REPORT_ID, policyRoom));
+        await waitForBatchedUpdatesWithAct();
+        await screen.findByText(TestHelper.translateLocal('common.settings'));
+
+        let iteration = 0;
+        await measureAsyncFunction(async () => {
+            iteration++;
+            await act(async () => {
+                await Onyx.set(ONYXKEYS.IS_DEBUG_MODE_ENABLED, iteration % 2 === 1);
+                await waitForBatchedUpdates();
+            });
+        });
+    });
+
+    test('[DynamicReportDetailsPage] should re-render mounted policy room details when the report last message changes', async () => {
+        await seedPolicyRoom();
+        render(renderDetailsPage(ROOM_REPORT_ID, policyRoom));
+        await waitForBatchedUpdatesWithAct();
+        await screen.findByText(TestHelper.translateLocal('common.settings'));
+
+        let iteration = 0;
+        await measureAsyncFunction(async () => {
+            iteration++;
+            await act(async () => {
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${ROOM_REPORT_ID}`, {lastMessageText: `message ${iteration}`});
+                await waitForBatchedUpdates();
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

<!-- Explain what your change does and how it addresses the linked issue -->

Decomposes `DynamicReportDetailsPage`: the menu-items block (`menuItems` useMemo, ~300 lines) becomes `ReportDetailsMenuItems`. The child owns the Onyx subscriptions only the menu needs (billing grace periods, amount owed, quick action, intro selected, onboarding tour, betas, transaction drafts, policy selectors, debug mode, action report actions), the "is room currently open" focus state, Go to room / Go to workspace / Leave visibility and the leave-chat handlers. The page passes report/policy/parentReport plus booleans it already computes. Behaviour unchanged. The child compiles and memoizes under both React Compilers (the page itself still bails on "existing memoization could not be preserved", pre-existing).

Perf evidence (reassure, new `tests/perf-test/DynamicReportDetailsPage.perf-test.tsx`, 3 comparison runs, all consistent): mount policy room with 50 members 14.9 -> 13.4 ms (-10%); mount self-DM tracked expense 14.3 -> 13.3 ms (-7%); quick-action Onyx update 14.1 -> 13.0 ms (-7%); debug-mode toggle 11.0 -> 5.1 ms (-54%, menu-only key now re-renders only the child); report lastMessageText update 12.6 -> 13.8 ms (+9%, ~+1 ms: the new boundary adds memo-cache checks and menu items still rebuild when `report` changes). On-device (iOS simulator, dev Hermes bundle, #admins room details, warm): open-details span main 108-115 ms (mean 112) vs branch 102-110 ms (mean 106), overlapping ranges = parity; Pin/Unpin re-render of the page 13-15 ms on both sides = parity. This is a trade-off: the win is isolating menu-only Onyx subscriptions and a smaller page, not faster mount on device.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/callstack-internal/expensify-issues/issues/2931
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a workspace room (e.g. #admins) and tap the header title to open Report details. Verify Members (with count), Settings, Leave rows behave as before.
2. Open a group chat's details: verify Members, Settings, Leave; with a single member Leave shows the "last member" confirmation.
3. Open a user-created room where you are not a workspace member: verify Invite row instead of Members.
4. Open details of a tracked expense in the self DM: verify "Submit it to someone" rows (friend / employer) navigate to the participant selector.
5. Open a completed task's details: verify "Mark as incomplete".
6. Enable debug mode in Troubleshoot settings, reopen details: verify Debug row appears.
7. From a workspace chat opened from the LHN, open details: verify "Go to room" is hidden; open the same details from search: verify "Go to room" is shown and "Go to workspace" hidden accordingly.
8. Verify the Delete row on an expense/task details page still works.

- [x] Verify that no errors appear in the JS console

### Offline tests

<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as above while offline; menu rows still render and navigation still works.

### QA Steps

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A - no visual change

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A - no visual change

</details>

<details>
<summary>iOS: Native</summary>

N/A - no visual change

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A - no visual change

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A - no visual change

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
