### PR TITLE
[No QA][Onyx bump] Bump react-native-onyx from 3.0.109 to 3.0.110

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "react-native-nitro-fetch": "1.5.4",
         "react-native-nitro-modules": "0.36.3",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-onyx": "3.0.109",
+        "react-native-onyx": "3.0.110",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -35907,9 +35907,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.109",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.109.tgz",
-      "integrity": "sha512-/+oUOd/0xz8fxUUMvjoO1KUmRhr0pbEOtug8KMzdMNwqt2GGX+tgEMMvD/3JcEsKWvN8sZUlefQJwBI0oBnhxg==",
+      "version": "3.0.110",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.110.tgz",
+      "integrity": "sha512-Uo6z6ILQ5+pa+VtQVaSj8JU41JZ4v1o+H9uaBjaS6+sbzQWuxe5ds3Db+/pOVUk5trblL0Evfxg8B1f+LROFaA==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "react-native-nitro-fetch": "1.5.4",
     "react-native-nitro-modules": "0.36.3",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-onyx": "3.0.109",
+    "react-native-onyx": "3.0.110",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",


### PR DESCRIPTION
### Explanation of Change

Bumps `react-native-onyx` to [3.0.110](https://www.npmjs.com/package/react-native-onyx/v/3.0.110).

This picks up the Onyx fix for the `UnknownError: Attempt to generate key in database without an in-progress transaction` storage error.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100046
PROPOSAL: N/A

### Tests

1. Run `npm install` and verify it completes with `react-native-onyx@3.0.110`.
2. Run the app and verify it boots and Onyx-backed screens (e.g. chat list) load normally.
3. Verify that no `UnknownError: Attempt to generate key in database without an in-progress transaction` errors appear in the JS console.

### Offline tests

N/A — dependency bump only; verify the app boots offline and the storage error does not reproduce.

### QA Steps

No QA

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — dependency bump only.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — dependency bump only.

</details>

<details>
<summary>iOS: Native</summary>

N/A — dependency bump only.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — dependency bump only.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — dependency bump only.

</details>
