### PR TITLE
Fix doubled bottom safe area padding on the Uber send invites page

### DIFF
--- a/src/pages/workspace/receiptPartners/DynamicInviteReceiptPartnerPolicyPage.tsx
+++ b/src/pages/workspace/receiptPartners/DynamicInviteReceiptPartnerPolicyPage.tsx
@@ -211,7 +211,10 @@ function DynamicInviteReceiptPartnerPolicyPage({route}: DynamicInviteReceiptPart
             policyID={policyID}
             featureName={CONST.POLICY.MORE_FEATURES.ARE_RECEIPT_PARTNERS_ENABLED}
         >
-            <ScreenWrapper testID="DynamicInviteReceiptPartnerPolicyPage">
+            <ScreenWrapper
+                testID="DynamicInviteReceiptPartnerPolicyPage"
+                enableEdgeToEdgeBottomSafeAreaPadding
+            >
                 <HeaderWithBackButton
                     title={translate('workspace.receiptPartners.uber.sendInvites')}
                     onBackButtonPress={() => Navigation.goBack(backPath)}

--- a/tests/ui/ReceiptPartnersInvitePaddingTest.tsx
+++ b/tests/ui/ReceiptPartnersInvitePaddingTest.tsx
@@ -1,0 +1,243 @@
+import {act, render, screen, waitFor} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import FixedFooter from '@components/FixedFooter';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import {ModalProvider} from '@components/Modal/Global/ModalContext';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import PersonalDetailsByLoginProvider from '@components/PersonalDetailsByLoginProvider';
+
+import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
+import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
+import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+
+import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
+
+import type {WorkspaceSplitNavigatorParamList} from '@navigation/types';
+
+import DynamicEditInviteReceiptPartnerPolicyPage from '@pages/workspace/receiptPartners/DynamicEditInviteReceiptPartnerPolicyPage';
+import DynamicInviteReceiptPartnerPolicyPage from '@pages/workspace/receiptPartners/DynamicInviteReceiptPartnerPolicyPage';
+
+import variables from '@styles/variables';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import type {PersonalDetails} from '@src/types/onyx';
+
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import {PortalProvider} from '@gorhom/portal';
+import {NavigationContainer} from '@react-navigation/native';
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import Onyx from 'react-native-onyx';
+
+import * as LHNTestUtils from '../utils/LHNTestUtils';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+TestHelper.setupGlobalFetchMock();
+
+const Stack = createPlatformStackNavigator<WorkspaceSplitNavigatorParamList>();
+const UBER_INTEGRATION = CONST.POLICY.RECEIPT_PARTNERS.NAME.UBER;
+const EMPLOYEE_EMAIL = 'employee@company.com';
+const BILLING_EMAIL = 'billing@company.com';
+const POLICY_ID = 'policy123';
+
+const BOTTOM_INSET = 34;
+const SAFE_AREA_PADDING_BOTTOM = BOTTOM_INSET * variables.iosSafeAreaInsetsPercentage;
+const FOOTER_BASE_PADDING_BOTTOM = 20;
+
+jest.mock('@hooks/useSafeAreaInsets', () => ({
+    __esModule: true,
+    default: () => ({top: 24, right: 0, bottom: 34, left: 0}),
+}));
+
+const employeePersonalDetails: Record<number, PersonalDetails> = {};
+employeePersonalDetails[2] = {
+    accountID: 2,
+    login: EMPLOYEE_EMAIL,
+    displayName: 'Employee User',
+    firstName: 'Employee',
+    lastName: 'User',
+    pronouns: '',
+    timezone: CONST.DEFAULT_TIME_ZONE,
+    phoneNumber: '',
+};
+employeePersonalDetails[3] = {
+    accountID: 3,
+    login: BILLING_EMAIL,
+    displayName: 'Billing User',
+    firstName: 'Billing',
+    lastName: 'User',
+    pronouns: '',
+    timezone: CONST.DEFAULT_TIME_ZONE,
+    phoneNumber: '',
+};
+
+const basePolicy = {
+    ...LHNTestUtils.getFakePolicy(),
+    id: POLICY_ID,
+    role: CONST.POLICY.ROLE.ADMIN,
+    receiptPartners: {
+        enabled: true,
+        uber: {
+            enabled: true,
+            centralBillingAccountEmail: BILLING_EMAIL,
+            employees: {
+                [EMPLOYEE_EMAIL]: {
+                    status: CONST.POLICY.RECEIPT_PARTNERS.UBER_EMPLOYEE_STATUS.CREATED,
+                },
+            },
+        },
+    },
+    employeeList: {
+        [EMPLOYEE_EMAIL]: {
+            email: EMPLOYEE_EMAIL,
+            role: CONST.POLICY.ROLE.USER,
+        },
+        [BILLING_EMAIL]: {
+            email: BILLING_EMAIL,
+            role: CONST.POLICY.ROLE.USER,
+        },
+    },
+};
+
+function renderWithProviders(children: React.ReactNode) {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentReportIDContextProvider, PersonalDetailsByLoginProvider]}>
+            <PortalProvider>
+                <ModalProvider>
+                    <NavigationContainer>{children}</NavigationContainer>
+                </ModalProvider>
+            </PortalProvider>
+        </ComposeProviders>,
+    );
+}
+
+function renderInvitePage(initialParams: WorkspaceSplitNavigatorParamList[typeof SCREENS.WORKSPACE.DYNAMIC_RECEIPT_PARTNERS_INVITE]) {
+    return renderWithProviders(
+        <Stack.Navigator initialRouteName={SCREENS.WORKSPACE.DYNAMIC_RECEIPT_PARTNERS_INVITE}>
+            <Stack.Screen
+                name={SCREENS.WORKSPACE.DYNAMIC_RECEIPT_PARTNERS_INVITE}
+                component={DynamicInviteReceiptPartnerPolicyPage}
+                initialParams={initialParams}
+            />
+        </Stack.Navigator>,
+    );
+}
+
+function renderEditInvitePage(initialParams: WorkspaceSplitNavigatorParamList[typeof SCREENS.WORKSPACE.DYNAMIC_RECEIPT_PARTNERS_INVITE_EDIT]) {
+    return renderWithProviders(
+        <Stack.Navigator initialRouteName={SCREENS.WORKSPACE.DYNAMIC_RECEIPT_PARTNERS_INVITE_EDIT}>
+            <Stack.Screen
+                name={SCREENS.WORKSPACE.DYNAMIC_RECEIPT_PARTNERS_INVITE_EDIT}
+                component={DynamicEditInviteReceiptPartnerPolicyPage}
+                initialParams={initialParams}
+            />
+        </Stack.Navigator>,
+    );
+}
+
+function getPaddingBottom(element: {props: {style?: StyleProp<ViewStyle>}} | string | undefined): number {
+    if (!element || typeof element === 'string') {
+        return 0;
+    }
+    const style = StyleSheet.flatten(element.props.style);
+    return typeof style?.paddingBottom === 'number' ? style.paddingBottom : 0;
+}
+
+function getFixedFooterPaddingBottom(): number {
+    return getPaddingBottom(screen.UNSAFE_getByType(FixedFooter).children.at(0));
+}
+
+function getLegacyScreenWrapperSpacerPaddingBottom(testID: string): number {
+    const children = screen.getByTestId(testID).children.filter((child) => typeof child !== 'string');
+    return children.length < 2 ? 0 : getPaddingBottom(children.at(-1));
+}
+
+describe('ReceiptPartnersInvitePadding', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            evictableKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        });
+    });
+
+    beforeEach(async () => {
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, CONST.LOCALES.EN);
+        });
+        const responsiveLayoutMock: ResponsiveLayoutResult = {
+            isSmallScreenWidth: false,
+            shouldUseNarrowLayout: false,
+            isInNarrowPaneModal: false,
+            isExtraSmallScreenHeight: false,
+            isMediumScreenWidth: false,
+            isLargeScreenWidth: false,
+            isExtraLargeScreenWidth: false,
+            isExtraSmallScreenWidth: false,
+            isSmallScreen: false,
+            onboardingIsMediumOrLargerScreenWidth: false,
+            isInLandscapeMode: false,
+        };
+        jest.spyOn(useResponsiveLayoutModule, 'default').mockReturnValue(responsiveLayoutMock);
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+        });
+        jest.clearAllMocks();
+    });
+
+    it('applies the bottom safe area inset exactly once on the send invites page', async () => {
+        await TestHelper.signInWithTestUser();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, basePolicy);
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, employeePersonalDetails);
+        });
+
+        renderInvitePage({policyID: POLICY_ID, integration: UBER_INTEGRATION});
+        await waitForBatchedUpdatesWithAct();
+        await waitFor(() => {
+            expect(screen.getByText(TestHelper.translateLocal('workspace.receiptPartners.uber.confirm'))).toBeOnTheScreen();
+        });
+
+        expect(getFixedFooterPaddingBottom()).toBe(FOOTER_BASE_PADDING_BOTTOM + SAFE_AREA_PADDING_BOTTOM);
+        expect(getLegacyScreenWrapperSpacerPaddingBottom('DynamicInviteReceiptPartnerPolicyPage')).toBe(0);
+    });
+
+    it('keeps the bottom safe area inset on the all set page, which relies on the legacy screen wrapper spacer', async () => {
+        await TestHelper.signInWithTestUser();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, {...basePolicy, employeeList: {}});
+        });
+
+        renderInvitePage({policyID: POLICY_ID, integration: UBER_INTEGRATION});
+        await waitForBatchedUpdatesWithAct();
+        await waitFor(() => {
+            expect(screen.getByText(TestHelper.translateLocal('workspace.receiptPartners.uber.allSet'))).toBeOnTheScreen();
+        });
+
+        expect(getFixedFooterPaddingBottom()).toBe(FOOTER_BASE_PADDING_BOTTOM);
+        expect(getLegacyScreenWrapperSpacerPaddingBottom('DynamicInviteReceiptPartnerPolicyPage')).toBe(SAFE_AREA_PADDING_BOTTOM);
+    });
+
+    it('applies the bottom safe area inset exactly once on the manage invites page', async () => {
+        await TestHelper.signInWithTestUser();
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, basePolicy);
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, employeePersonalDetails);
+        });
+
+        renderEditInvitePage({policyID: POLICY_ID, integration: UBER_INTEGRATION});
+        await waitForBatchedUpdatesWithAct();
+        await waitFor(() => {
+            expect(screen.getByText(TestHelper.translateLocal('workspace.receiptPartners.uber.manageInvites'))).toBeOnTheScreen();
+        });
+
+        expect(getLegacyScreenWrapperSpacerPaddingBottom('DynamicEditInviteReceiptPartnerPolicyPage')).toBe(SAFE_AREA_PADDING_BOTTOM);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

