### PR TITLE
fix: show converted exclude commute distance unit

### DIFF
--- a/src/libs/PolicyDistanceRatesUtils.ts
+++ b/src/libs/PolicyDistanceRatesUtils.ts
@@ -6,7 +6,7 @@ import type {GovernmentRateCountry, IOURequestType} from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';
-import type {CustomUnit, Rate, RateAttributes, Unit} from '@src/types/onyx/Policy';
+import type {CommuterExclusions, CustomUnit, Rate, RateAttributes, Unit} from '@src/types/onyx/Policy';
 import type {OnyxData} from '@src/types/onyx/Request';
 
 import type {NullishDeep, OnyxUpdate} from 'react-native-onyx';
@@ -237,6 +237,33 @@ function getGovernmentRateCountryPhraseTranslationKey(currency?: string): Transl
     return `workspace.distanceRates.governmentRateCountries.${country}`;
 }
 
+function isDistanceUnit(unit: string | undefined): unit is Unit {
+    return unit === CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES || unit === CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS;
+}
+
+function convertCommuterExclusionDistance(distance: number, fromUnit: string | undefined, toUnit: Unit | undefined): number {
+    if (!toUnit || !isDistanceUnit(fromUnit) || fromUnit === toUnit) {
+        return distance;
+    }
+
+    const conversionRate = fromUnit === CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES ? CONST.CUSTOM_UNITS.MILES_TO_KILOMETERS : CONST.CUSTOM_UNITS.KILOMETERS_TO_MILES;
+    return Number((distance * conversionRate).toFixed(CONST.DISTANCE_DECIMAL_PLACES));
+}
+
+function getCommuterExclusionsSummary(commuterExclusions: CommuterExclusions | undefined, defaultUnit: Unit | undefined, translate: LocalizedTranslate): string {
+    if (commuterExclusions?.method === CONST.POLICY.COMMUTER_EXCLUSION_METHOD.HOME_AND_OFFICE) {
+        return translate('workspace.distanceRates.commuterExclusions.summaryHomeAndOffice');
+    }
+    if (commuterExclusions?.method === CONST.POLICY.COMMUTER_EXCLUSION_METHOD.FIXED_DISTANCE && commuterExclusions?.fixedDistance != null) {
+        const unit = defaultUnit ?? commuterExclusions.fixedDistanceUnit ?? CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES;
+        return translate('workspace.distanceRates.commuterExclusions.summaryFixedDistance', {
+            distance: convertCommuterExclusionDistance(commuterExclusions.fixedDistance, commuterExclusions.fixedDistanceUnit, defaultUnit),
+            unit,
+        });
+    }
+    return translate('workspace.distanceRates.commuterExclusions.summaryDisabled');
+}
+
 function isCommuterExclusionEnabled(policy: Policy | null | undefined): policy is Policy & {id: string; commuterExclusions: NonNullable<Policy['commuterExclusions']>} {
     return !!policy?.id && !!policy.commuterExclusions;
 }
