### PR TITLE
[Phase 4] -  Remove module-level reportAttributesDerivedValue in isEmptyReport()

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -12,6 +12,7 @@ import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import useParentReportAction from '@hooks/useParentReportAction';
 import usePrevious from '@hooks/usePrevious';
+import {useDerivedIsEmptyReport} from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportScrollManager from '@hooks/useReportScrollManager';
 import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
@@ -186,6 +187,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
     const isReportArchived = useReportIsArchived(reportID);
+    const derivedIsEmptyReport = useDerivedIsEmptyReport(reportID);
     const canPerformWriteAction = canUserPerformWriteAction(report, isReportArchived);
     const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
 
@@ -385,7 +387,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             return;
         }
 
-        if (isUnread(report, transactionThreadReport, isReportArchived) || (lastAction && isCurrentActionUnread(report, lastAction, visibleReportActions))) {
+        if (isUnread(report, transactionThreadReport, isReportArchived, derivedIsEmptyReport) || (lastAction && isCurrentActionUnread(report, lastAction, visibleReportActions))) {
             // On desktop, when the notification center is displayed, isVisible will return false.
             // Currently, there's no programmatic way to dismiss the notification center panel.
             // To handle this, we use the 'referrer' parameter to check if the current navigation is triggered from a notification.

--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -23,6 +23,7 @@ import useAppFocusEvent from './useAppFocusEvent';
 import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
 import useIsAnonymousUser from './useIsAnonymousUser';
 import useIsReportActionsLoaded from './useIsReportActionsLoaded';
+import {useDerivedIsEmptyReport} from './useReportAttributes';
 import useReportIsArchived from './useReportIsArchived';
 
 // useRef gets reset when the reportID changes (the list reuses the same instance per report),
@@ -52,6 +53,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
     const route = useRoute<PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>>();
     const isFocused = useIsFocused();
     const isReportArchived = useReportIsArchived(reportID);
+    const derivedIsEmptyReport = useDerivedIsEmptyReport(reportID);
     const isReportActionsLoaded = useIsReportActionsLoaded(reportID);
 
     const [isVisible, setIsVisible] = useState(Visibility.isVisible);
@@ -73,7 +75,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
     const didMarkReportAsReadInitially = useRef(false);
 
     const lastAction = sortedVisibleReportActions.at(0);
-    const isReportUnreadValue = isUnread(report, transactionThreadReport, isReportArchived) || (!!lastAction && isCurrentActionUnread(report, lastAction));
+    const isReportUnreadValue = isUnread(report, transactionThreadReport, isReportArchived, derivedIsEmptyReport) || (!!lastAction && isCurrentActionUnread(report, lastAction));
 
     useEffect(() => {
         userActiveSince.current = DateUtils.getDBTime();
@@ -111,7 +113,7 @@ function useMarkAsRead({reportID, report, transactionThreadReport, sortedVisible
         }
 
         const isLastActionUnread = !!lastAction && isCurrentActionUnread(report, lastAction, sortedVisibleReportActions);
-        if (!isUnread(report, transactionThreadReport, isReportArchived) && !isLastActionUnread) {
+        if (!isUnread(report, transactionThreadReport, isReportArchived, derivedIsEmptyReport) && !isLastActionUnread) {
             return;
         }
         const isFromNotification = route?.params?.referrer === CONST.REFERRER.NOTIFICATION;

--- a/src/hooks/useReportActionsListModel.ts
+++ b/src/hooks/useReportActionsListModel.ts
@@ -18,6 +18,7 @@ import useOnyx from './useOnyx';
 import useParentReportAction from './useParentReportAction';
 import useReportActionsPagination from './useReportActionsPagination';
 import useReportActionsVisibility from './useReportActionsVisibility';
+import {useDerivedIsEmptyReport} from './useReportAttributes';
 import useReportIsArchived from './useReportIsArchived';
 
 /**
@@ -65,6 +66,7 @@ function useReportActionsListModel(reportID: string, isReportLoadPending: boolea
     const shouldBeAlignedToTop = shouldReportAlignToTop(report, parentReportAction);
 
     const isReportArchived = useReportIsArchived(reportID);
+    const derivedIsEmptyReport = useDerivedIsEmptyReport(reportID);
     const canPerformWriteAction = !!canUserPerformWriteAction(report, isReportArchived);
 
     const isAppLoadPending = useIsAppLoadPending();
@@ -138,6 +140,7 @@ function useReportActionsListModel(reportID: string, isReportLoadPending: boolea
         isConciergeMainDM,
         hasCachedReportActions,
         showConciergeSidePanelWelcome,
+        derivedIsEmptyReport,
     };
 
     // The render state slice on `ReportActionsListStateContext`; this is what drives list re-renders.

--- a/src/hooks/useReportAttributes.ts
+++ b/src/hooks/useReportAttributes.ts
@@ -3,7 +3,7 @@ import type {ReportAttributesDerivedValue} from '@src/types/onyx';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import {reportNameSelector} from '@selectors/ReportAttributes';
+import {reportIsEmptySelector, reportNameSelector} from '@selectors/ReportAttributes';
 
 import useOnyx from './useOnyx';
 
@@ -68,5 +68,18 @@ function useDerivedReportNamesByReportIDs(reportIDs: Array<string | undefined>) 
     return reportNames;
 }
 
+/**
+ * Returns a single report's cached `isEmpty` flag using a selector.
+ *
+ * The selector output is a primitive boolean, so its comparison is trivial and the component re-renders only when
+ * that specific report's emptiness changes — not on every global report attribute change.
+ */
+function useDerivedIsEmptyReport(reportID: string | undefined) {
+    const [isEmpty] = useOnyx(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, {
+        selector: (value: OnyxEntry<ReportAttributesDerivedValue>) => reportIsEmptySelector(value, reportID),
+    });
+    return isEmpty;
+}
+
 export default useReportAttributes;
-export {useReportAttributesByID, useDerivedReportNameByReportID, useDerivedReportNamesByReportIDs};
+export {useReportAttributesByID, useDerivedReportNameByReportID, useDerivedReportNamesByReportIDs, useDerivedIsEmptyReport};

--- a/src/libs/DebugUtils.ts
+++ b/src/libs/DebugUtils.ts
@@ -1486,6 +1486,7 @@ function getReasonForShowingRowInLHN({
     currentUserAccountID,
     conciergeReportID,
     hasGuidesEmails,
+    derivedIsEmptyReport,
 }: {
     report: OnyxEntry<Report>;
     chatReport: OnyxEntry<Report>;
@@ -1499,6 +1500,7 @@ function getReasonForShowingRowInLHN({
     currentUserAccountID?: number;
     hasGuidesEmails: boolean;
     conciergeReportID: string | undefined;
+    derivedIsEmptyReport?: boolean;
 }): TranslationPaths | null {
     if (!report) {
         return null;
@@ -1519,6 +1521,7 @@ function getReasonForShowingRowInLHN({
         currentUserLogin,
         currentUserAccountID,
         conciergeReportID,
+        derivedIsEmptyReport,
         hasGuidesEmails,
     });
 

--- a/src/libs/Navigation/AppNavigator/KeyboardShortcutsHandler/MarkAllMessagesAsReadHandler.tsx
+++ b/src/libs/Navigation/AppNavigator/KeyboardShortcutsHandler/MarkAllMessagesAsReadHandler.tsx
@@ -1,4 +1,5 @@
 import useOnyx from '@hooks/useOnyx';
+import useReportAttributes from '@hooks/useReportAttributes';
 
 import markAllMessagesAsRead from '@libs/actions/Report/MarkAllMessageAsRead';
 import KeyboardShortcut from '@libs/KeyboardShortcut';
@@ -11,19 +12,25 @@ import {useEffect, useRef} from 'react';
 
 function MarkAllMessagesAsReadHandler() {
     const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS, {selector: reportNameValuePairsArchivedSelector});
+    const reportAttributesDerived = useReportAttributes();
     // The keyboard-shortcut callback below is registered once on mount, so keep the latest archived state in a ref
     // for it to read at fire time instead of closing over a stale value.
     const reportNameValuePairsRef = useRef(reportNameValuePairs);
+    const reportAttributesDerivedRef = useRef(reportAttributesDerived);
 
     useEffect(() => {
         reportNameValuePairsRef.current = reportNameValuePairs;
     }, [reportNameValuePairs]);
 
     useEffect(() => {
+        reportAttributesDerivedRef.current = reportAttributesDerived;
+    }, [reportAttributesDerived]);
+
+    useEffect(() => {
         const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.MARK_ALL_MESSAGES_AS_READ;
         const unsubscribe = KeyboardShortcut.subscribe(
             shortcutConfig.shortcutKey,
-            () => markAllMessagesAsRead(reportNameValuePairsRef.current),
+            () => markAllMessagesAsRead(reportNameValuePairsRef.current, reportAttributesDerivedRef.current),
             shortcutConfig.descriptionKey,
             shortcutConfig.modifiers,
             true,

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -1930,7 +1930,7 @@ function prepareReportOptionsForDisplay(
                     : undefined;
             const oneTransactionThreadReport = oneTransactionThreadReportID ? allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${oneTransactionThreadReportID}`] : undefined;
 
-            isOptionUnread = isUnread(report, oneTransactionThreadReport, option.private_isArchived) && !!report.lastActorAccountID;
+            isOptionUnread = isUnread(report, oneTransactionThreadReport, option.private_isArchived, reportAttributesDerived?.[report.reportID]?.isEmpty) && !!report.lastActorAccountID;
         }
 
         let lastIOUCreationDate;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9611,20 +9611,15 @@ function buildOptimisticMoneyRequestEntities({
 
 /**
  * Check if the report is empty, meaning it has no visible messages (i.e. only a "created" report action).
- * Added caching mechanism via derived values.
+ *
+ * @param derivedIsEmptyReport Always prefer passing this cached flag for this report from ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, i.e.
+ *                             `reportAttributes?.[reportID]?.isEmpty`.
  */
-function isEmptyReport(report: OnyxEntry<Report>, isReportArchived: boolean | undefined): boolean {
+function isEmptyReport(report: OnyxEntry<Report>, isReportArchived: boolean | undefined, derivedIsEmptyReport?: boolean): boolean {
     if (!report) {
         return true;
     }
-
-    // Get the `isEmpty` state from cached report attributes
-    const attributes = reportAttributesDerivedValue?.[report.reportID];
-    if (attributes) {
-        return attributes.isEmpty;
-    }
-
-    return generateIsEmptyReport(report, isReportArchived);
+    return derivedIsEmptyReport ?? generateIsEmptyReport(report, isReportArchived);
 }
 
 /**
@@ -9724,12 +9719,12 @@ function generateIsEmptyReport(report: OnyxEntry<Report>, isReportArchived: bool
 }
 
 // We need oneTransactionThreadReport to get the correct last visible action created
-function isUnread(report: OnyxEntry<Report>, oneTransactionThreadReport: OnyxEntry<Report>, isReportArchived: boolean | undefined): boolean {
+function isUnread(report: OnyxEntry<Report>, oneTransactionThreadReport: OnyxEntry<Report>, isReportArchived: boolean | undefined, derivedIsEmptyReport?: boolean): boolean {
     if (!report) {
         return false;
     }
 
-    if (isEmptyReport(report, isReportArchived)) {
+    if (isEmptyReport(report, isReportArchived, derivedIsEmptyReport)) {
         return false;
     }
 
@@ -10270,6 +10265,8 @@ type ShouldReportBeInOptionListParams = {
     conciergeReportID: string | undefined;
     /** Pre-computed value from reportAttributes derived value. When provided, skips the expensive requiresAttentionFromCurrentUser recomputation. */
     requiresAttention?: boolean;
+    /** Pre-computed isEmpty flag from reportAttributes derived value. When provided, skips the module-level reportAttributesDerivedValue read inside isEmptyReport. */
+    derivedIsEmptyReport?: boolean;
     hasGuidesEmails: boolean;
 };
 
@@ -10290,6 +10287,7 @@ function reasonForReportToBeInOptionList({
     isReportArchived,
     conciergeReportID,
     requiresAttention,
+    derivedIsEmptyReport,
     hasGuidesEmails,
 }: ShouldReportBeInOptionListParams): ValueOf<typeof CONST.REPORT_IN_LHN_REASONS> | null {
     const isInDefaultMode = !isInFocusMode;
@@ -10338,7 +10336,7 @@ function reasonForReportToBeInOptionList({
     // We used to use the system DM for A/B testing onboarding tasks, but now only create them in the Concierge chat. We
     // still need to allow existing users who have tasks in the system DM to see them, but otherwise we don't need to
     // show that chat
-    if (report?.participants?.[CONST.ACCOUNT_ID.NOTIFICATIONS] && isEmptyReport(report, isReportArchived)) {
+    if (report?.participants?.[CONST.ACCOUNT_ID.NOTIFICATIONS] && isEmptyReport(report, isReportArchived, derivedIsEmptyReport)) {
         return null;
     }
 
@@ -10375,7 +10373,7 @@ function reasonForReportToBeInOptionList({
         return CONST.REPORT_IN_LHN_REASONS.HAS_GBR;
     }
 
-    const isEmptyChat = isEmptyReport(report, isReportArchived);
+    const isEmptyChat = isEmptyReport(report, isReportArchived, derivedIsEmptyReport);
     const canHideReport = shouldHideReport(report, currentReportId, isReportArchived);
 
     // Drafts already return early above, so no draft check needed here
@@ -10416,7 +10414,7 @@ function reasonForReportToBeInOptionList({
     if (isInFocusMode) {
         const oneTransactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, currentReportActions);
         const oneTransactionThreadReport = deprecatedAllReports?.[`${ONYXKEYS.COLLECTION.REPORT}${oneTransactionThreadReportID}`];
-        return isUnread(report, oneTransactionThreadReport, isReportArchived) && getReportNotificationPreference(report) !== CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE
+        return isUnread(report, oneTransactionThreadReport, isReportArchived, derivedIsEmptyReport) && getReportNotificationPreference(report) !== CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE
             ? CONST.REPORT_IN_LHN_REASONS.IS_UNREAD
             : null;
     }
@@ -14631,6 +14629,7 @@ export {
     isDefaultRoom,
     isDeprecatedGroupDM,
     generateIsEmptyReport,
+    isEmptyReport,
     isRootGroupChat,
     isExpenseReport,
     isExpenseRequest,

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -230,6 +230,7 @@ function shouldDisplayReportInLHN({
         includeSelfDM: true,
         isReportArchived,
         requiresAttention,
+        derivedIsEmptyReport: reportAttributes?.[report?.reportID]?.isEmpty,
         currentUserLogin,
         currentUserAccountID,
         conciergeReportID,
@@ -302,7 +303,7 @@ function getReportsToDisplayInLHN({
 
         if (shouldDisplay) {
             const requiresAttention = reportAttributes?.[report?.reportID]?.requiresAttention ?? false;
-            const isUnreadReport = getIsUnreadReportForInboxTab(report, isReportArchived);
+            const isUnreadReport = getIsUnreadReportForInboxTab(report, isReportArchived, reportAttributes?.[report?.reportID]?.isEmpty);
             reportsToDisplay[reportID] =
                 requiresAttention || hasErrorsOtherThanFailedReceipt || isUnreadReport ? {...report, requiresAttention, hasErrorsOtherThanFailedReceipt, isUnreadReport} : report;
         }
@@ -391,7 +392,7 @@ function updateReportsToDisplayInLHN({
 
         if (shouldDisplay) {
             const requiresAttention = reportAttributes?.[report?.reportID]?.requiresAttention ?? false;
-            const isUnreadReport = getIsUnreadReportForInboxTab(report, isReportArchived);
+            const isUnreadReport = getIsUnreadReportForInboxTab(report, isReportArchived, reportAttributes?.[report?.reportID]?.isEmpty);
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             const hasFlags = requiresAttention || hasErrorsOtherThanFailedReceipt || isUnreadReport;
             const existingEntry = displayedReports[reportID];
@@ -820,7 +821,7 @@ function getOptionData({
     result.statusNum = report.statusNum;
     // When the only message of a report is deleted lastVisibleActionCreated is not reset leading to wrongly
     // setting it Unread so we add additional condition here to avoid empty chat LHN from being bold.
-    result.isUnread = isUnread(report, oneTransactionThreadReport, isReportArchived) && !!report.lastActorAccountID;
+    result.isUnread = isUnread(report, oneTransactionThreadReport, isReportArchived, reportAttributes?.isEmpty) && !!report.lastActorAccountID;
     result.isUnreadWithMention = isUnreadWithMention(report);
     result.isPinned = report.isPinned;
     result.iouReportID = report.iouReportID;
@@ -964,10 +965,14 @@ function getOptionData({
  * Whether a report should appear in the "Unread" Inbox tab: it has unread messages and is not muted.
  * Computed once while building the LHN report set (which is cached/incremental) so the tab filter only reads a flag.
  */
-function getIsUnreadReportForInboxTab(report: Report, isReportArchived: boolean): boolean {
+function getIsUnreadReportForInboxTab(report: Report, isReportArchived: boolean, derivedIsEmptyReport?: boolean): boolean {
     // The `lastActorAccountID` guard matches getOptionData: it keeps chats whose only visible message was
     // deleted out of the Unread tab even though isUnread() can still be true (lastVisibleActionCreated isn't reset).
-    return isUnread(report, undefined, isReportArchived) && !!report.lastActorAccountID && getReportNotificationPreference(report) !== CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE;
+    return (
+        isUnread(report, undefined, isReportArchived, derivedIsEmptyReport) &&
+        !!report.lastActorAccountID &&
+        getReportNotificationPreference(report) !== CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE
+    );
 }
 
 /** Whether a report belongs in the "To-do" Inbox tab: it has an outstanding GBR (requiresAttention) or RBR (errors). */

--- a/src/libs/actions/Report/MarkAllMessageAsRead.tsx
+++ b/src/libs/actions/Report/MarkAllMessageAsRead.tsx
@@ -7,7 +7,7 @@ import {getOneTransactionThreadReportID} from '@libs/ReportActionsUtils';
 import {isArchivedReport, isUnread} from '@libs/ReportUtils';
 
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Report, ReportActions} from '@src/types/onyx';
+import type {Report, ReportActions, ReportAttributesDerivedValue} from '@src/types/onyx';
 
 import type {ReportNameValuePairsArchivedState} from '@selectors/ReportNameValuePairs';
 import type {OnyxCollection} from 'react-native-onyx';
@@ -31,7 +31,7 @@ Onyx.connectWithoutView({
 // The archived state is passed in by the caller (read via useOnyx with reportNameValuePairsArchivedSelector) rather
 // than subscribed to here, so this action stays a plain function and callers only re-render when the archived flags
 // actually change.
-function markAllMessagesAsRead(reportNameValuePairs: OnyxCollection<ReportNameValuePairsArchivedState>) {
+function markAllMessagesAsRead(reportNameValuePairs: OnyxCollection<ReportNameValuePairsArchivedState>, reportAttributesDerived?: ReportAttributesDerivedValue['reports']) {
     if (isAnonymousUser()) {
         return;
     }
@@ -55,7 +55,7 @@ function markAllMessagesAsRead(reportNameValuePairs: OnyxCollection<ReportNameVa
         const oneTransactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.reportID}`], isOffline);
         const oneTransactionThreadReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${oneTransactionThreadReportID}`];
         const isReportArchived = isArchivedReport(reportNameValuePairs?.[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${report.reportID}`]);
-        if (!isUnread(report, oneTransactionThreadReport, isReportArchived)) {
+        if (!isUnread(report, oneTransactionThreadReport, isReportArchived, reportAttributesDerived?.[report.reportID]?.isEmpty)) {
             continue;
         }
 

--- a/src/pages/Debug/Report/DebugReportPage.tsx
+++ b/src/pages/Debug/Report/DebugReportPage.tsx
@@ -8,6 +8,7 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import {useDerivedIsEmptyReport} from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
@@ -90,6 +91,7 @@ function DebugReportPage({
     const isReportArchived = useReportIsArchived(reportID);
     const [guideAccountIDs] = useOnyx(ONYXKEYS.DERIVED.GUIDE_ACCOUNT_IDS);
     const hasGuidesEmails = hasExpensifyGuidesEmails(Object.keys(report?.participants ?? {}).map(Number), guideAccountIDs);
+    const derivedIsEmptyReport = useDerivedIsEmptyReport(reportID);
 
     const metadata = useMemo<Metadata[]>(() => {
         if (!report) {
@@ -128,6 +130,7 @@ function DebugReportPage({
             currentUserAccountID,
             conciergeReportID,
             hasGuidesEmails,
+            derivedIsEmptyReport,
         });
 
         return [
@@ -190,6 +193,7 @@ function DebugReportPage({
         translate,
         conciergeReportID,
         hasGuidesEmails,
+        derivedIsEmptyReport,
     ]);
 
     const icons = useMemoizedLazyExpensifyIcons(['Eye']);

--- a/src/pages/inbox/report/ContextMenu/BaseReportActionContextMenu.tsx
+++ b/src/pages/inbox/report/ContextMenu/BaseReportActionContextMenu.tsx
@@ -17,7 +17,7 @@ import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
-import useReportAttributes, {useDerivedReportNameByReportID} from '@hooks/useReportAttributes';
+import useReportAttributes, {useDerivedIsEmptyReport, useDerivedReportNameByReportID} from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportOrReportDraft from '@hooks/useReportOrReportDraft';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -273,7 +273,8 @@ function BaseReportActionContextMenu({
     const isArchivedRoom = isArchivedNonExpenseReport(originalReport, isOriginalReportArchived);
     const isChronosReport = chatIncludesChronosWithID(originalReportID);
     const isPinnedChat = !!report?.isPinned;
-    const isUnreadChat = isUnread(report, lhnOneTransactionThreadReport, isOriginalReportArchived);
+    const derivedIsEmptyReport = useDerivedIsEmptyReport(reportID);
+    const isUnreadChat = isUnread(report, lhnOneTransactionThreadReport, isOriginalReportArchived, derivedIsEmptyReport);
     const shouldEnableArrowNavigation = !isMini && (isVisible || shouldKeepOpen);
     const isHarvestReport = isHarvestCreatedExpenseReport(reportNameValuePairs?.origin, reportNameValuePairs?.originalID);
     const memberChangeLogReportActionMessage = isMemberChangeAction(reportAction) ? getOriginalMessage(reportAction) : undefined;

--- a/src/pages/inbox/report/ReportActionsListContext.tsx
+++ b/src/pages/inbox/report/ReportActionsListContext.tsx
@@ -63,9 +63,10 @@ function computeReportActionsSkeletonState(readinessSignals: ReportActionsReadin
         isConciergeMainDM,
         hasCachedReportActions,
         showConciergeSidePanelWelcome,
+        derivedIsEmptyReport,
     } = readinessSignals;
 
-    const isReportUnread = isUnread(report, transactionThreadReport, isReportArchived);
+    const isReportUnread = isUnread(report, transactionThreadReport, isReportArchived, derivedIsEmptyReport);
 
     // Before the first successful load, a missing loading-state entry means ReportFetchHandler has not
     // enqueued OpenReport yet. Once a terminal failure writes false, the stored state releases the gate.

--- a/src/pages/inbox/sidebar/InboxTabSelector.tsx
+++ b/src/pages/inbox/sidebar/InboxTabSelector.tsx
@@ -10,6 +10,7 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePopoverPosition from '@hooks/usePopoverPosition';
+import useReportAttributes from '@hooks/useReportAttributes';
 import {useSidebarOrderedReportsActions, useSidebarOrderedReportsState} from '@hooks/useSidebarOrderedReports';
 import useThemeStyles from '@hooks/useThemeStyles';
 
@@ -35,6 +36,7 @@ function InboxTabSelector() {
     const {activeTab, inboxTabCounts} = useSidebarOrderedReportsState();
     const {setActiveTab} = useSidebarOrderedReportsActions();
     const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS, {selector: reportNameValuePairsArchivedSelector});
+    const reportAttributesDerived = useReportAttributes();
     const icons = useMemoizedLazyExpensifyIcons(['Checkmark']);
     const {showConfirmModal} = useConfirmModal();
 
@@ -67,7 +69,7 @@ function InboxTabSelector() {
             if (action !== ModalActions.CONFIRM) {
                 return;
             }
-            markAllMessagesAsRead(reportNameValuePairs);
+            markAllMessagesAsRead(reportNameValuePairs, reportAttributesDerived);
         });
     };
 

--- a/src/selectors/ReportAttributes.ts
+++ b/src/selectors/ReportAttributes.ts
@@ -17,5 +17,7 @@ const reportByIDsSelector = (reportIDs: string[]) => (attributes: OnyxEntry<Repo
 
 const reportNameSelector = (attributes: OnyxEntry<ReportAttributesDerivedValue>, reportID: string | undefined) => (reportID ? attributes?.reports?.[reportID]?.reportName : undefined);
 
-export {reportNameSelector};
+const reportIsEmptySelector = (attributes: OnyxEntry<ReportAttributesDerivedValue>, reportID: string | undefined) => (reportID ? attributes?.reports?.[reportID]?.isEmpty : undefined);
+
+export {reportNameSelector, reportIsEmptySelector};
 export default reportByIDsSelector;

--- a/tests/unit/ReportActionsListContextTest.ts
+++ b/tests/unit/ReportActionsListContextTest.ts
@@ -53,6 +53,7 @@ function createReadinessSignals(overrides: Partial<ReportActionsReadinessSignals
         isConciergeMainDM: false,
         hasCachedReportActions: false,
         showConciergeSidePanelWelcome: false,
+        derivedIsEmptyReport: undefined,
         ...overrides,
     };
 }

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -182,6 +182,7 @@ import {
     isCurrentUserSubmitter,
     isCurrentUserTheOnlyParticipant,
     isDeprecatedGroupDM,
+    isEmptyReport,
     isGroupPolicyExpenseReport,
     isHarvestCreatedExpenseReport,
     isJoinRequestInAdminRoom,
@@ -9723,6 +9724,73 @@ describe('ReportUtils', () => {
             };
 
             expect(isUnread(report, transactionThreadReport, false)).toBe(false);
+        });
+
+        it('returns false when derivedIsEmptyReport is true (empty report is never unread)', () => {
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                reportID: '1',
+                lastReadTime: '2024-03-01 12:00:00.000',
+                lastVisibleActionCreated: '2024-03-01 12:00:01.000',
+                lastMessageText: 'Hello',
+            };
+
+            expect(isUnread(report, undefined, false, true)).toBe(false);
+        });
+
+        it('does not short-circuit when derivedIsEmptyReport is false', () => {
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                reportID: '1',
+                lastReadTime: '2024-03-01 12:00:00.000',
+                lastVisibleActionCreated: '2024-03-01 12:00:01.000',
+                lastMessageText: 'Hello',
+            };
+
+            // derivedIsEmptyReport=false means report is not empty, so isUnread proceeds to check lastReadTime
+            expect(isUnread(report, undefined, false, false)).toBe(true);
+        });
+
+        it('falls through to generateIsEmptyReport when derivedIsEmptyReport is undefined', () => {
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                reportID: '1',
+                lastReadTime: '2024-03-01 12:00:00.000',
+                lastVisibleActionCreated: '2024-03-01 12:00:01.000',
+                lastMessageText: 'Hello',
+            };
+
+            // report has lastMessageText so generateIsEmptyReport returns false, isUnread proceeds
+            expect(isUnread(report, undefined, false, undefined)).toBe(true);
+            expect(isUnread(report, undefined, false)).toBe(true);
+        });
+    });
+
+    describe('isEmptyReport', () => {
+        const report = {
+            ...LHNTestUtils.getFakeReport(),
+            reportID: '1',
+            lastMessageText: 'Hello',
+        };
+
+        it('returns the passed value when derivedIsEmptyReport is true', () => {
+            expect(isEmptyReport(report, false, true)).toBe(true);
+        });
+
+        it('returns the passed value when derivedIsEmptyReport is false', () => {
+            // Verifies ?? (not ||) — false is a valid cache hit, must NOT fall through
+            expect(isEmptyReport(report, false, false)).toBe(false);
+        });
+
+        it('falls through to generateIsEmptyReport when derivedIsEmptyReport is undefined', () => {
+            // report has lastMessageText so generateIsEmptyReport returns false
+            expect(isEmptyReport(report, false, undefined)).toBe(false);
+            expect(isEmptyReport(report, false)).toBe(false);
+        });
+
+        it('returns true when report is undefined', () => {
+            expect(isEmptyReport(undefined, false, false)).toBe(true);
+            expect(isEmptyReport(undefined, false, true)).toBe(true);
         });
     });
 

--- a/tests/unit/useReportAttributesTest.ts
+++ b/tests/unit/useReportAttributesTest.ts
@@ -1,12 +1,13 @@
 import {renderHook} from '@testing-library/react-native';
 
-import useReportAttributes, {useDerivedReportNameByReportID, useDerivedReportNamesByReportIDs} from '@hooks/useReportAttributes';
+import useReportAttributes, {useDerivedIsEmptyReport, useDerivedReportNameByReportID, useDerivedReportNamesByReportIDs} from '@hooks/useReportAttributes';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {ReportAttributesDerivedValue} from '@src/types/onyx';
 import type {ReportAttributes} from '@src/types/onyx/DerivedValues';
 
+import {reportIsEmptySelector} from '@selectors/ReportAttributes';
 import Onyx from 'react-native-onyx';
 
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
@@ -266,5 +267,104 @@ describe('useDerivedReportNamesByReportIDs', () => {
 
         expect(result.current?.[REPORT_ID_1]).toBe('Renamed Report 1');
         expect(result.current?.[REPORT_ID_2]).toBe('Report 2');
+    });
+});
+
+describe('useDerivedIsEmptyReport', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+    });
+
+    it('should return undefined when the derived value is not set', async () => {
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDerivedIsEmptyReport(REPORT_ID_1));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('should return false for a non-empty report', async () => {
+        await Onyx.set(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, createDerivedValue(MOCK_REPORTS));
+
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDerivedIsEmptyReport(REPORT_ID_1));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('should return true for an empty report', async () => {
+        await Onyx.set(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, createDerivedValue(MOCK_REPORTS));
+
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDerivedIsEmptyReport(REPORT_ID_2));
+
+        expect(result.current).toBe(true);
+    });
+
+    it('should return undefined when reportID is undefined', async () => {
+        await Onyx.set(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, createDerivedValue(MOCK_REPORTS));
+
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDerivedIsEmptyReport(undefined));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('should return undefined when the reportID does not exist', async () => {
+        await Onyx.set(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, createDerivedValue(MOCK_REPORTS));
+
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDerivedIsEmptyReport('nonExistentReportID'));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('should update when the isEmpty flag changes', async () => {
+        await Onyx.set(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, createDerivedValue(MOCK_REPORTS));
+
+        await waitForBatchedUpdates();
+
+        const {result, rerender} = renderHook(() => useDerivedIsEmptyReport(REPORT_ID_1));
+
+        expect(result.current).toBe(false);
+
+        await Onyx.set(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, createDerivedValue({[REPORT_ID_1]: createMockReport({isEmpty: true})}));
+
+        await waitForBatchedUpdates();
+        rerender(undefined);
+
+        expect(result.current).toBe(true);
+    });
+});
+
+describe('reportIsEmptySelector', () => {
+    const derivedValue = createDerivedValue(MOCK_REPORTS);
+
+    it('should return false for a non-empty report', () => {
+        expect(reportIsEmptySelector(derivedValue, REPORT_ID_1)).toBe(false);
+    });
+
+    it('should return true for an empty report', () => {
+        expect(reportIsEmptySelector(derivedValue, REPORT_ID_2)).toBe(true);
+    });
+
+    it('should return undefined when reportID is undefined', () => {
+        expect(reportIsEmptySelector(derivedValue, undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when reportID does not exist', () => {
+        expect(reportIsEmptySelector(derivedValue, 'nonExistentReportID')).toBeUndefined();
+    });
+
+    it('should return undefined when attributes is undefined', () => {
+        expect(reportIsEmptySelector(undefined, REPORT_ID_1)).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Remove module-level reportAttributesDerivedValue read inside isEmptyReport() by accepting an optional derivedIsEmptyReport parameter, mirroring Phase 2's derivedReportName pattern.

- Add reportIsEmptySelector to ReportAttributes selectors
- Add useDerivedIsEmptyReport hook
- Thread derivedIsEmptyReport through isUnread, reasonForReportToBeInOptionList, and ShouldReportBeInOptionListParams
- Update call sites in SidebarUtils, OptionsListUtils, DebugUtils, MarkAllMessageAsRead, and components/hooks
- Add tests for new hook

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/66427
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

**1. LHN displays reports correctly**

1. Check chat list in LHN
2. Verify empty chats do NOT appear
3. Verify non-empty unread chats show bold text
4. Verify pinned empty chats still appear

**2. Inbox Unread tab and Mark all as read**

1. Go to Inbox, switch to Unread tab
2. Verify only reports with unread messages appear
3. Verify empty reports do NOT appear in Unread tab
4. Long-press on Unread tab, select "Mark all as read"
5. Verify all unread indicators are cleared and Unread tab count goes to 0

**3. Report View — Expense report marks as read**

1. Have another user send a message in an expense report
2. Open that unread expense report
3. Verify unread indicator disappears after viewing

**4. Report View — Chat navigates to unread position**

1. Have another user send multiple messages in a chat
2. Open that unread chat
3. Verify chat scrolls to correct unread position

**5. Search displays correct unread state**

1. Go to Search
2. Search for a chat that has unread messages
3. Verify search results show correct bold/unread state
4. Search for an empty chat
5. Verify empty chat does not show as unread/bold

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


https://github.com/user-attachments/assets/215e7f5a-1854-419b-9030-789c7013a5ea

