### PR TITLE
Fix receipt full-res image not loading when preview displaces it in flow

### DIFF
--- a/src/components/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading.tsx
@@ -51,10 +51,6 @@ function ImageWithLoading({
     const isLoadedRef = useRef<boolean | null>(null);
     const [isImageCached, setIsImageCached] = useState(true);
     const [isLoading, setIsLoading] = useState(false);
-    // The full-resolution image is not guaranteed to ever emit `onLoad`/`onError` (e.g. a receipt derivative that is
-    // still being generated server-side), so `isLoading` can stay `true` indefinitely. Once the low-resolution preview
-    // is on screen we have something readable to show, so the loading state must stop being visible at that point.
-    const [isThumbnailLoading, setIsThumbnailLoading] = useState(!!previewUri);
     const {isOffline} = useNetwork();
 
     const handleError = () => {
@@ -101,12 +97,9 @@ function ImageWithLoading({
                     <Image
                         {...rest}
                         source={{uri: previewUri}}
-                        style={[styles.w100, styles.h100, style]}
+                        style={[styles.pAbsolute, styles.w100, styles.h100, styles.opacitySemiTransparent, style]}
                         resizeMode={resizeMode}
-                        onLoad={(e) => {
-                            setIsThumbnailLoading(false);
-                            onLoad?.(e);
-                        }}
+                        onLoad={onLoad}
                         loadingIconSize={loadingIconSize}
                         loadingIndicatorStyles={loadingIndicatorStyles}
                     />
@@ -132,13 +125,12 @@ function ImageWithLoading({
                     isLoadedRef.current = false;
                     setIsImageCached(false);
                     setIsLoading(true);
-                    setIsThumbnailLoading(!!previewUri);
                     waitForSession?.();
                 }}
                 loadingIconSize={loadingIconSize}
                 loadingIndicatorStyles={loadingIndicatorStyles}
             />
-            {isLoading && (!previewUri || isThumbnailLoading) && !isImageCached && !isOffline && (
+            {(previewUri ? isLoading : isLoading && !isImageCached) && !isOffline && (
                 <LoadingIndicator
                     iconSize={loadingIconSize}
                     style={[styles.opacity1, styles.bgTransparent, loadingIndicatorStyles]}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
While `isLoading` is true, `ImageWithLoading` renders the low-res preview and full-res image as two in-flow siblings inside a clipped receipt container. On web, the preview pushes the full-res `<img>` below the visible box, so lazy loading never decodes it, `onLoad` never fires, and the receipt can stay on the blurry preview or show an infinite spinner.

This change positions the preview absolutely so it overlays the receipt box instead of displacing the full-res image. The full-res image remains the only in-flow child, stays inside the clip rect, and loads normally with `loading="lazy"` unchanged.

### Fixed Issues
$ https://github.com/Expensify/App/issues/99199
PROPOSAL: https://github.com/Expensify/App/issues/99199#issuecomment-5410592436

### Tests
1. Open a workspace with per diem rates configured
2. Create a per diem expense with an image receipt in the workspace chat
3. Go to Account → Troubleshoot → Clear cache and restart → Reset and refresh
4. Reopen the chat containing the per diem expense
5. Verify the receipt transitions from the low-res preview to the sharp full-res image and the loading spinner clears
6. Verify other image receipts in the same report also load full resolution correctly
7. Open the same receipt from the expense details/attachment view and verify it still loads correctly
8. Scroll through a long report with multiple receipts and verify below-the-fold receipts still load after scrolling into view

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Open a chat with image receipts while online and wait for receipts to load
2. Go offline
3. Reopen the chat
4. Verify previously loaded receipts still display and no unexpected errors appear in the console

### QA Steps
1. Open a workspace with per diem rates configured
2. Create a per diem expense with an image receipt in the workspace chat
3. Go to Account → Troubleshoot → Clear cache and restart → Reset and refresh
4. Reopen the chat containing the per diem expense
5. Verify the receipt shows the low-res preview briefly, then transitions to the sharp full-res image without an infinite spinner
6. Verify other image receipts in the report load full resolution correctly
7. Verify opening the receipt from expense details still works as expected
8. Verify no errors appear in the JS console

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- N/A - web-specific layout bug; native layout unaffected by this change -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add before/after repro videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- N/A - web-specific layout bug; native layout unaffected by this change -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add before/after repro videos here if tested -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/b68cbca3-2242-4e22-a458-1d9f7a55bbe0



</details>