@@ -280,6 +307,7 @@ export {
     isCurrencySupportedForAutoUpdate,
     getExpectedUnitForCurrency,
     getGovernmentRateCountryPhraseTranslationKey,
+    getCommuterExclusionsSummary,
     isCommuterExclusionEnabled,
     isMapOrGPSRequired,
     getDistanceExpenseTypeForPolicy,

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesSettingsPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesSettingsPage.tsx
@@ -21,7 +21,7 @@ import {getLatestErrorField} from '@libs/ErrorUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {getGovernmentRateCountryPhraseTranslationKey, isCommuterExclusionEnabled, isCurrencySupportedForAutoUpdate, isMapOrGPSRequired} from '@libs/PolicyDistanceRatesUtils';
+import {getCommuterExclusionsSummary, getGovernmentRateCountryPhraseTranslationKey, isCommuterExclusionEnabled, isCurrencySupportedForAutoUpdate, isMapOrGPSRequired} from '@libs/PolicyDistanceRatesUtils';
 import {getDistanceRateCustomUnit, isControlPolicy} from '@libs/PolicyUtils';
 import {getUnitTranslationKey} from '@libs/WorkspacesSettingsUtils';
 
@@ -45,26 +45,13 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
-import type {CommuterExclusions, CustomUnit} from '@src/types/onyx/Policy';
+import type {CustomUnit} from '@src/types/onyx/Policy';
 
 import {Str} from 'expensify-common';
 import React, {useEffect} from 'react';
 import {View} from 'react-native';
 
 type PolicyDistanceRatesSettingsPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.DISTANCE_RATES_SETTINGS>;
-
-function getCommuterExclusionsSummary(commuterExclusions: CommuterExclusions | undefined, defaultUnit: string | undefined, translate: ReturnType<typeof useLocalize>['translate']): string {
-    if (commuterExclusions?.method === CONST.POLICY.COMMUTER_EXCLUSION_METHOD.HOME_AND_OFFICE) {
-        return translate('workspace.distanceRates.commuterExclusions.summaryHomeAndOffice');
-    }
-    if (commuterExclusions?.method === CONST.POLICY.COMMUTER_EXCLUSION_METHOD.FIXED_DISTANCE && commuterExclusions?.fixedDistance != null) {
-        return translate('workspace.distanceRates.commuterExclusions.summaryFixedDistance', {
-            distance: commuterExclusions.fixedDistance,
-            unit: commuterExclusions.fixedDistanceUnit ?? defaultUnit ?? CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
-        });
-    }
-    return translate('workspace.distanceRates.commuterExclusions.summaryDisabled');
-}
 
 function PolicyDistanceRatesSettingsPage({route}: PolicyDistanceRatesSettingsPageProps) {
     const policyID = route.params.policyID;

--- a/tests/unit/PolicyDistanceRatesUtilsTest.ts
+++ b/tests/unit/PolicyDistanceRatesUtilsTest.ts
@@ -1,4 +1,5 @@
 import {
+    getCommuterExclusionsSummary,
     getDistanceExpenseTypeForPolicy,
     getExpectedUnitForCurrency,
     getGovernmentRateCountryForCurrency,
@@ -159,6 +160,60 @@ describe('PolicyDistanceRatesUtils', () => {
 
         it('should return undefined for an unsupported currency', () => {
             expect(getGovernmentRateCountryPhraseTranslationKey('NZD')).toBeUndefined();
+        });
+    });
+
+    describe('getCommuterExclusionsSummary', () => {
+        it('should convert fixed-distance commuter exclusions to the current workspace unit', () => {
+            expect(
+                getCommuterExclusionsSummary(
+                    {
+                        method: CONST.POLICY.COMMUTER_EXCLUSION_METHOD.FIXED_DISTANCE,
+                        fixedDistance: 2,
+                        fixedDistanceUnit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS,
+                    },
+                    CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
+                    translateLocal,
+                ),
+            ).toBe('Exclude 1.24 mi per claim');
+        });
+
+        it('should keep the fixed-distance commuter exclusion value when units already match', () => {
+            expect(
+                getCommuterExclusionsSummary(
+                    {
+                        method: CONST.POLICY.COMMUTER_EXCLUSION_METHOD.FIXED_DISTANCE,
+                        fixedDistance: 2,
+                        fixedDistanceUnit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS,
+                    },
+                    CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS,
+                    translateLocal,
+                ),
+            ).toBe('Exclude 2 km per claim');
+        });
+
+        it('should fall back to the stored commuter exclusion unit while the workspace unit is unavailable', () => {
+            expect(
+                getCommuterExclusionsSummary(
+                    {
+                        method: CONST.POLICY.COMMUTER_EXCLUSION_METHOD.FIXED_DISTANCE,
+                        fixedDistance: 10,
+                        fixedDistanceUnit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
+                    },
+                    undefined,
+                    translateLocal,
+                ),
+            ).toBe('Exclude 10 mi per claim');
+        });
+
+        it('should return the home and office summary for home and office exclusions', () => {
+            expect(getCommuterExclusionsSummary({method: CONST.POLICY.COMMUTER_EXCLUSION_METHOD.HOME_AND_OFFICE}, CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS, translateLocal)).toBe(
+                'Use home and office locations',
+            );
+        });
+
+        it('should return the disabled summary when commuter exclusions are unset', () => {
+            expect(getCommuterExclusionsSummary(undefined, CONST.CUSTOM_UNITS.DISTANCE_UNIT_KILOMETERS, translateLocal)).toBe('No commute exclusion');
         });
     });
 


### PR DESCRIPTION
## Summary

$ #96135.

- Move the commuter exclusion summary formatting into `PolicyDistanceRatesUtils`.
- Convert fixed-distance commuter exclusion summaries from the stored unit to the current workspace distance unit when they differ.
- Add regression coverage for the stale-unit case where the workspace unit changes without re-saving the commute exclusion.

## Test Plan

1. Go to workspace settings and enable distance rates.
2. Configure exclude commutes with a fixed distance while the workspace unit is miles.
3. Change the distance rate unit to kilometers.
4. Verify the distance rates settings page immediately shows the converted exclude commute summary in kilometers without opening and saving the exclude commute setting again.

## Tests

- `git diff --check`
- Attempted: `jest tests/unit/PolicyDistanceRatesUtilsTest.ts --runInBand`

Jest could not complete locally because the sparse, blobless checkout was missing unmodified Jest setup dependencies and repeated GitHub/raw file fetches timed out or disconnected. The dependency install completed with Node 26.5.0 and npm 11.17.0.
