### PR TITLE
[HOLD] fix: preserve Markdown formatting in long messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@expensify/nitro-utils": "file:./modules/ExpensifyNitroUtils",
         "@expensify/react-native-background-task": "file:./modules/background-task",
         "@expensify/react-native-hybrid-app": "file:./modules/hybrid-app",
-        "@expensify/react-native-live-markdown": "0.1.336",
+        "@expensify/react-native-live-markdown": "0.1.337",
         "@expensify/react-native-wallet": "0.1.22",
         "@expo/metro-config": "57.0.7",
         "@expo/metro-runtime": "57.0.7",
@@ -5533,9 +5533,9 @@
       "link": true
     },
     "node_modules/@expensify/react-native-live-markdown": {
-      "version": "0.1.336",
-      "resolved": "https://registry.npmjs.org/@expensify/react-native-live-markdown/-/react-native-live-markdown-0.1.336.tgz",
-      "integrity": "sha512-rrbcQmiTNdv7iySVbQWoY7wMGpIf9e+Wx7LJkx23AGkGwAkq7Mfptsly/4a6GaunIQ3Qh5+D84cLxlI42rLlWQ==",
+      "version": "0.1.337",
+      "resolved": "https://registry.npmjs.org/@expensify/react-native-live-markdown/-/react-native-live-markdown-0.1.337.tgz",
+      "integrity": "sha512-+I3jCqTLIq0+dRgAUXXZZB+0HYXcuQ7uECm6VsFxiiHuPaKZ647RnLSDfJ0+1ZBBGHQJjMtkBYNcv/xs/I52tw==",
       "license": "MIT",
       "workspaces": [
         "./example",
@@ -5545,7 +5545,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "expensify-common": ">=2.0.189",
+        "expensify-common": ">=2.0.201",
         "react": "*",
         "react-native": "*",
         "react-native-worklets": ">=0.7.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@expensify/nitro-utils": "file:./modules/ExpensifyNitroUtils",
     "@expensify/react-native-background-task": "file:./modules/background-task",
     "@expensify/react-native-hybrid-app": "file:./modules/hybrid-app",
-    "@expensify/react-native-live-markdown": "0.1.336",
+    "@expensify/react-native-live-markdown": "0.1.337",
     "@expensify/react-native-wallet": "0.1.22",
     "@expo/metro-config": "57.0.7",
     "@expo/metro-runtime": "57.0.7",

--- a/src/libs/EmojiUtils.tsx
+++ b/src/libs/EmojiUtils.tsx
@@ -43,7 +43,7 @@ const findEmojiByCode = (code: string): Emoji => Emojis.emojiCodeTableWithSkinTo
 const CODE_RANGE_TYPES = new Set(['code', 'pre']);
 
 function getCodeRanges(text: string): MarkdownRange[] {
-    return parseExpensiMark(text).filter((range) => CODE_RANGE_TYPES.has(range.type));
+    return parseExpensiMark(text, CONST.MAX_MARKUP_LENGTH).filter((range) => CODE_RANGE_TYPES.has(range.type));
 }
 
 function isPositionInsideCodeRanges(ranges: MarkdownRange[], position: number): boolean {
@@ -51,7 +51,7 @@ function isPositionInsideCodeRanges(ranges: MarkdownRange[], position: number): 
 }
 
 function isPositionInsideCodeBlock(text: string, position: number): boolean {
-    return isPositionInsideCodeRanges(parseExpensiMark(text), position);
+    return isPositionInsideCodeRanges(parseExpensiMark(text, CONST.MAX_MARKUP_LENGTH), position);
 }
 
 /**
@@ -462,7 +462,7 @@ function replaceEmojis(text: string, preferredSkinTone: OnyxEntry<number | strin
         return {text: revertEmojisInCodeBlocks(newText).text, emojis};
     }
 
-    const codeBlockRanges = parseExpensiMark(text);
+    const codeBlockRanges = parseExpensiMark(text, CONST.MAX_MARKUP_LENGTH);
     const replacements: Array<{position: number; shortcode: string; replacement: string; name: string}> = [];
     const shortcodeSearchPositions: Record<string, number> = {};
     const englishTrie = normalizedLocale !== CONST.LOCALES.DEFAULT ? getEmojiTrie(CONST.LOCALES.DEFAULT) : null;

--- a/src/libs/FormatSelectionUtils.ts
+++ b/src/libs/FormatSelectionUtils.ts
@@ -1,3 +1,5 @@
+import CONST from '@src/CONST';
+
 import type {MarkdownType} from '@expensify/react-native-live-markdown';
 
 import {parseExpensiMark} from '@expensify/react-native-live-markdown';
@@ -23,7 +25,7 @@ function applyFormatting(text: string, selectionStart: number, selectionEnd: num
 }
 
 function findMatchingFormat(text: string, selectionStart: number, selectionEnd: number, formatRule: FormatRule): Match | null {
-    const markdownRanges = parseExpensiMark(text);
+    const markdownRanges = parseExpensiMark(text, CONST.MAX_MARKUP_LENGTH);
     for (const range of markdownRanges) {
         if (range?.type === formatRule.markdownType && range.start != null && range.length != null) {
             const rangeEnd = range.start + range.length;

--- a/src/libs/ParsingUtils.ts
+++ b/src/libs/ParsingUtils.ts
@@ -61,7 +61,7 @@ function decorateRangesWithShortMentions(ranges: MarkdownRange[], text: string, 
 function parseExpensiMarkWithShortMentions(text: string, availableMentions: string[], currentUserMentions?: string[]) {
     'worklet';
 
-    const parsedRanges = parseExpensiMark(text);
+    const parsedRanges = parseExpensiMark(text, CONST.MAX_MARKUP_LENGTH);
     return decorateRangesWithShortMentions(parsedRanges, text, availableMentions, currentUserMentions);
 }
 

--- a/tests/unit/EmojiTest.ts
+++ b/tests/unit/EmojiTest.ts
@@ -5,6 +5,7 @@ import * as Browser from '@libs/Browser';
 import emojiTrieForLocale, {buildEmojisTrie} from '@libs/EmojiTrie';
 import * as EmojiUtils from '@libs/EmojiUtils';
 
+import CONST from '@src/CONST';
 import type FrequentlyUsedEmoji from '@src/types/onyx/FrequentlyUsedEmoji';
 import type {ReportActionReaction} from '@src/types/onyx/ReportActionReactions';
 
@@ -176,6 +177,12 @@ describe('EmojiTest', () => {
             expect(EmojiUtils.replaceEmojis(text).text).toBe('`:smile:`');
         });
 
+        it('should revert emoji unicode inside a code block at the maximum markup length', () => {
+            const code = '`😄`';
+            const prefix = 'a'.repeat(CONST.MAX_MARKUP_LENGTH - code.length);
+            expect(EmojiUtils.replaceEmojis(`${prefix}${code}`).text).toBe(`${prefix}\`:smile:\``);
+        });
+
         it('should revert multiple emojis inside code block', () => {
             const text = '`😄👋`';
             expect(EmojiUtils.replaceEmojis(text).text).toBe('`:smile::wave:`');
@@ -189,6 +196,12 @@ describe('EmojiTest', () => {
         it('should handle mixed scenario with emoji inside and outside code blocks', () => {
             const text = ':wave: hello `😄` world';
             expect(EmojiUtils.replaceEmojis(text).text).toBe('👋 hello `:smile:` world');
+        });
+
+        it('should replace a shortcode outside code but preserve one inside code at the maximum markup length', () => {
+            const markdown = '\n:smile: and `:wave:`';
+            const prefix = 'a'.repeat(CONST.MAX_MARKUP_LENGTH - markdown.length);
+            expect(EmojiUtils.replaceEmojis(`${prefix}${markdown}`).text).toBe(`${prefix}\n😄 and \`:wave:\``);
         });
 
         it('should handle same shortcode both inside and outside code block', () => {
@@ -282,6 +295,13 @@ describe('EmojiTest', () => {
             const text = '`:joy:`';
             // Position 1 is the colon after the backtick
             expect(EmojiUtils.isPositionInsideCodeBlock(text, 1)).toBe(true);
+        });
+
+        it('should return true for a position inside inline code at the maximum markup length', () => {
+            const code = '`:smi`';
+            const prefix = 'a'.repeat(CONST.MAX_MARKUP_LENGTH - code.length);
+            const text = `${prefix}${code}`;
+            expect(EmojiUtils.isPositionInsideCodeBlock(text, prefix.length + 1)).toBe(true);
         });
 
         it('should return false for position outside code block', () => {

--- a/tests/unit/FormatSelectionUtilsTest.ts
+++ b/tests/unit/FormatSelectionUtilsTest.ts
@@ -1,5 +1,7 @@
 import toggleSelectionFormat from '@libs/FormatSelectionUtils';
 
+import CONST from '@src/CONST';
+
 jest.unmock('@expensify/react-native-live-markdown');
 
 describe('FormatSelectionUtils', () => {
@@ -77,6 +79,12 @@ describe('FormatSelectionUtils', () => {
     it('remove italic formatting from bold-italic word and asterisks', () => {
         expect(toggleSelectionFormat('_*aaa*_', 1, 6, 'formatItalic')).toEqual({updatedText: '*aaa*', cursorOffset: -1});
         expect(toggleSelectionFormat('_aaa_ _*bbb*_ _ccc_', 7, 12, 'formatItalic')).toEqual({updatedText: '_aaa_ *bbb* _ccc_', cursorOffset: -1});
+    });
+
+    it('remove formatting from a long Markdown range', () => {
+        const text = `*${'a'.repeat(CONST.MAX_MARKUP_LENGTH - 2)}*`;
+
+        expect(toggleSelectionFormat(text, 1, text.length - 1, 'formatBold')).toEqual({updatedText: 'a'.repeat(CONST.MAX_MARKUP_LENGTH - 2), cursorOffset: -1});
     });
 
     it('do nothing for unsupported command', () => {

--- a/tests/unit/libs/ParsingUtilsTest.ts
+++ b/tests/unit/libs/ParsingUtilsTest.ts
@@ -1,8 +1,12 @@
-import {decorateRangesWithShortMentions, getParsedMessageWithShortMentions} from '@libs/ParsingUtils';
+import {decorateRangesWithShortMentions, getParsedMessageWithShortMentions, parseExpensiMarkWithShortMentions} from '@libs/ParsingUtils';
+
+import CONST from '@src/CONST';
 
 import type {MarkdownRange} from '@expensify/react-native-live-markdown';
 
 const TEST_COMPANY_DOMAIN = 'myCompany.com';
+
+jest.unmock('@expensify/react-native-live-markdown');
 
 describe('decorateRangesWithShortMentions', () => {
     test('returns empty list for empty text', () => {
@@ -221,5 +225,15 @@ describe('getParsedMessageWithShortMentions', () => {
     test("returns text with short mention that is followed by special ' char", () => {
         const result = getParsedMessageWithShortMentions({text: `this is @john.doe's mention`, availableMentionLogins, userEmailDomain: TEST_COMPANY_DOMAIN, parserOptions: {}});
         expect(result).toEqual(`this is <mention-user>@john.doe@myCompany.com</mention-user>&#x27;s mention`);
+    });
+});
+
+describe('parseExpensiMarkWithShortMentions', () => {
+    test('parses Markdown up to the App markup limit', () => {
+        const text = `*${'a'.repeat(CONST.MAX_MARKUP_LENGTH - 2)}*`;
+
+        const result = parseExpensiMarkWithShortMentions(text, [], []);
+
+        expect(result).toContainEqual({type: 'bold', start: 1, length: CONST.MAX_MARKUP_LENGTH - 2});
     });
 });


### PR DESCRIPTION
### Explanation of Change

`ExpensiMark.replace()` was optimized to avoid running the autolink, bold, and strikethrough regexes over the complete text on every change. The scanner first finds small possible URL and Markdown candidates, then the existing ExpensiMark regexes validate and replace only those candidates.

This keeps the existing parsing behavior while reducing the work required for long composer messages.

`react-native-live-markdown` now allows `parseExpensiMark` function callers to provide the maximum length passed to `parseExpensiMark`.

App uses `CONST.MAX_MARKUP_LENGTH`, which is `10,000` characters. This PR passes that value to all the locations in the App that use `parseExpensiMark` for composer Markdown parsing and selected-text formatting, instead of using the library default of `4,000`.

### Fixed Issues

$ [#95210](https://github.com/Expensify/App/issues/95210)
PROPOSAL: [#95210 (comment)](https://github.com/Expensify/App/issues/95210#issuecomment-4928540531)

### Tests

> [!NOTE]
> The complete composer text, including the Markdown added during testing, must contain more than 4,000 and fewer than 10,000 characters.

#### Test 1 (All platforms)

> [!NOTE]
> Android native has a separate known typing-delay issue with long text, which will be handled in a follow-up. Do not fail this PR because of that delay. For Android native, verify that Markdown remains preserved after 4,000 characters. On the other platforms, also verify that typing remains responsive.

1. Go to staging.new.expensify.com or open Expensify App
2. Login with any account
3. Go to any chat
4. Paste any long text (4000+ characters) containing markdown (bold, italic, strikethrough and autolink).
5. Try to write something after pasting.
6. Verify that the typing experience is smooth and it doesn't lag or freezes while typing.
7. Verify that the markdown is preserved when we type after pasting 4000+ characters text in the composer.

#### Test 2 (Web)

1. Open https://staging.new.expensify.com/
2. Go to any chat.
3. Paste the long text more than 4000 characters in the composer containing bold and italic (the long text must include bold and italic markdown formatting).
4. Select only `bold`, without selecting the stars (*).
5. Press `Cmd+B` on macOS or `Ctrl+B` on Windows
6. Verify that the surrounding stars are removed and the text becomes plain.
7. Select `italic`, without underscores.
8. Press `Cmd+I` or `Ctrl+I`.
9. Verify that the underscores are removed and the text become plain.
10. Select the plain text again and repeat the shortcuts.
11. Verify that the plain text becomes `bold` on pressing `cmd/ctrl + b` and becomes `italic` on pressing `cmd/ctrl + i`.

#### Test 3 (All platforms)

1. Open any chat.
2. Paste plain text containing more than 4,000 characters, while keeping the complete composer text under 10,000 characters.
3. On a new line, paste `` `😄` `` without selecting any existing text.
4. Verify that the emoji inside the backticks is converted to `` `:smile:` ``.
5. On another new line, paste `` :smile: and `:wave:` `` without selecting any existing text.
6. Verify that `:smile:` outside the backticks becomes 😄.
7. Verify that `:wave:` inside the backticks remains unchanged.

#### Test 4 (All platforms)

> [!NOTE]
> There are no suggestions in the composer in iOS native app either we type in the code range or outside the code range and this issue also exist in existing main so this Test 4 can't reliably be performed on iOS native. This existing issue only reproducible after composer has 4000 characters.

1. Open any chat.
2. Paste plain text containing more than 4,000 characters, while keeping the complete composer text under 10,000 characters.
3. On a new line, type two backticks.
4. Place the cursor between the backticks and type `:smi`, for example: `` `:smi` ``.
5. Verify that emoji suggestions do not appear because the cursor is inside a complete code range.
6. Type `:smi` outside the backticks.
7. Verify that emoji suggestions appear outside the code range.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Test

### QA Steps

Same as Test

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

### Test 1

https://github.com/user-attachments/assets/92a27caa-b734-4023-a07e-84611c3a5f25

### Test 3


https://github.com/user-attachments/assets/a1d8a197-3e56-4fba-b353-c6a871fb7c64



### Test 4


https://github.com/user-attachments/assets/fa9d31ce-6c25-481a-a621-e0784cc95a5d



</details>

<details>
<summary>Android: mWeb Chrome</summary>

### Test 1:

https://github.com/user-attachments/assets/6540dd93-de1c-47d8-af10-9c9f87f3188d

### Test 3:


https://github.com/user-attachments/assets/dcd193bf-bc67-476a-906a-c9340df23f7e



### Test 4:


https://github.com/user-attachments/assets/185b3e90-35ae-4b1f-bcf4-6393e4a4d012



</details>

<details>
<summary>iOS: Native</summary>

### Test 1:

https://github.com/user-attachments/assets/1de502db-0952-4b9a-b1f3-b91fef9eb5f2

### Test 3:

https://github.com/user-attachments/assets/8ef9d40d-86d7-4c8c-9d53-5fffca7a1ea7




</details>

<details>
<summary>iOS: mWeb Safari</summary>

### Test 1:

https://github.com/user-attachments/assets/879b646b-556c-4119-9262-5388764110c4

### Test 3:

https://github.com/user-attachments/assets/a5be5f0c-97b7-4fe2-87ac-79acae4f9c20




### Test 4:


https://github.com/user-attachments/assets/62219738-b506-4dbf-a538-26b5e0e8aee9



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

### Test 1:

https://github.com/user-attachments/assets/0fb33f51-e017-470e-ac83-e36ed048aac6

### Test 2:


https://github.com/user-attachments/assets/e8bd13c1-2db4-4e19-9224-3c133f73614e

### Test 3 (Part 1):


https://github.com/user-attachments/assets/17b024c1-b65f-4b0b-87f1-b38e00570e5b

### Test 3 (Part 2):


https://github.com/user-attachments/assets/dd876b85-4480-4c48-9654-cfafec761a19

### Test 4:

https://github.com/user-attachments/assets/ef239b01-f8aa-4db7-848d-568fc66b9cf5



</details>