The Send invites page kept `ScreenWrapper` in legacy bottom safe-area mode while its `SelectionList` also passed `addBottomSafeAreaPadding`, so the bottom inset was applied twice: once by the wrapper's trailing spacer and once by the list's `FixedFooter`.

Passing `enableEdgeToEdgeBottomSafeAreaPadding` to that `ScreenWrapper` turns off the legacy spacer and leaves the footer as the single source of the inset. Measured below the Confirm button on iOS: `67.6pt` → `43.8pt`, matching the reference `DynamicWorkspaceInvitePage`.

The "All set" branch of the same file is intentionally left in legacy mode — it renders `ConfirmationPage`, whose `FixedFooter` does not pass `addBottomSafeAreaPadding` and relies on the wrapper's spacer.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99763
PROPOSAL: https://github.com/Expensify/App/issues/99763#issuecomment-5511680965

### Tests

Native only — web and mWeb report `insets.bottom === 0`, so nothing changes there.

1. On iOS/Android native, open a workspace you are an admin of, with at least one other member.
2. Go to **More features** → **Integrate** → enable **Receipt partners**.
3. Open **Receipt partners** → tap **Setup** next to Uber for Business and complete the connection.
4. Once the connection is established the app lands on **Send invites**. Verify the space below the **Confirm** button is not oversized and matches **Members → Invite** on the same device.
5. If the workspace has 12+ members, tap the **Search** field. Verify **Confirm** sits directly above the keyboard with normal padding, and that the padding returns to its previous value when the keyboard closes.
6. Go back → **Manage invites**. Verify its bottom spacing is unchanged.
7. Complete the invite to reach the **All set** page. Verify the **Confirm** button is not flush against the home indicator / navigation bar.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Reach the **Send invites** page, then turn off the network.
2. Verify the offline indicator is docked above the home indicator / navigation bar and is not overlapped by it.
3. Verify the **Confirm** button's bottom spacing is unchanged from the online state.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

After fix:




https://github.com/user-attachments/assets/42ecb4e0-1fed-4242-9e3c-2540f6658516




</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

After fix:




https://github.com/user-attachments/assets/32bb0b29-969a-4279-ab82-7bf5e754c291





</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
