### PR TITLE
Claim `/oauth/native-callback` as an iOS universal link

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -49,6 +49,10 @@
                         "comment": "Plaid setup"
                     },
                     {
+                        "/": "/oauth/callback",
+                        "comment": "Cloudflare Access OAuth callback for the QA environment"
+                    },
+                    {
                         "/": "/statements/*",
                         "comment": "Wallet statements"
                     },

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -49,8 +49,8 @@
                         "comment": "Plaid setup"
                     },
                     {
-                        "/": "/oauth/callback",
-                        "comment": "Cloudflare Access OAuth callback for the QA environment"
+                        "/": "/oauth/native-callback",
+                        "comment": "Native-only Cloudflare Access OAuth callback, no web route"
                     },
                     {
                         "/": "/statements/*",

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -3944,6 +3944,12 @@ const CONST = {
         OAUTH_REDIRECT_PATH_IOS: 'partners/plaid/oauth_ios',
     },
 
+    CLOUDFLARE_ACCESS: {
+        // Claimed as an iOS Universal Link in .well-known/apple-app-site-association. Web keeps its own
+        // /oauth/callback so a browser-started sign-in is never handed to the app. No screen lives here.
+        NATIVE_OAUTH_CALLBACK_PATH: '/oauth/native-callback',
+    },
+
     ONFIDO: {
         CONTAINER_ID: 'onfido-mount',
         TYPE: {

--- a/src/libs/Navigation/linkingConfig/index.ts
+++ b/src/libs/Navigation/linkingConfig/index.ts
@@ -15,8 +15,10 @@ const linkingConfig: LinkingOptions<RootNavigatorParamList> = {
     prefixes,
     config,
     subscribe,
-    // Covers both the initial URL and later `url` events. The native OAuth callback is consumed by the auth
-    // session that opened it, so routing it would only land on NotFound and tear down the returning screen.
+    // Native only: react-navigation reads `filter` in useLinking.native, not on web. There it covers both the
+    // initial URL and later `url` events. The native OAuth callback is consumed by the auth session that opened
+    // it, so routing it would only land on NotFound and tear down the returning screen. The signed-out path goes
+    // through openReportFromDeepLink instead, which has its own guard.
     filter: (url) => !isNativeOAuthCallbackURL(url),
 };
 

--- a/src/libs/Navigation/linkingConfig/index.ts
+++ b/src/libs/Navigation/linkingConfig/index.ts
@@ -5,6 +5,7 @@ import type {RootNavigatorParamList} from '@libs/Navigation/types';
 import type {LinkingOptions} from '@react-navigation/native';
 
 import {config} from './config';
+import isNativeOAuthCallbackURL from './isNativeOAuthCallbackURL';
 import prefixes from './prefixes';
 import subscribe from './subscribe';
 
@@ -14,6 +15,9 @@ const linkingConfig: LinkingOptions<RootNavigatorParamList> = {
     prefixes,
     config,
     subscribe,
+    // Covers both the initial URL and later `url` events. The native OAuth callback is consumed by the auth
+    // session that opened it, so routing it would only land on NotFound and tear down the returning screen.
+    filter: (url) => !isNativeOAuthCallbackURL(url),
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/libs/Navigation/linkingConfig/isNativeOAuthCallbackURL.ts
+++ b/src/libs/Navigation/linkingConfig/isNativeOAuthCallbackURL.ts
@@ -1,0 +1,15 @@
+import CONST from '@src/CONST';
+
+/**
+ * Exact pathname match only. The apple-app-site-association file claiming this path is served by the production
+ * and staging NewDot hosts, so a substring match would also swallow unrelated deep links.
+ */
+function isNativeOAuthCallbackURL(url: string): boolean {
+    try {
+        return new URL(url).pathname === CONST.CLOUDFLARE_ACCESS.NATIVE_OAUTH_CALLBACK_PATH;
+    } catch {
+        return false;
+    }
+}
+
+export default isNativeOAuthCallbackURL;

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -12,6 +12,7 @@ import normalizePath from '@libs/Navigation/helpers/normalizePath';
 import shouldOpenOnAdminRoom from '@libs/Navigation/helpers/shouldOpenOnAdminRoom';
 import swapBackgroundTabForRHPTarget from '@libs/Navigation/helpers/swapBackgroundTabForRHPTarget';
 import willRouteNavigateToRHP from '@libs/Navigation/helpers/willRouteNavigateToRHP';
+import isNativeOAuthCallbackURL from '@libs/Navigation/linkingConfig/isNativeOAuthCallbackURL';
 import Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
 import REPORT_LINK_ROUTE_PARAMS from '@libs/Navigation/reportLinkRouteParams';
@@ -518,6 +519,12 @@ function openReportFromDeepLink(
 
     // The Plaid OAuth redirect URI is handled by the native Plaid SDK on iOS — skip navigation to avoid showing NotFound
     if (route?.includes(CONST.PLAID.OAUTH_REDIRECT_PATH_IOS)) {
+        return;
+    }
+
+    // The native OAuth callback is consumed by the auth session that opened it. linkingConfig.filter already drops
+    // it for signed-in users, but this post-sign-in navigate runs outside react-navigation's linking.
+    if (isNativeOAuthCallbackURL(url)) {
         return;
     }
 

--- a/tests/unit/IsNativeOAuthCallbackURLTest.ts
+++ b/tests/unit/IsNativeOAuthCallbackURLTest.ts
@@ -1,0 +1,49 @@
+import isNativeOAuthCallbackURL from '@libs/Navigation/linkingConfig/isNativeOAuthCallbackURL';
+
+import CONST from '@src/CONST';
+
+describe('isNativeOAuthCallbackURL', () => {
+    it('matches the native callback path on any host, with or without a query string', () => {
+        // Given the claimed native callback path on the production host with OAuth query params
+        const url = `https://new.expensify.com${CONST.CLOUDFLARE_ACCESS.NATIVE_OAUTH_CALLBACK_PATH}?code=abc&state=xyz`;
+
+        // When the URL is checked
+        const result = isNativeOAuthCallbackURL(url);
+
+        // Then it is recognized as the native callback
+        expect(result).toBe(true);
+    });
+
+    it('does not match the web callback path', () => {
+        // Given the web-only callback path that Safari must keep
+        const url = 'https://new.expensify.com/oauth/callback?code=abc';
+
+        // When the URL is checked
+        const result = isNativeOAuthCallbackURL(url);
+
+        // Then it is left for normal routing
+        expect(result).toBe(false);
+    });
+
+    it('does not match a path that merely contains the callback path', () => {
+        // Given a deep link whose path embeds the callback path as a substring
+        const url = `https://new.expensify.com/r/123${CONST.CLOUDFLARE_ACCESS.NATIVE_OAUTH_CALLBACK_PATH}`;
+
+        // When the URL is checked
+        const result = isNativeOAuthCallbackURL(url);
+
+        // Then it is not treated as the callback
+        expect(result).toBe(false);
+    });
+
+    it('returns false for a value that is not a URL', () => {
+        // Given a relative path with no origin
+        const url = CONST.CLOUDFLARE_ACCESS.NATIVE_OAUTH_CALLBACK_PATH;
+
+        // When the URL is checked
+        const result = isNativeOAuthCallbackURL(url);
+
+        // Then parsing fails safely
+        expect(result).toBe(false);
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Claims `/oauth/native-callback` as an iOS Universal Link so the Cloudflare Access OAuth callback of the native
sign-in flow (`ASWebAuthenticationSession` with an https callback, iOS 17.4+) returns to the app. One
`components` entry added to `.well-known/apple-app-site-association`, next to the existing Plaid OAuth entry.
`appIDs` are untouched.

The path is native-only on purpose. Web keeps `/oauth/callback`, which no app claims, so a sign-in started in
Safari stays in Safari where its PKCE state lives.

Because the standalone NewDot entitlements in this repo already list `applinks:new.expensify.com` and
`applinks:staging.new.expensify.com`, this claim is live on production iOS as soon as the file deploys, without
an app release. Since no screen exists at the path, `linkingConfig.filter` drops it for both cold start and
warm `url` events so a tap never lands on NotFound (`isNativeOAuthCallbackURL`, unit tested).

Android is not covered here: `assetlinks.json` `handle_all_urls` is only the verification relation, the
intent-filter in Mobile-Expensify decides what opens the app and is a separate PR, as is the HybridApp
entitlement.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/91419
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

This is a static claim file with no runtime behaviour in the app, so there is nothing to click. It is only
verifiable once deployed, and only together with the Mobile-Expensify entitlement PR.

1. After this is deployed, run `curl -s https://new.expensify.com/apple-app-site-association | jq '.applinks.details[0].components[] | select(."/" == "/oauth/native-callback")'`
2. Verify that the entry is returned, and that the response `Content-Type` is `application/json`
3. Verify that existing Universal Links still work: on an iOS device with the app installed, open Notes, paste
   `https://new.expensify.com/settings` and tap it (the Safari address bar does not trigger Universal Links)
4. Verify that the app opens on the Settings screen rather than Safari, confirming the file is still valid and
   no existing claim regressed

### Offline tests

N/A

### QA Steps

1. On an iOS device with the staging app installed, open Notes and paste `https://staging.new.expensify.com/settings`
2. Tap the link
3. Verify that the app opens on the Settings screen instead of Safari, confirming existing Universal Link
   handling is unaffected

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
