### PR TITLE
perf: drop redundant whole-collection Onyx subscriptions from the split expense page

### DIFF
--- a/src/libs/actions/IOU/SplitTransactionUpdate.ts
+++ b/src/libs/actions/IOU/SplitTransactionUpdate.ts
@@ -80,7 +80,7 @@ import type {BuildOnyxDataForMoneyRequestKeys, MoneyRequestInformationParams} fr
 import type {UpdateMoneyRequestDataKeys} from './UpdateMoneyRequest';
 
 import {getCleanUpTransactionThreadReportOnyxData} from './DeleteMoneyRequest';
-import {getAllReports} from './index';
+import {getAllPersonalDetails, getAllReportActionsFromIOU, getAllReportNameValuePairs, getAllReports, getAllSnapshots} from './index';
 import {getMoneyRequestParticipantsFromReport} from './MoneyRequest';
 import {getMoneyRequestInformation, getReportPreviewReportAction} from './MoneyRequestBuilder';
 import {getDeleteTrackExpenseInformation} from './TrackExpense';
@@ -89,8 +89,11 @@ import {getUpdateMoneyRequestParams} from './UpdateMoneyRequest';
 type UpdateSplitTransactionsParams = {
     allTransactionsList: OnyxCollection<OnyxTypes.Transaction>;
     allReportsList: OnyxCollection<OnyxTypes.Report>;
-    allReportActionsList: OnyxCollection<OnyxTypes.ReportActions>;
-    allReportNameValuePairsList: OnyxCollection<OnyxTypes.ReportNameValuePairs>;
+    /** Optional: falls back to the module-level cache in `actions/IOU/index`, which already tracks this collection */
+    allReportActionsList?: OnyxCollection<OnyxTypes.ReportActions>;
+    /** Optional: falls back to the module-level cache in `actions/IOU/index`, which already tracks this collection */
+    allReportNameValuePairsList?: OnyxCollection<OnyxTypes.ReportNameValuePairs>;
+    /** Optional: falls back to the module-level cache in `actions/IOU/index`, which already tracks this collection */
     allSnapshots?: OnyxCollection<OnyxTypes.SearchResults>;
     allPolicyTags: OnyxCollection<OnyxTypes.PolicyTagLists>;
     transactionData: {
@@ -115,7 +118,8 @@ type UpdateSplitTransactionsParams = {
     isFromSplitExpensesFlow?: boolean;
     /** Keeps the new splits off the highlight rail, for flows that never open the expense report */
     shouldSkipReportHighlightRail?: boolean;
-    personalDetails: OnyxEntry<OnyxTypes.PersonalDetailsList>;
+    /** Optional: falls back to the module-level cache in `actions/IOU/index`, which already tracks this key */
+    personalDetails?: OnyxEntry<OnyxTypes.PersonalDetailsList>;
     transactionReport: OnyxEntry<OnyxTypes.Report>;
     expenseReport: OnyxEntry<OnyxTypes.Report>;
     isOffline: boolean;
@@ -179,9 +183,9 @@ function rescaleSnapshotGroupAmount<T extends OnyxTypes.Transaction>(transaction
 function updateSplitTransactions({
     allTransactionsList,
     allReportsList,
-    allReportActionsList,
-    allReportNameValuePairsList,
-    allSnapshots,
+    allReportActionsList = getAllReportActionsFromIOU(),
+    allReportNameValuePairsList = getAllReportNameValuePairs(),
+    allSnapshots = getAllSnapshots(),
     allPolicyTags,
     transactionData,
     searchContext,
@@ -199,7 +203,7 @@ function updateSplitTransactions({
     isFromSplitExpensesFlow,
     shouldSkipReportHighlightRail,
     betas,
-    personalDetails,
+    personalDetails = getAllPersonalDetails(),
     transactionReport,
     expenseReport: expenseReportFromParams,
     isOffline,

--- a/src/pages/iou/DynamicSplitExpensePage.tsx
+++ b/src/pages/iou/DynamicSplitExpensePage.tsx
@@ -116,7 +116,6 @@ function DynamicSplitExpensePage({route}: DynamicSplitExpensePageProps) {
     const [draftTransaction, draftTransactionMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.SPLIT_TRANSACTION_DRAFT}${transactionID}`);
     const isLoadingDraftTransaction = isLoadingOnyxValue(draftTransactionMetadata);
     const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
-    const [allReportActions] = useOnyx(ONYXKEYS.COLLECTION.REPORT_ACTIONS);
     const draftTransactionReport = useReportOrReportDraft(draftTransaction?.reportID);
     const parentTransactionReport = useReportOrReportDraft(draftTransactionReport?.parentReportID);
     const expenseReport = draftTransactionReport?.type === CONST.REPORT.TYPE.EXPENSE ? draftTransactionReport : parentTransactionReport;
@@ -128,8 +127,6 @@ function DynamicSplitExpensePage({route}: DynamicSplitExpensePageProps) {
     const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(transactionID)}`];
     const originalTransaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(transaction?.comment?.originalTransactionID)}`];
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
-    const [allReportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS);
-    const [allSnapshots] = useOnyx(ONYXKEYS.COLLECTION.SNAPSHOT);
     const [selfDMReportID] = useOnyx(ONYXKEYS.SELF_DM_REPORT_ID);
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
     const parentReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${report?.parentReportID}`];
@@ -209,9 +206,8 @@ function DynamicSplitExpensePage({route}: DynamicSplitExpensePageProps) {
 
     // For selfDM expenses, the IOU action lives in the selfDM report, not in an expense report.
     const iouReportIDForActions = expenseReport?.reportID ?? (isSelfDM(draftTransactionReport) ? draftTransactionReport?.reportID : undefined);
-    const iouActions = getIOUActionForTransactions([originalTransactionID], allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportIDForActions}`]).filter(
-        (action) => action.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
-    );
+    const [iouReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getNonEmptyStringOnyxID(iouReportIDForActions)}`);
+    const iouActions = getIOUActionForTransactions([originalTransactionID], iouReportActions).filter((action) => action.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
     const {iouReport} = useGetIOUReportFromReportAction(iouActions.at(0));
 
     const isPercentageMode = (selectedTab as string) === CONST.TAB.SPLIT.PERCENTAGE;
@@ -232,7 +228,6 @@ function DynamicSplitExpensePage({route}: DynamicSplitExpensePageProps) {
     const splitFieldDataFromOriginalTransaction = initSplitExpenseItemData(transaction, transactionReport, {isManuallyEdited: true, policy: effectivePolicy, getCurrencyDecimals});
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
     const [quickAction] = useOnyx(ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE);
-    const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
     const icons = useMemoizedLazyExpensifyIcons(['ArrowsLeftRight', 'Plus']);
 
     const {isBetaEnabled} = usePermissions();
@@ -387,9 +382,6 @@ function DynamicSplitExpensePage({route}: DynamicSplitExpensePageProps) {
             getCurrencySymbol,
             allTransactionsList: allTransactions,
             allReportsList: allReports,
-            allReportActionsList: allReportActions,
-            allReportNameValuePairsList: allReportNameValuePairs,
-            allSnapshots,
             allPolicyTags,
             transactionData: {
                 reportID: draftTransaction?.reportID ?? String(CONST.DEFAULT_NUMBER_ID),
@@ -410,7 +402,6 @@ function DynamicSplitExpensePage({route}: DynamicSplitExpensePageProps) {
             policyRecentlyUsedCurrencies: policyRecentlyUsedCurrencies ?? [],
             quickAction,
             betas,
-            personalDetails,
             transactionReport: draftTransactionReport,
             expenseReport,
             isOffline,

--- a/tests/actions/IOU/SplitTransactionUpdateCachedCollectionsTest.ts
+++ b/tests/actions/IOU/SplitTransactionUpdateCachedCollectionsTest.ts
@@ -1,0 +1,216 @@
+import {getAllPersonalDetails, getAllReportActionsFromIOU, getAllReportNameValuePairs, getAllSnapshots} from '@libs/actions/IOU';
+import {updateSplitTransactionsFromSplitExpensesFlow} from '@libs/actions/IOU/SplitTransactionUpdate';
+import initOnyxDerivedValues from '@libs/actions/OnyxDerived';
+
+import CONST from '@src/CONST';
+import IntlStore from '@src/languages/IntlStore';
+import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {SearchResults, Transaction} from '@src/types/onyx';
+import type {SplitExpense} from '@src/types/onyx/IOU';
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import type {OnyxEntry} from 'react-native-onyx';
+
+import Onyx from 'react-native-onyx';
+
+import currencyList from '../../unit/currencyList.json';
+import {getGlobalFetchMock, formatPhoneNumber, getCurrencyDecimalsLocal, getCurrencySymbolLocal} from '../../utils/TestHelper';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+
+jest.mock('@src/libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+    dismissModal: jest.fn(),
+    dismissToPreviousRHP: jest.fn(),
+    dismissToSuperWideRHP: jest.fn(),
+    navigateBackToLastSuperWideRHPScreen: jest.fn(),
+    dismissModalWithReport: jest.fn(),
+    goBack: jest.fn(),
+    getTopmostReportId: jest.fn(() => '23423423'),
+    setNavigationActionToMicrotaskQueue: jest.fn(),
+    removeScreenByKey: jest.fn(),
+    isNavigationReady: jest.fn(() => Promise.resolve()),
+    getReportRouteByID: jest.fn(),
+    getActiveRouteWithoutParams: jest.fn(),
+    getActiveRoute: jest.fn(),
+    getIsFullscreenPreInsertedUnderRHP: jest.fn(() => false),
+    clearFullscreenPreInsertedFlag: jest.fn(),
+    revealRouteBeforeDismissingModal: jest.fn(),
+    navigationRef: {getRootState: jest.fn(), isReady: jest.fn(() => true)},
+}));
+jest.mock('@react-navigation/native');
+jest.mock('@src/libs/actions/Report', () => {
+    const originalModule = jest.requireActual('@src/libs/actions/Report');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {...originalModule, notifyNewAction: jest.fn()};
+});
+jest.mock('@libs/Navigation/helpers/isSearchTopmostFullScreenRoute', () => jest.fn());
+jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => jest.fn());
+jest.mock('@libs/actions/IOU/PendingNewTransactions', () => ({
+    addPendingNewTransactionIDs: jest.fn(),
+    deletePendingNewTransactionIDs: jest.fn(),
+    isOneToTwoTransactionTransition: jest.fn(() => false),
+}));
+jest.mock('@hooks/useCardFeedsForDisplay', () => jest.fn(() => ({defaultCardFeed: null, cardFeedsByPolicy: {}})));
+
+const RORY_EMAIL = 'rory@expensifail.com';
+const RORY_ACCOUNT_ID = 3;
+const EXPENSE_REPORT_ID = 'expense-report-1';
+const CHAT_REPORT_ID = 'chat-report-1';
+const ORIGINAL_TX_ID = 'orig-tx-1';
+const KEPT_TX_ID = 'child-tx-kept';
+const DROPPED_TX_ID = 'child-tx-dropped';
+const SNAPSHOT_HASH = '12345';
+
+/** Reads one search snapshot once, then disconnects. */
+function readSnapshot(hash: string): Promise<OnyxEntry<SearchResults>> {
+    return new Promise((resolve) => {
+        const connectionID = Onyx.connect({
+            key: `${ONYXKEYS.COLLECTION.SNAPSHOT}${hash}`,
+            callback: (value) => {
+                Onyx.disconnect(connectionID);
+                resolve(value);
+            },
+        });
+    });
+}
+
+OnyxUpdateManager();
+describe('updateSplitTransactionsFromSplitExpensesFlow cached collections', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            initialKeyStates: {
+                [ONYXKEYS.SESSION]: {accountID: RORY_ACCOUNT_ID, email: RORY_EMAIL},
+                [ONYXKEYS.CURRENCY_LIST]: currencyList,
+            },
+        });
+        initOnyxDerivedValues();
+        IntlStore.load(CONST.LOCALES.EN);
+        return waitForBatchedUpdates();
+    });
+
+    beforeEach(() => {
+        global.fetch = getGlobalFetchMock();
+        return Onyx.clear().then(waitForBatchedUpdates);
+    });
+
+    /** The collections `DynamicSplitExpensePage` used to subscribe to purely so it could forward them here. */
+    const personalDetails = {[RORY_ACCOUNT_ID]: {accountID: RORY_ACCOUNT_ID, login: RORY_EMAIL, displayName: 'Rory'}};
+    const reportActions = {
+        [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${CHAT_REPORT_ID}`]: {
+            action1: {reportActionID: 'action1', actionName: CONST.REPORT.ACTIONS.TYPE.IOU, created: '2024-01-01 00:00:00'},
+        },
+    };
+    const reportNameValuePairs = {[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${EXPENSE_REPORT_ID}`]: {private_isArchived: ''}};
+    const snapshots = {
+        [`${ONYXKEYS.COLLECTION.SNAPSHOT}${SNAPSHOT_HASH}`]: {
+            data: {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${KEPT_TX_ID}`]: {transactionID: KEPT_TX_ID},
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${DROPPED_TX_ID}`]: {transactionID: DROPPED_TX_ID},
+            },
+            search: {type: 'expense', status: 'all'},
+        },
+    };
+
+    function seedOnyx() {
+        return Onyx.multiSet({
+            [ONYXKEYS.PERSONAL_DETAILS_LIST]: personalDetails,
+            ...reportActions,
+            ...reportNameValuePairs,
+            ...snapshots,
+        } as Parameters<typeof Onyx.multiSet>[0]).then(waitForBatchedUpdates);
+    }
+
+    function buildChildTransaction(transactionID: string): Transaction {
+        return {
+            transactionID,
+            reportID: EXPENSE_REPORT_ID,
+            amount: -500,
+            currency: CONST.CURRENCY.USD,
+            created: '2024-01-01',
+            merchant: '',
+            comment: {originalTransactionID: ORIGINAL_TX_ID, source: CONST.IOU.TYPE.SPLIT},
+        };
+    }
+
+    /** Params as the page now sends them: the four cached collections are omitted. */
+    function buildParams(): Parameters<typeof updateSplitTransactionsFromSplitExpensesFlow>[0] {
+        return {
+            getCurrencyDecimals: getCurrencyDecimalsLocal,
+            getCurrencySymbol: getCurrencySymbolLocal,
+            allTransactionsList: {
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${ORIGINAL_TX_ID}`]: {
+                    transactionID: ORIGINAL_TX_ID,
+                    reportID: EXPENSE_REPORT_ID,
+                    amount: -1000,
+                    currency: CONST.CURRENCY.USD,
+                    created: '2024-01-01',
+                    merchant: '',
+                },
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${KEPT_TX_ID}`]: buildChildTransaction(KEPT_TX_ID),
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${DROPPED_TX_ID}`]: buildChildTransaction(DROPPED_TX_ID),
+            },
+            allReportsList: {
+                [`${ONYXKEYS.COLLECTION.REPORT}${EXPENSE_REPORT_ID}`]: {reportID: EXPENSE_REPORT_ID, chatReportID: CHAT_REPORT_ID, type: CONST.REPORT.TYPE.EXPENSE},
+            },
+            transactionData: {
+                reportID: EXPENSE_REPORT_ID,
+                originalTransactionID: ORIGINAL_TX_ID,
+                // Two splits keeps this off the reverse-split path; DROPPED_TX_ID is left out, so it gets deleted
+                splitExpenses: [
+                    {transactionID: KEPT_TX_ID, reportID: EXPENSE_REPORT_ID, statusNum: 0, amount: 500, created: '2024-01-01'},
+                    {transactionID: 'new-tx-1', reportID: EXPENSE_REPORT_ID, statusNum: 0, amount: 500, created: '2024-01-01'},
+                ] as SplitExpense[],
+                splitExpensesTotal: 1000,
+            },
+            policyCategories: undefined,
+            policy: undefined,
+            policyRecentlyUsedCategories: undefined,
+            iouReport: undefined,
+            firstIOU: undefined,
+            isASAPSubmitBetaEnabled: false,
+            currentUserPersonalDetails: {accountID: RORY_ACCOUNT_ID, login: RORY_EMAIL, displayName: 'Rory', avatar: '', fallbackIcon: ''},
+            transactionViolations: {},
+            quickAction: undefined,
+            policyRecentlyUsedCurrencies: [],
+            betas: [],
+            allPolicyTags: {},
+            transactionReport: {reportID: EXPENSE_REPORT_ID, chatReportID: CHAT_REPORT_ID},
+            expenseReport: {reportID: EXPENSE_REPORT_ID, chatReportID: CHAT_REPORT_ID},
+            isOffline: false,
+            delegateAccountID: undefined,
+            isTrackIntentUser: false,
+            formatPhoneNumber,
+        };
+    }
+
+    it('hydrates the module-level caches for the collections the page no longer subscribes to', async () => {
+        // Given the four collections written to Onyx
+        await seedOnyx();
+
+        // Then the action layer's own caches hold them, so it can resolve them without the page forwarding them
+        expect(getAllPersonalDetails()).toMatchObject(personalDetails);
+        expect(getAllReportActionsFromIOU()).toMatchObject(reportActions);
+        expect(getAllReportNameValuePairs()).toMatchObject(reportNameValuePairs);
+        expect(getAllSnapshots()).toMatchObject(snapshots);
+    });
+
+    it('still clears deleted splits out of search snapshots when the caller omits allSnapshots', async () => {
+        // Given a cached search snapshot holding both child transactions
+        await seedOnyx();
+
+        // When the split is saved without DROPPED_TX_ID, and without the page passing allSnapshots
+        updateSplitTransactionsFromSplitExpensesFlow(buildParams());
+        await waitForBatchedUpdates();
+
+        // Then the dropped split is removed from the snapshot, so search can't show it as stale.
+        // Reading allSnapshots from the module cache is what makes this possible — before the
+        // fallback existed, an omitted allSnapshots silently skipped this cleanup entirely.
+        const snapshot = await readSnapshot(SNAPSHOT_HASH);
+        expect(snapshot?.data?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${DROPPED_TX_ID}`]).toBeUndefined();
+
+        // And the split that survived is untouched
+        expect(snapshot?.data?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${KEPT_TX_ID}`]).toBeDefined();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

`DynamicSplitExpensePage` subscribed to four Onyx collections **in full** that it never reads during render — it held them only to hand them to `updateSplitTransactionsFromSplitExpensesFlow` on Save:

| Subscription | Read during render? | Only use |
| --- | --- | --- |
| `useOnyx(ONYXKEYS.COLLECTION.SNAPSHOT)` | no | forwarded as `allSnapshots` |
| `useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS)` | no | forwarded as `allReportNameValuePairsList` |
| `useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST)` | no | forwarded as `personalDetails` |
| `useOnyx(ONYXKEYS.COLLECTION.REPORT_ACTIONS)` | one keyed lookup | forwarded as `allReportActionsList` |

`src/libs/actions/IOU/index.ts` **already** maintains module-level caches of all four, with accessors that are already exported and already used in this very file (`getAllReports()` at `SplitTransactionUpdate.ts#L886`). The page was subscribing to data the action layer had in hand the whole time.

So the four params become optional and default to those accessors, and the page drops the subscriptions. `REPORT_ACTIONS` becomes a keyed subscription for the one report whose actions render actually needs.

**Why this is on the Save press's critical path.** Saving a split writes optimistic data to `SNAPSHOT`, `REPORT_ACTIONS`, `REPORT_NAME_VALUE_PAIRS` and the transaction/report collections. The page subscribed to those same collections, so its own optimistic writes woke it for a full re-render — recomputing `childTransactions`, `splitFieldDataFromChildTransactions`, the distance-rate loop over every policy, and the `options` map — while the RHP was being dismissed. `SNAPSHOT` is the worst of them: each value is a whole cached search payload, and on a high-traffic account there are many.

Nothing about what reaches the server changes. Only where the action reads it from.

### On measurement — please read

I have **not** produced a production p75 for this. The issue is explicit that this bug is invisible on a fresh account, and I don't have a high-traffic account to measure against, so I am not going to claim an INP number I can't stand behind. What I can support is the mechanism above and the behavioural equivalence below. Treat the perf claim as unverified until someone measures it on a high-traffic account per [PERFORMANCE.md §4](https://github.com/Expensify/App/blob/main/contributingGuides/PERFORMANCE.md).

### Fixed Issues

$ https://github.com/Expensify/App/issues/97802
PROPOSAL: https://github.com/Expensify/App/issues/97802#issuecomment-5183413475

### Tests

New: `tests/actions/IOU/SplitTransactionUpdateCachedCollectionsTest.ts`

1. `hydrates the module-level caches for the collections the page no longer subscribes to` — writes the four collections to Onyx and asserts the `actions/IOU` accessors return them.
2. `still clears deleted splits out of search snapshots when the caller omits allSnapshots` — seeds a search snapshot holding two child transactions, saves a split that drops one, and asserts the dropped transaction is removed from the snapshot.

Test 2 guards the exact failure this refactor could have introduced: an empty `allSnapshots` silently skips the stale-snapshot cleanup, which is the bug class behind #99805. **I verified the test actually fails without the fix** — reverting just the `allSnapshots = getAllSnapshots()` default makes it fail on that assertion, and restoring it makes it pass.

Existing suites, all passing unchanged: `SplitTest.ts` (132), `SplitSelfDMTest.ts`, `SplitReportTotalsTest.ts`, `TransactionTest.ts` — 179 tests. They pass the collections explicitly, which the optional params preserve.

Manual:
1. Open an expense, tap **Split**
2. Add two or more splits, adjust amounts, tap **Save**
3. Verify the splits are created and the amounts are right
4. From Search: `group-by:from`, expand the group, select the expense, **Split → Save**, verify the split rows appear and the original does not flip to **Unreported**

- [x] Verify that no errors appear in the JS console

### Offline steps

1. Go offline
2. Repeat the manual steps above
3. Verify splits appear optimistically and queue, unchanged from today

### QA steps

Same as the Tests section above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Draft — the unchecked boxes above are the honest state. Platform runs, the offline pass, the high-traffic regression check and the INP measurement are still outstanding; I'll add them and mark this ready for review rather than check them off now.

There is no UI change in this PR: it removes Onyx subscriptions and changes where the action reads four collections from. Rendered output is unchanged.
