### PR TITLE
Remove vendor gate intacct

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -2478,19 +2478,19 @@ function isXeroActiveMatchingSource(policy: OnyxEntry<Policy>): boolean {
  * the field.
  *
  * The `vendorMatching` beta only gates the integrations that haven't reached GA yet, so
- * `isVendorMatchingBetaEnabled` is consulted on the Intacct and Xero branches but not on QBO:
+ * `isVendorMatchingBetaEnabled` is consulted on the Xero branch but not on QBO or Sage Intacct:
  *   - QBO (R1) with non-reimbursable export = Credit Card or Debit Card. GA, so no beta required
- *   - Sage Intacct (R2) with non-reimbursable export = Credit Card Charge. Beta required
+ *   - Sage Intacct (R2) with non-reimbursable export = Credit Card Charge. GA, so no beta required
  *   - Xero (R3) has no export destination enum, so a present connection is enough. Beta required
  */
 function hasVendorFeature(policy: OnyxEntry<Policy>, isVendorMatchingBetaEnabled: boolean): boolean {
     if (!policy) {
         return false;
     }
-    if (isQBOVendorMatchingActive(policy)) {
+    if (isQBOVendorMatchingActive(policy) || isIntacctVendorMatchingActive(policy)) {
         return true;
     }
-    return isVendorMatchingBetaEnabled && (isIntacctVendorMatchingActive(policy) || isXeroVendorMatchingActive(policy));
+    return isVendorMatchingBetaEnabled && isXeroVendorMatchingActive(policy);
 }
 
 /**

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -573,8 +573,9 @@ const ViolationsUtils = {
                     : getTagViolationsForMultiLevelTags(updatedTransaction, newTransactionViolations, policyTagList, hasDependentTags);
         }
 
-        // Inactive vendor violation, gated behind the `vendorMatching` beta. The transaction's
-        // vendor is never cleared here — admins need to see what was set so they can re-pick.
+        // Inactive vendor violation, gated on `hasVendorFeature`, which only consults the
+        // `vendorMatching` beta for integrations that haven't reached GA. The transaction's
+        // vendor is never cleared here because admins need to see what was set so they can re-pick.
         if (allBetas !== undefined) {
             const isVendorMatchingBetaEnabled = Permissions.isBetaEnabled(CONST.BETAS.VENDOR_MATCHING, allBetas);
             const hasInactiveVendorViolation = newTransactionViolations.some((violation) => violation.name === CONST.VIOLATIONS.INACTIVE_VENDOR);

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage/index.tsx
@@ -167,11 +167,13 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
     // `hasVendorFeature` stays as the narrower `isActive` predicate (is the export config scoping
     // vendors right now), so it can't double as the visibility gate.
     //
-    // Beta gating mirrors `hasVendorFeature`: QBO (R1) is GA, so a connected QBO workspace always
-    // sees the row regardless of the `vendorMatching` beta. Sage Intacct (R2) and Xero (R3) haven't
-    // reached GA, so they only show the row while the beta is enabled.
-    const vendorMatchingConnection = getConnectedIntegration(policy, [CONST.POLICY.CONNECTIONS.NAME.QBO, CONST.POLICY.CONNECTIONS.NAME.XERO, CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]);
-    const shouldShowVendorsFeature = vendorMatchingConnection === CONST.POLICY.CONNECTIONS.NAME.QBO || (isVendorMatchingEnabled && !!vendorMatchingConnection);
+    // Beta gating mirrors `hasVendorFeature`: QBO (R1) and Sage Intacct (R2) are GA, so a workspace
+    // connected to either always sees the row regardless of the `vendorMatching` beta. Xero (R3)
+    // hasn't reached GA, so it only shows the row while the beta is enabled. The two groups are
+    // checked separately so a GA connection wins even when a beta-gated one is also connected.
+    const hasGenerallyAvailableVendorConnection = !!getConnectedIntegration(policy, [CONST.POLICY.CONNECTIONS.NAME.QBO, CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]);
+    const hasBetaGatedVendorConnection = !!getConnectedIntegration(policy, [CONST.POLICY.CONNECTIONS.NAME.XERO]);
+    const shouldShowVendorsFeature = hasGenerallyAvailableVendorConnection || (isVendorMatchingEnabled && hasBetaGatedVendorConnection);
 
     const warnAccountingManagesOrganizeFeature = async () => {
         if (!hasAccountingConnection || !policyID) {

--- a/tests/ui/MoneyRequestViewTest.tsx
+++ b/tests/ui/MoneyRequestViewTest.tsx
@@ -626,6 +626,38 @@ describe('MoneyRequestView edit fields', () => {
         });
     });
 
+    it('shows the vendor row on Sage Intacct without the vendorMatching beta because Intacct (R2) is generally available', async () => {
+        const threadReport = {
+            ...LHNTestUtils.getFakeReport(),
+            parentReportID: expenseReportID,
+            parentReportActionID,
+        };
+
+        await setupTestData();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {
+                reimbursable: false,
+                comment: {vendor: {externalID: 'iv-1', wasManuallySet: false}},
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderMoneyRequestView(threadReport, {
+            connections: {
+                [CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {
+                    config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE}},
+                    data: {vendors: [{id: 'iv-1', name: 'V001', value: 'Acme Intacct'}]},
+                },
+            },
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        // Intacct keeps the "Vendor" label and shows the vendor's display name, which Intacct stores in `value`.
+        await waitFor(() => {
+            expect(screen.getByTestId('menu-item-title-common.vendor')).toHaveTextContent('Acme Intacct');
+        });
+    });
+
     it('hides the vendor row on Xero without the vendorMatching beta because Xero (R3) is still pre-GA', async () => {
         const threadReport = {
             ...LHNTestUtils.getFakeReport(),

--- a/tests/ui/WorkspaceMoreFeaturesPageTest.tsx
+++ b/tests/ui/WorkspaceMoreFeaturesPageTest.tsx
@@ -467,7 +467,36 @@ describe('WorkspaceMoreFeaturesPage', () => {
             await expect(findLockedSwitch('workspace.moreFeatures.vendors.subtitle')).resolves.toBeOnTheScreen();
         });
 
-        // Sage Intacct (R2) and Xero (R3) are still beta-gated, so they stay hidden when the beta is off.
+        // Sage Intacct R2 is GA, so a connected Intacct workspace shows the row regardless of the vendorMatching beta.
+        it('shows the Vendors row locked ON for Sage Intacct scoping vendors even with the beta disabled (Intacct is GA)', async () => {
+            await renderWithVendorMatching(
+                {[CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE}}}},
+                false,
+            );
+            await expect(findLockedSwitch('workspace.moreFeatures.vendors.subtitle')).resolves.toBeOnTheScreen();
+        });
+
+        it('shows the Vendors row locked OFF for Sage Intacct not scoping vendors even with the beta disabled (discovery state, Intacct is GA)', async () => {
+            await renderWithVendorMatching(
+                {[CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL}}}},
+                false,
+            );
+            await expect(findLockedSwitch('workspace.moreFeatures.vendors.subtitle')).resolves.toBeOnTheScreen();
+        });
+
+        // A GA connection wins the visibility decision even when a beta-gated one is also connected.
+        it('shows the Vendors row for a Sage Intacct workspace with a lingering Xero connection when the beta is disabled', async () => {
+            await renderWithVendorMatching(
+                {
+                    [CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE}}},
+                    [CONST.POLICY.CONNECTIONS.NAME.XERO]: {config: {isConfigured: true}},
+                },
+                false,
+            );
+            await expect(findLockedSwitch('workspace.moreFeatures.vendors.subtitle')).resolves.toBeOnTheScreen();
+        });
+
+        // Xero (R3) is still beta-gated, so it stays hidden when the beta is off.
         it('hides the Vendors row for a beta-gated integration (Xero) when the beta is disabled', async () => {
             await renderWithVendorMatching({[CONST.POLICY.CONNECTIONS.NAME.XERO]: {config: {}}}, false);
             expect(vendorsSwitchQuery()).toBeNull();

--- a/tests/unit/AddVendorPageTest.ts
+++ b/tests/unit/AddVendorPageTest.ts
@@ -24,6 +24,18 @@ const buildQBOPolicy = (vendors: Array<{id: string; name: string; currency: stri
         }),
     });
 
+/** Sage Intacct policy whose Credit Card Charge export scopes vendor matching to Intacct. */
+const buildIntacctPolicy = (vendors: Array<{id: string; name: string; value: string}>): Policy =>
+    createMock<Policy>({
+        ...createRandomPolicy(0),
+        connections: createMock<Connections>({
+            [CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {
+                config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE}},
+                data: {vendors},
+            },
+        }),
+    });
+
 /** Xero policy whose supplier list scopes vendor matching to Xero (label flips vendor -> supplier). */
 const buildXeroPolicy = (contacts: Record<string, {id: string; name: string; email: string}>): Policy =>
     createMock<Policy>({
@@ -124,10 +136,15 @@ describe('AddVendorPage', () => {
      */
     describe('vendor rule row derivation (MerchantRulePageBase)', () => {
         const qboPolicy = buildQBOPolicy([{id: 'v-1', name: 'Acme Co', currency: 'USD'}]);
+        const intacctPolicy = buildIntacctPolicy([{id: 'iv-1', name: 'V001', value: 'Acme Intacct'}]);
         const xeroPolicy = buildXeroPolicy({xc1: {id: 'xc1', name: 'Acme Xero', email: 'acme@example.com'}});
 
         it('shows the row on QBO with the beta off because QBO vendor matching is generally available', () => {
             expect(hasVendorFeature(qboPolicy, false)).toBe(true);
+        });
+
+        it('shows the row on Sage Intacct with the beta off because Intacct vendor matching is generally available', () => {
+            expect(hasVendorFeature(intacctPolicy, false)).toBe(true);
         });
 
         it('hides the row on Xero when the beta is off because Xero vendor matching is not generally available yet', () => {

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -3799,8 +3799,16 @@ describe('PolicyUtils', () => {
                 expect(hasVendorFeature(buildQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL), false)).toBe(false);
             });
 
-            it('returns false when beta is disabled and Intacct CC Charge export is configured because Intacct (R2) is still pre-GA', () => {
-                expect(hasVendorFeature(buildIntacctPolicy(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE), false)).toBe(false);
+            it('returns true when beta is disabled and Intacct non-reimbursable export is Credit Card Charge because Intacct (R2) is generally available', () => {
+                expect(hasVendorFeature(buildIntacctPolicy(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE), false)).toBe(true);
+            });
+
+            it('returns false when beta is disabled and Intacct non-reimbursable export is Vendor Bill because GA did not widen the export mode gate', () => {
+                expect(hasVendorFeature(buildIntacctPolicy(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL), false)).toBe(false);
+            });
+
+            it('returns false when beta is disabled and the Intacct non-reimbursable export destination is not set', () => {
+                expect(hasVendorFeature(buildIntacctPolicy(undefined), false)).toBe(false);
             });
 
             it('returns false when beta is disabled and Xero is connected because Xero (R3) is still pre-GA', () => {

--- a/tests/unit/VendorMatchingMerchantRulesTest.ts
+++ b/tests/unit/VendorMatchingMerchantRulesTest.ts
@@ -64,6 +64,18 @@ const buildQBOWithVendorBillExportPolicy = (vendors: Array<{id: string; name: st
     });
 
 /** Xero policy whose supplier list scopes vendor matching to Xero (label flips vendor -> supplier). */
+/** Sage Intacct policy whose Credit Card Charge export scopes vendor matching to Intacct. */
+const buildIntacctPolicy = (vendors: Array<{id: string; name: string; value: string}>): Policy =>
+    createMock<Policy>({
+        ...createRandomPolicy(0),
+        connections: createMock<Connections>({
+            [CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {
+                config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE}},
+                data: {vendors},
+            },
+        }),
+    });
+
 const buildXeroPolicy = (contacts: Record<string, {id: string; name: string; email: string}> | undefined): Policy =>
     createMock<Policy>({
         ...createRandomPolicy(0),
@@ -259,6 +271,10 @@ describe('Vendor matching on merchant rules', () => {
 
         it('is visible on QBO when the beta is off because QBO (R1) is generally available', () => {
             expect(hasVendorFeature(buildQBOPolicy([{id: 'v-1', name: 'Acme Co', currency: 'USD'}]), false)).toBe(true);
+        });
+
+        it('is visible on Sage Intacct when the beta is off because Intacct (R2) is generally available', () => {
+            expect(hasVendorFeature(buildIntacctPolicy([{id: 'iv-1', name: 'V001', value: 'Acme Intacct'}]), false)).toBe(true);
         });
 
         it('is hidden on Xero when the beta is off because Xero (R3) is still pre-GA', () => {

--- a/tests/unit/VendorMatchingMerchantRulesTest.ts
+++ b/tests/unit/VendorMatchingMerchantRulesTest.ts
@@ -63,7 +63,6 @@ const buildQBOWithVendorBillExportPolicy = (vendors: Array<{id: string; name: st
         }),
     });
 
-/** Xero policy whose supplier list scopes vendor matching to Xero (label flips vendor -> supplier). */
 /** Sage Intacct policy whose Credit Card Charge export scopes vendor matching to Intacct. */
 const buildIntacctPolicy = (vendors: Array<{id: string; name: string; value: string}>): Policy =>
     createMock<Policy>({
@@ -76,6 +75,7 @@ const buildIntacctPolicy = (vendors: Array<{id: string; name: string; value: str
         }),
     });
 
+/** Xero policy whose supplier list scopes vendor matching to Xero (label flips vendor -> supplier). */
 const buildXeroPolicy = (contacts: Record<string, {id: string; name: string; email: string}> | undefined): Policy =>
     createMock<Policy>({
         ...createRandomPolicy(0),

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -8,6 +8,7 @@ import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy, PolicyCategories, PolicyTagLists, Report, Transaction, TransactionViolation} from '@src/types/onyx';
+import type {SageIntacctExportConfig} from '@src/types/onyx/Policy';
 import type {TransactionCollectionDataSet} from '@src/types/onyx/Transaction';
 
 import Onyx from 'react-native-onyx';
@@ -3009,7 +3010,7 @@ describe('getViolationsOnyxData', () => {
             // Pass a `vendors` array to control the synced list, or `null` to simulate the list still
             // hydrating. Intacct vendors carry the display name in `value`.
             const policyWithIntacctVendorFeature = (
-                nonReimbursable: string = CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE,
+                nonReimbursable: SageIntacctExportConfig['nonReimbursable'] = CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE,
                 vendors: Array<{id: string; name: string; value: string}> | null = [{id: 'iv-active', name: 'V001', value: 'Acme Intacct'}],
             ) =>
                 createMock<Policy>({

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -3005,6 +3005,94 @@ describe('getViolationsOnyxData', () => {
             expect(result.value).toContainEqual(inactiveVendorViolation);
         });
 
+        describe('Sage Intacct (R2)', () => {
+            // Pass a `vendors` array to control the synced list, or `null` to simulate the list still
+            // hydrating. Intacct vendors carry the display name in `value`.
+            const policyWithIntacctVendorFeature = (
+                nonReimbursable: string = CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE,
+                vendors: Array<{id: string; name: string; value: string}> | null = [{id: 'iv-active', name: 'V001', value: 'Acme Intacct'}],
+            ) =>
+                createMock<Policy>({
+                    requiresTag: false,
+                    requiresCategory: false,
+                    connections: {
+                        [CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT]: {
+                            config: {export: {nonReimbursable}},
+                            data: vendors ? {vendors} : {},
+                        },
+                    },
+                });
+
+            it('adds the violation when the vendorMatching beta is disabled but Intacct is configured, because Intacct (R2) is generally available', () => {
+                isBetaEnabledSpy.mockImplementation(() => false);
+                policy = policyWithIntacctVendorFeature();
+                transaction.comment = {...transaction.comment, vendor: {externalID: 'iv-missing', wasManuallySet: true}};
+                const result = ViolationsUtils.getViolationsOnyxData({
+                    ownerLogin: undefined,
+                    updatedTransaction: transaction,
+                    transactionViolations,
+                    policy,
+                    policyTagList: policyTags,
+                    policyCategories,
+                    hasDependentTags: false,
+                    isInvoiceTransaction: false,
+                });
+                // Intacct is not a supplier source, so the plain vendor violation (no isSupplierViolation flag) is expected.
+                expect(result.value).toEqual(expect.arrayContaining([inactiveVendorViolation]));
+            });
+
+            it('does not add the violation when the Intacct vendor is in the synced list', () => {
+                isBetaEnabledSpy.mockImplementation(() => false);
+                policy = policyWithIntacctVendorFeature();
+                transaction.comment = {...transaction.comment, vendor: {externalID: 'iv-active', wasManuallySet: true}};
+                const result = ViolationsUtils.getViolationsOnyxData({
+                    ownerLogin: undefined,
+                    updatedTransaction: transaction,
+                    transactionViolations,
+                    policy,
+                    policyTagList: policyTags,
+                    policyCategories,
+                    hasDependentTags: false,
+                    isInvoiceTransaction: false,
+                });
+                expect(result.value).not.toContainEqual(inactiveVendorViolation);
+            });
+
+            it('does not add the violation while the Intacct vendor list is still hydrating (vendors undefined)', () => {
+                isBetaEnabledSpy.mockImplementation(() => false);
+                policy = policyWithIntacctVendorFeature(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE, null);
+                transaction.comment = {...transaction.comment, vendor: {externalID: 'iv-anything', wasManuallySet: true}};
+                const result = ViolationsUtils.getViolationsOnyxData({
+                    ownerLogin: undefined,
+                    updatedTransaction: transaction,
+                    transactionViolations,
+                    policy,
+                    policyTagList: policyTags,
+                    policyCategories,
+                    hasDependentTags: false,
+                    isInvoiceTransaction: false,
+                });
+                expect(result.value).not.toContainEqual(inactiveVendorViolation);
+            });
+
+            it('removes an existing violation when the Intacct export switches to Vendor Bill with the beta disabled', () => {
+                isBetaEnabledSpy.mockImplementation(() => false);
+                policy = policyWithIntacctVendorFeature(CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL);
+                transaction.comment = {...transaction.comment, vendor: {externalID: 'iv-missing', wasManuallySet: true}};
+                const result = ViolationsUtils.getViolationsOnyxData({
+                    ownerLogin: undefined,
+                    updatedTransaction: transaction,
+                    transactionViolations: [inactiveVendorViolation],
+                    policy,
+                    policyTagList: policyTags,
+                    policyCategories,
+                    hasDependentTags: false,
+                    isInvoiceTransaction: false,
+                });
+                expect(result.value).not.toContainEqual(inactiveVendorViolation);
+            });
+        });
+
         describe('Xero (R4)', () => {
             // Placeholder for "Xero connected, contacts not yet synced". Explicit symbol avoids the
             // default-parameter trap where `undefined` would fall back to the populated default.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Vendor matching R2 (Sage Intacct) has shipped, every Sage Intacct-connected workspace has been enrolled in the `vendorMatching` beta, and the Integration-Server exporter gate is already gone (https://github.com/Expensify/Integration-Server/pull/9282, on production since 2026-09-04). Intacct code paths should therefore stop consulting the beta. Xero (R3), Rillet (R4), and DualEntry are still pre-GA, so `CONST.BETAS.VENDOR_MATCHING` stays and keeps gating those three. This is the Intacct counterpart of the QBO cleanup in https://github.com/Expensify/App/pull/98516.

Only two gates read the beta on an Intacct path, so only two change:

- **`PolicyUtils.hasVendorFeature`** now short-circuits to `true` on `isIntacctVendorMatchingActive` alongside `isQBOVendorMatchingActive`, before the beta is consulted:

  ```ts
  if (isQBOVendorMatchingActive(policy) || isIntacctVendorMatchingActive(policy)) {
      return true;
  }
  return isVendorMatchingBetaEnabled && (isXeroVendorMatchingActive(policy) || isRilletVendorMatchingActive(policy) || isDualEntryVendorMatchingActive(policy));
  ```

  Every cross-integration vendor surface already routes through it and needed no edit: `ViolationsUtils`, `MoneyRequestView`, `WorkspaceVendorsPage`, `getWorkspaceMenuItems` (workspace menu and search router suggestions), `MerchantRulePageBase`, `AddVendorPage`, `IOURequestStepVendor`, and the product marketing CTA.
- **`WorkspaceMoreFeaturesPage`** decides whether the Vendors row is visible from the active vendor source, and used to exempt only QBO from the beta. It now treats both QBO and Sage Intacct as GA. The active-source lookup itself is unchanged, so a lingering GA connection still cannot unlock the row for a beta-gated integration.

GA does not widen the export mode gate: an Intacct workspace exporting non-reimbursable expenses as Vendor Bill still has no vendor feature, with or without the beta.

Deliberately untouched: no page under `src/pages/workspace/accounting/intacct/` reads the beta, so there is no Intacct analogue of the QBO accounting page change. The two Xero-only pages (`DynamicXeroExportConfigurationPage`, `DynamicXeroNonReimbursableDefaultContactSelectPage`) keep their beta check.

Known follow-up, out of scope here: `ProductMarketingWindowManager` still gates its fallback-workspace connections prefetch on the beta, so an off-beta QBO or Intacct fallback workspace routes the marketing CTA to More features instead of Vendors. That is a one-line change plus a test and will go in its own PR.

**Deploy order:** this PR goes first. The matching Web-Expensify PR (https://github.com/Expensify/Web-Expensify/pull/55939, auto-matcher and card-feed gates) must only be merged after this one is on production. Otherwise Concierge auto-match messages would show up on workspaces whose App still hides the Vendor row.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
https://github.com/Expensify/Expensify/issues/677006


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Ran the suites that cover every surface behind the gate and verified they all pass:
   ```
   npx jest tests/unit/PolicyUtilsTest.ts tests/unit/ViolationUtilsTest.ts tests/unit/AddVendorPageTest.ts tests/unit/VendorMatchingMerchantRulesTest.ts tests/ui/MoneyRequestViewTest.tsx tests/ui/WorkspaceMoreFeaturesPageTest.tsx
   ```
   What they pin, all with the `vendorMatching` beta **off**:
   - `hasVendorFeature` is true for Intacct on Credit Card Charge, and still false for Intacct on Vendor Bill, for Intacct with no export destination, and for Xero.
   - The `inactiveVendor` violation is added for an Intacct vendor missing from the synced list, not added for a vendor that is in the list, not added while the vendor list is still hydrating, and removed when the export switches to Vendor Bill.
   - The Vendor row renders on a non-reimbursable Intacct expense and shows the vendor display name.
   - The More features Vendors row shows locked ON for Intacct on Credit Card Charge, locked OFF for Intacct on Vendor Bill, still shows for Intacct with a lingering Xero connection, and stays hidden for a Xero-only workspace.
   - The merchant rule "Set vendor to" row and the Add vendor page are available on Intacct.
2. Ran `npm run typecheck` and ESLint on the touched files and verified no errors.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
No network-dependent behavior changes. The gate is resolved from `policy.connections`, which is already in Onyx, so the vendor UI shows or hides identically offline.

1. On a Sage Intacct workspace set up as in the QA steps, open a non-reimbursable expense while online and verify the Vendor row is visible.
2. Go offline, reopen the same expense, and verify the Vendor row is still visible.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Precondition: two workspaces on the Control plan whose **owners are not in the `vendorMatching` beta**. Workspace A is connected to Sage Intacct, workspace B is connected to Xero. Each needs at least one non-reimbursable (company card) expense.

1. On workspace A, go to Workspace > Accounting > Export > Non-reimbursable expenses and set "Export as" to **Credit card charge**. Let the sync finish.
2. Open Workspace > More features and verify the **Vendors** row is present, switched on, and locked.
3. Open Workspace > Vendors and verify the page lists the vendors imported from Sage Intacct.
4. Open a non-reimbursable expense on workspace A and verify a **Vendor** row is shown on the expense.
5. Tap the Vendor row, pick a vendor, and verify the selection saves and the row shows that vendor's name.
6. Open Workspace > Rules > Merchant, add or edit a rule, and verify the **Set vendor to** row is present and its picker lists the Sage Intacct vendors.
7. Set a vendor on an expense, make that vendor inactive in Sage Intacct, run Sync now on the connection, and verify the expense shows the inactive vendor violation.
8. Change workspace A's non-reimbursable export to **Vendor bill**. Verify the Vendors row in More features is still present but switched off, the Vendors page is no longer in the workspace menu, and the Vendor row no longer shows on non-reimbursable expenses.
9. Regression check on workspace B (Xero, owner not in the beta): repeat steps 2 to 6 and verify **none** of the vendor UI appears.
10. Add workspace B's owner to the `vendorMatching` beta, reload, and verify the vendor UI (labeled Supplier on Xero) appears.

Cover web plus one native platform. We can tag @heyjennahay to help with this.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

