### PR TITLE
[No QA] Use OXC to transform Reassure perf tests

### DIFF
--- a/config/babel/oxcJestTransformer.js
+++ b/config/babel/oxcJestTransformer.js
@@ -5,14 +5,16 @@ const esbuild = require('esbuild');
 const {transformSync} = require('oxc-transform-react');
 
 const babelJest = require('babel-jest');
-const BaseReactCompilerConfig = require('../config/babel/reactCompilerConfig');
+const BaseReactCompilerConfig = require('./reactCompilerConfig');
 
 const babelTransformer = babelJest.createTransformer();
 
 const NODE_MODULES_RE = /[/\\]node_modules[/\\]/;
 const TESTS_RE = /[/\\]tests[/\\]/;
+const JEST_SETUP_RE = /[/\\]jest[/\\]/;
+const MOCKS_RE = /[/\\]__mocks__[/\\]/;
 
-const TRANSFORMER_VERSION = '1';
+const TRANSFORMER_VERSION = '2';
 
 function getLang(filename) {
     const ext = path.extname(filename).slice(1);
@@ -26,11 +28,11 @@ function getLang(filename) {
 }
 
 function shouldUseOxc(filename) {
-    return !NODE_MODULES_RE.test(filename);
+    return !NODE_MODULES_RE.test(filename) && !TESTS_RE.test(filename) && !JEST_SETUP_RE.test(filename) && !MOCKS_RE.test(filename);
 }
 
 function shouldRunReactCompiler(filename) {
-    return !TESTS_RE.test(filename) && !NODE_MODULES_RE.test(filename);
+    return shouldUseOxc(filename);
 }
 
 function processWithOxc(sourceText, sourcePath) {
@@ -64,20 +66,11 @@ function processWithOxc(sourceText, sourcePath) {
 module.exports = {
     canInstrument: false,
     getCacheKey(sourceText, sourcePath, transformOptions) {
-        const useOxc = shouldUseOxc(sourcePath);
-        if (!useOxc) {
+        if (!shouldUseOxc(sourcePath)) {
             return babelTransformer.getCacheKey(sourceText, sourcePath, transformOptions);
         }
 
-        return crypto
-            .createHash('sha1')
-            .update(TRANSFORMER_VERSION)
-            .update(sourceText)
-            .update('\0', 'utf8')
-            .update(sourcePath)
-            .update(shouldRunReactCompiler(sourcePath) ? 'compiler' : 'plain')
-            .update(fs.readFileSync(__filename))
-            .digest('hex');
+        return crypto.createHash('sha1').update(TRANSFORMER_VERSION).update(sourceText).update('\0', 'utf8').update(sourcePath).update(fs.readFileSync(__filename)).digest('hex');
     },
     process(sourceText, sourcePath, transformOptions) {
         if (shouldUseOxc(sourcePath)) {

--- a/config/babel/oxcJestTransformer.js
+++ b/config/babel/oxcJestTransformer.js
@@ -5,6 +5,7 @@ const esbuild = require('esbuild');
 const {transformSync} = require('oxc-transform-react');
 
 const babelJest = require('babel-jest');
+const OXC_TRANSFORM_REACT_VERSION = require('oxc-transform-react/package.json').version;
 const BaseReactCompilerConfig = require('./reactCompilerConfig');
 
 const babelTransformer = babelJest.createTransformer();
@@ -14,7 +15,14 @@ const TESTS_RE = /[/\\]tests[/\\]/;
 const JEST_SETUP_RE = /[/\\]jest[/\\]/;
 const MOCKS_RE = /[/\\]__mocks__[/\\]/;
 
-const TRANSFORMER_VERSION = '2';
+const TRANSFORMER_SOURCE = fs.readFileSync(__filename);
+const REACT_COMPILER_CONFIG_KEY = JSON.stringify(BaseReactCompilerConfig);
+
+const REACT_COMPILER_OPTIONS = {
+    ...BaseReactCompilerConfig,
+    panicThreshold: 'none',
+    eslintSuppressionRules: [],
+};
 
 function getLang(filename) {
     const ext = path.extname(filename).slice(1);
@@ -31,22 +39,12 @@ function shouldUseOxc(filename) {
     return !NODE_MODULES_RE.test(filename) && !TESTS_RE.test(filename) && !JEST_SETUP_RE.test(filename) && !MOCKS_RE.test(filename);
 }
 
-function shouldRunReactCompiler(filename) {
-    return shouldUseOxc(filename);
-}
-
 function processWithOxc(sourceText, sourcePath) {
     const oxcResult = transformSync(sourcePath, sourceText, {
         lang: getLang(sourcePath),
         sourcemap: true,
         jsx: {runtime: 'automatic', development: true},
-        reactCompiler: shouldRunReactCompiler(sourcePath)
-            ? {
-                  ...BaseReactCompilerConfig,
-                  panicThreshold: 'none',
-                  eslintSuppressionRules: [],
-              }
-            : false,
+        reactCompiler: REACT_COMPILER_OPTIONS,
     });
 
     if (oxcResult.fatal || !oxcResult.code) {
@@ -56,6 +54,7 @@ function processWithOxc(sourceText, sourcePath) {
     const cjs = esbuild.transformSync(oxcResult.code, {
         loader: 'js',
         format: 'cjs',
+        supported: {'dynamic-import': false},
         sourcefile: sourcePath,
         sourcemap: true,
     });
@@ -70,7 +69,16 @@ module.exports = {
             return babelTransformer.getCacheKey(sourceText, sourcePath, transformOptions);
         }
 
-        return crypto.createHash('sha1').update(TRANSFORMER_VERSION).update(sourceText).update('\0', 'utf8').update(sourcePath).update(fs.readFileSync(__filename)).digest('hex');
+        return crypto
+            .createHash('sha1')
+            .update(sourceText)
+            .update('\0', 'utf8')
+            .update(sourcePath)
+            .update(TRANSFORMER_SOURCE)
+            .update(REACT_COMPILER_CONFIG_KEY)
+            .update(esbuild.version)
+            .update(OXC_TRANSFORM_REACT_VERSION)
+            .digest('hex');
     },
     process(sourceText, sourcePath, transformOptions) {
         if (shouldUseOxc(sourcePath)) {

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,8 +20,8 @@ module.exports = {
     transform: {
         // Reassure re-transforms ~7k files under `--max-opt=1` (V8 sparkplug only), which
         // makes Babel ~half of each measure job. OXC + esbuild is native and stays fast
-        // without TurboFan. Flow in node_modules still falls through to babel-jest.
-        '^.+\\.[jt]sx?$': isPerfTestRun ? '<rootDir>/jest/oxcTransformer.js' : 'babel-jest',
+        // without TurboFan. Test files stay on babel-jest so `jest.mock` is still hoisted.
+        '^.+\\.[jt]sx?$': isPerfTestRun ? '<rootDir>/config/babel/oxcJestTransformer.js' : 'babel-jest',
         '^.+\\.svg?$': 'jest-transformer-svg',
     },
     transformIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,10 @@ module.exports = {
         `<rootDir>/?(*.)+(spec|test).${testFileExtension}`,
     ],
     transform: {
-        '^.+\\.[jt]sx?$': 'babel-jest',
+        // Reassure re-transforms ~7k files under `--max-opt=1` (V8 sparkplug only), which
+        // makes Babel ~half of each measure job. OXC + esbuild is native and stays fast
+        // without TurboFan. Flow in node_modules still falls through to babel-jest.
+        '^.+\\.[jt]sx?$': isPerfTestRun ? '<rootDir>/jest/oxcTransformer.js' : 'babel-jest',
         '^.+\\.svg?$': 'jest-transformer-svg',
     },
     transformIgnorePatterns: [

--- a/jest/oxcTransformer.js
+++ b/jest/oxcTransformer.js
@@ -1,0 +1,92 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const esbuild = require('esbuild');
+const {transformSync} = require('oxc-transform-react');
+
+const babelJest = require('babel-jest');
+const BaseReactCompilerConfig = require('../config/babel/reactCompilerConfig');
+
+const babelTransformer = babelJest.createTransformer();
+
+const NODE_MODULES_RE = /[/\\]node_modules[/\\]/;
+const TESTS_RE = /[/\\]tests[/\\]/;
+
+const TRANSFORMER_VERSION = '1';
+
+function getLang(filename) {
+    const ext = path.extname(filename).slice(1);
+    if (ext === 'tsx') {
+        return 'tsx';
+    }
+    if (ext === 'ts') {
+        return 'ts';
+    }
+    return 'jsx';
+}
+
+function shouldUseOxc(filename) {
+    return !NODE_MODULES_RE.test(filename);
+}
+
+function shouldRunReactCompiler(filename) {
+    return !TESTS_RE.test(filename) && !NODE_MODULES_RE.test(filename);
+}
+
+function processWithOxc(sourceText, sourcePath) {
+    const oxcResult = transformSync(sourcePath, sourceText, {
+        lang: getLang(sourcePath),
+        sourcemap: true,
+        jsx: {runtime: 'automatic', development: true},
+        reactCompiler: shouldRunReactCompiler(sourcePath)
+            ? {
+                  ...BaseReactCompilerConfig,
+                  panicThreshold: 'none',
+                  eslintSuppressionRules: [],
+              }
+            : false,
+    });
+
+    if (oxcResult.fatal || !oxcResult.code) {
+        return null;
+    }
+
+    const cjs = esbuild.transformSync(oxcResult.code, {
+        loader: 'js',
+        format: 'cjs',
+        sourcefile: sourcePath,
+        sourcemap: true,
+    });
+
+    return {code: cjs.code, map: cjs.map};
+}
+
+module.exports = {
+    canInstrument: false,
+    getCacheKey(sourceText, sourcePath, transformOptions) {
+        const useOxc = shouldUseOxc(sourcePath);
+        if (!useOxc) {
+            return babelTransformer.getCacheKey(sourceText, sourcePath, transformOptions);
+        }
+
+        return crypto
+            .createHash('sha1')
+            .update(TRANSFORMER_VERSION)
+            .update(sourceText)
+            .update('\0', 'utf8')
+            .update(sourcePath)
+            .update(shouldRunReactCompiler(sourcePath) ? 'compiler' : 'plain')
+            .update(fs.readFileSync(__filename))
+            .digest('hex');
+    },
+    process(sourceText, sourcePath, transformOptions) {
+        if (shouldUseOxc(sourcePath)) {
+            const result = processWithOxc(sourceText, sourcePath);
+            if (result) {
+                return result;
+            }
+        }
+
+        return babelTransformer.process(sourceText, sourcePath, transformOptions);
+    },
+};

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,7 @@
                 "tests/globals.d.ts",
                 ".storybook/**/*.{js,ts,tsx}",
                 "metro.config.js",
+                "config/babel/oxcJestTransformer.js",
                 "eslint.changed.config.mjs",
                 "react-native.config.js",
                 "rock.config.mjs",

--- a/tests/tooling/oxcTransformer.test.ts
+++ b/tests/tooling/oxcTransformer.test.ts
@@ -59,6 +59,17 @@ describe('oxcTransformer', () => {
         expect(result.code.indexOf('_getJestObj().mock')).toBeLessThan(result.code.indexOf('exports.x'));
     });
 
+    it('lowers dynamic import() so Jest still owns the module graph', () => {
+        const source = `
+            export function loadLazy() {
+                return import('./LazyScreen');
+            }
+        `;
+        const result = oxcTransformer.process(source, path.resolve('src/libs/loadLazy.ts'), transformOptions);
+        expect(result.code).not.toMatch(/\bimport\s*\(/);
+        expect(result.code).toMatch(/require\(['"]\.\/LazyScreen['"]\)/);
+    });
+
     it('falls back to babel-jest for Flow in node_modules', () => {
         const source = `
             // @flow

--- a/tests/tooling/oxcTransformer.test.ts
+++ b/tests/tooling/oxcTransformer.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'bun:test';
+
+import {createRequire} from 'node:module';
+import path from 'node:path';
+
+type TransformResult = {code: string};
+
+type OxcTransformer = {
+    process: (sourceText: string, sourcePath: string, transformOptions: unknown) => TransformResult;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Jest transformers are CJS and tsconfig.bun.json does not type-check jest/
+const oxcTransformer = createRequire(import.meta.url)('../../jest/oxcTransformer') as OxcTransformer;
+
+const transformOptions = {
+    config: {cwd: process.cwd(), rootDir: process.cwd(), cache: false},
+    cacheFS: new Map(),
+    configString: '',
+    instrument: false,
+    supportsDynamicImport: false,
+    supportsExportNamespaceFrom: false,
+    supportsStaticESM: false,
+    supportsTopLevelAwait: false,
+};
+
+describe('oxcTransformer', () => {
+    it('emits CommonJS for app TypeScript', () => {
+        const source = `
+            export function add(a: number, b: number): number {
+                return a + b;
+            }
+        `;
+        const result = oxcTransformer.process(source, path.resolve('src/libs/math.ts'), transformOptions);
+        expect(result.code).toContain('module.exports');
+        expect(result.code).toContain('add: () => add');
+        expect(result.code).not.toMatch(/^export /m);
+        expect(result.code).not.toContain(': number');
+    });
+
+    it('runs React Compiler on app components', () => {
+        const source = `
+            export function Hello({name}: {name: string}) {
+                return <div>{name.toUpperCase()}</div>;
+            }
+        `;
+        const result = oxcTransformer.process(source, path.resolve('src/components/Hello.tsx'), transformOptions);
+        expect(result.code).toMatch(/compiler-runtime|_c\(/);
+        expect(result.code).toContain('jsxDEV');
+    });
+
+    it('does not run React Compiler on tests/', () => {
+        const source = `
+            export function Hello({name}: {name: string}) {
+                return <div>{name.toUpperCase()}</div>;
+            }
+        `;
+        const result = oxcTransformer.process(source, path.resolve('tests/perf-test/Hello.perf-test.tsx'), transformOptions);
+        expect(result.code).not.toMatch(/compiler-runtime|_c\(/);
+        expect(result.code).toContain('jsxDEV');
+    });
+
+    it('falls back to babel-jest for Flow in node_modules', () => {
+        const source = `
+            // @flow
+            export function add(a: number, b: number): number {
+                return a + b;
+            }
+        `;
+        const result = oxcTransformer.process(source, path.resolve('node_modules/react-native/Libraries/foo.js'), transformOptions);
+        expect(result.code).toBeTruthy();
+        expect(result.code).not.toContain(': number');
+    });
+});

--- a/tests/tooling/oxcTransformer.test.ts
+++ b/tests/tooling/oxcTransformer.test.ts
@@ -9,8 +9,8 @@ type OxcTransformer = {
     process: (sourceText: string, sourcePath: string, transformOptions: unknown) => TransformResult;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Jest transformers are CJS and tsconfig.bun.json does not type-check jest/
-const oxcTransformer = createRequire(import.meta.url)('../../jest/oxcTransformer') as OxcTransformer;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Jest transformers are CJS and tsconfig.bun.json does not type-check config/babel/
+const oxcTransformer = createRequire(import.meta.url)('../../config/babel/oxcJestTransformer') as OxcTransformer;
 
 const transformOptions = {
     config: {cwd: process.cwd(), rootDir: process.cwd(), cache: false},
@@ -48,15 +48,15 @@ describe('oxcTransformer', () => {
         expect(result.code).toContain('jsxDEV');
     });
 
-    it('does not run React Compiler on tests/', () => {
+    it('leaves test files on babel-jest so jest.mock is hoisted', () => {
         const source = `
-            export function Hello({name}: {name: string}) {
-                return <div>{name.toUpperCase()}</div>;
-            }
+            import foo from './foo';
+            jest.mock('./foo');
+            export const x = 1;
         `;
         const result = oxcTransformer.process(source, path.resolve('tests/perf-test/Hello.perf-test.tsx'), transformOptions);
-        expect(result.code).not.toMatch(/compiler-runtime|_c\(/);
-        expect(result.code).toContain('jsxDEV');
+        expect(result.code).toContain('_getJestObj().mock("./foo")');
+        expect(result.code.indexOf('_getJestObj().mock')).toBeLessThan(result.code.indexOf('exports.x'));
     });
 
     it('falls back to babel-jest for Flow in node_modules', () => {


### PR DESCRIPTION
### Explanation of Change
Reassure's measure jobs re-transform ~7k files through Babel on every run. That is worse than it looks: Reassure launches Jest with `--max-opt=1`, so V8 stays on Sparkplug and Babel's JS AST walk is about half of each job (issue #100428). Caching that output (#100297) is the right first cut. This PR asks whether we still need Babel at all for the perf path.

We already use `oxc-transform-react` on web (TS strip + JSX + React Compiler). The same pipeline covers what Jest actually needs from `babel.config.js` for app source:

- TypeScript / TSX
- automatic JSX (`jsxDEV` in tests)
- React Compiler, skipped for `tests/` the same way Babel's `sources` filter does
- CJS emit via esbuild (Jest 29 is CJS)

What Babel still uniquely does — Flow in `node_modules/react-native`, Fullstory, worklets, Expo env inlining, and `jest.mock` hoisting — is not needed for app `src/`. Those files still go through `babel-jest`. Regular unit tests keep `babel-jest` entirely.

The 12s/0.39s numbers are a 300-file microbench of the transform itself. The Reassure job wall clock is the row that matters.

| What | Before (Babel) | After (OXC on `src/`) |
| --- | --- | --- |
| Transform microbench, 300 files, `--max-opt=1` | 12.4s (24 files/s) | 0.39s (763 files/s) |
| CI `Run … performance tests` step | **5m 33s** | **4m 29s** (−1m 04s, −19%) |

### Fixed Issues
$ n/a

### Tests
Automated tests only.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - CI transformer change, no app/network surface.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


