### PR TITLE
Close a stuck in-app browser when leaving SAML sign-in on iOS

### DIFF
--- a/src/pages/signin/SAMLSignInPage/index.native.tsx
+++ b/src/pages/signin/SAMLSignInPage/index.native.tsx
@@ -63,6 +63,9 @@ function SAMLSignInPage() {
             hasExitedSAMLFlow.current = true;
             isAuthSessionOpen.current = false;
             dismissAuthSession();
+
+            // The exit that normally clears this guard is skipped above, and a stuck guard blocks the next SAML attempt.
+            setIsAuthenticatingWithShortLivedToken(false);
         },
         [],
     );

--- a/src/pages/signin/SAMLSignInPage/index.native.tsx
+++ b/src/pages/signin/SAMLSignInPage/index.native.tsx
@@ -20,7 +20,7 @@ import ROUTES from '@src/ROUTES';
 
 import type {WebBrowserAuthSessionResult} from 'expo-web-browser';
 
-import {openAuthSessionAsync} from 'expo-web-browser';
+import {dismissAuthSession, openAuthSessionAsync} from 'expo-web-browser';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 function SAMLSignInPage() {
@@ -30,8 +30,22 @@ function SAMLSignInPage() {
     const [SAMLUrl, setSAMLUrl] = useState('');
     const {translate} = useLocalize();
     const hasOpenedAuthSession = useRef(false);
+    const isAuthSessionOpen = useRef(false);
+    const hasExitedSAMLFlow = useRef(false);
 
     const handleExitSAMLFlow = useCallback(() => {
+        // Closing a stuck in-app browser settles its promise, which lands here a second time.
+        if (hasExitedSAMLFlow.current) {
+            return;
+        }
+        hasExitedSAMLFlow.current = true;
+
+        // An in-app browser left open blocks the next sign-in attempt from opening one, and only iOS can close it.
+        if (isAuthSessionOpen.current && getPlatform() === CONST.PLATFORM.IOS) {
+            isAuthSessionOpen.current = false;
+            dismissAuthSession();
+        }
+
         // Clear the guard we set before opening the in-app browser so we don't block future reauthentication
         setIsAuthenticatingWithShortLivedToken(false);
         Navigation.isNavigationReady().then(() => {
@@ -39,6 +53,19 @@ function SAMLSignInPage() {
             clearSignInData();
         });
     }, []);
+
+    useEffect(
+        () => () => {
+            // Leaving the page must not leave the in-app browser open, or the next sign-in attempt cannot open one.
+            if (!isAuthSessionOpen.current || getPlatform() !== CONST.PLATFORM.IOS) {
+                return;
+            }
+            hasExitedSAMLFlow.current = true;
+            isAuthSessionOpen.current = false;
+            dismissAuthSession();
+        },
+        [],
+    );
 
     /**
      * Handles in-app navigation once we get a response back from Expensify
@@ -102,8 +129,10 @@ function SAMLSignInPage() {
         // reauthenticate() abort while the SAML sign-in is in progress. signInWithShortLivedAuthToken() resets it on
         // success; the cancel/error/failure paths reset it via handleExitSAMLFlow and handleNavigationStateChange.
         setIsAuthenticatingWithShortLivedToken(true);
+        isAuthSessionOpen.current = true;
         openAuthSessionAsync(SAMLUrl, CONST.SAML_REDIRECT_URL)
             .then((response: WebBrowserAuthSessionResult) => {
+                isAuthSessionOpen.current = false;
                 if (response.type !== 'success') {
                     // The auth session closed without handing a callback URL back to the app (e.g. the in-app browser
                     // was dismissed/cancelled, or the redirect to the custom scheme never fired). Log the result type so
@@ -116,6 +145,7 @@ function SAMLSignInPage() {
                 handleNavigationStateChange(response.url);
             })
             .catch((error) => {
+                isAuthSessionOpen.current = false;
                 Log.hmmm('SAML sign in failed', {error});
                 handleExitSAMLFlow();
             });

--- a/tests/ui/SAMLSignInPageTest.tsx
+++ b/tests/ui/SAMLSignInPageTest.tsx
@@ -14,6 +14,8 @@ import type {PublicScreensParamList} from '@libs/Navigation/types';
 
 import SAMLSignInPage from '@pages/signin/SAMLSignInPage/index.native';
 
+import {setIsAuthenticatingWithShortLivedToken} from '@userActions/Session';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
@@ -118,6 +120,7 @@ describe('SAMLSignInPage', () => {
         unmount();
 
         expect(dismissAuthSession).toHaveBeenCalledTimes(1);
+        expect(setIsAuthenticatingWithShortLivedToken).toHaveBeenLastCalledWith(false);
     });
 
     it('leaves once when the user cancels the in-app browser', async () => {

--- a/tests/ui/SAMLSignInPageTest.tsx
+++ b/tests/ui/SAMLSignInPageTest.tsx
@@ -1,0 +1,145 @@
+import {act, fireEvent, render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
+
+import getPlatform from '@libs/getPlatform';
+import {postSAMLLogin} from '@libs/LoginUtils';
+import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
+import type {PublicScreensParamList} from '@libs/Navigation/types';
+
+import SAMLSignInPage from '@pages/signin/SAMLSignInPage/index.native';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+
+import {PortalProvider} from '@gorhom/portal';
+import {NavigationContainer} from '@react-navigation/native';
+import {dismissAuthSession, openAuthSessionAsync} from 'expo-web-browser';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import {translateLocal} from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('expo-web-browser', () => ({
+    openAuthSessionAsync: jest.fn(),
+    dismissAuthSession: jest.fn(),
+}));
+
+jest.mock('@libs/getPlatform', () => jest.fn());
+
+jest.mock('@libs/LoginUtils', () => ({
+    postSAMLLogin: jest.fn(),
+    handleSAMLLoginError: jest.fn(),
+}));
+
+jest.mock('@userActions/Session', () => ({
+    clearSignInData: jest.fn(),
+    setAccountError: jest.fn(),
+    setIsAuthenticatingWithShortLivedToken: jest.fn(),
+    signInWithShortLivedAuthToken: jest.fn(),
+}));
+
+const mockedOpenAuthSessionAsync = jest.mocked(openAuthSessionAsync);
+const mockedPostSAMLLogin = jest.mocked(postSAMLLogin);
+const mockedGetPlatform = jest.mocked(getPlatform);
+
+const RootStack = createPlatformStackNavigator<PublicScreensParamList>();
+
+const renderPage = () => {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentReportIDContextProvider]}>
+            <PortalProvider>
+                <NavigationContainer ref={navigationRef}>
+                    <RootStack.Navigator>
+                        <RootStack.Screen
+                            name={SCREENS.SAML_SIGN_IN}
+                            component={SAMLSignInPage}
+                        />
+                    </RootStack.Navigator>
+                </NavigationContainer>
+            </PortalProvider>
+        </ComposeProviders>,
+    );
+};
+
+describe('SAMLSignInPage', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+        });
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        mockedGetPlatform.mockReturnValue(CONST.PLATFORM.IOS);
+        // postSAMLLogin resolves with the parsed JSON body, and the page only reads its url.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        mockedPostSAMLLogin.mockResolvedValue({url: 'https://idp.example.com/sso'} as Response);
+        jest.spyOn(Navigation, 'goBack').mockImplementation(() => {});
+        jest.spyOn(Navigation, 'isNavigationReady').mockResolvedValue(undefined);
+        await act(async () => {
+            await Onyx.clear();
+            await Onyx.multiSet({
+                [ONYXKEYS.CREDENTIALS]: {login: 'user@saml.example.com'},
+                [ONYXKEYS.ACCOUNT]: {isLoading: false},
+            });
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    it('closes an in-app browser that never came back when the user goes back', async () => {
+        mockedOpenAuthSessionAsync.mockReturnValue(new Promise(() => {}));
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+        expect(mockedOpenAuthSessionAsync).toHaveBeenCalledTimes(1);
+
+        fireEvent.press(screen.getByLabelText(translateLocal('common.back')));
+        await waitForBatchedUpdatesWithAct();
+
+        expect(dismissAuthSession).toHaveBeenCalledTimes(1);
+        expect(Navigation.goBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes an in-app browser that never came back when the page unmounts', async () => {
+        mockedOpenAuthSessionAsync.mockReturnValue(new Promise(() => {}));
+
+        const {unmount} = renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        unmount();
+
+        expect(dismissAuthSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves once when the user cancels the in-app browser', async () => {
+        mockedOpenAuthSessionAsync.mockResolvedValue({type: 'cancel'});
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(dismissAuthSession).not.toHaveBeenCalled();
+        expect(Navigation.goBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not try to close the in-app browser on Android', async () => {
+        mockedGetPlatform.mockReturnValue(CONST.PLATFORM.ANDROID);
+        mockedOpenAuthSessionAsync.mockReturnValue(new Promise(() => {}));
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(screen.getByLabelText(translateLocal('common.back')));
+        await waitForBatchedUpdatesWithAct();
+
+        expect(dismissAuthSession).not.toHaveBeenCalled();
+        expect(Navigation.goBack).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/ui/SAMLSignInPageTest.tsx
+++ b/tests/ui/SAMLSignInPageTest.tsx
@@ -20,7 +20,7 @@ import SCREENS from '@src/SCREENS';
 
 import {PortalProvider} from '@gorhom/portal';
 import {NavigationContainer} from '@react-navigation/native';
-import {dismissAuthSession, openAuthSessionAsync} from 'expo-web-browser';
+import {dismissAuthSession, openAuthSessionAsync, WebBrowserResultType} from 'expo-web-browser';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 
@@ -30,6 +30,7 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 jest.mock('expo-web-browser', () => ({
     openAuthSessionAsync: jest.fn(),
     dismissAuthSession: jest.fn(),
+    WebBrowserResultType: {CANCEL: 'cancel'},
 }));
 
 jest.mock('@libs/getPlatform', () => jest.fn());
@@ -120,7 +121,7 @@ describe('SAMLSignInPage', () => {
     });
 
     it('leaves once when the user cancels the in-app browser', async () => {
-        mockedOpenAuthSessionAsync.mockResolvedValue({type: 'cancel'});
+        mockedOpenAuthSessionAsync.mockResolvedValue({type: WebBrowserResultType.CANCEL});
 
         renderPage();
         await waitForBatchedUpdatesWithAct();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
On iOS the in-app browser for SAML sometimes closes right after opening without answering, so the app sits on the loading screen. Going back did not close that browser session, and the next sign-in attempt cannot open one while it is still open, so users had to kill the app to retry.

Going back, or leaving the page, now closes the open in-app browser session on iOS. The retry then opens a fresh one. Cancelling the browser normally still leaves the page once.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/Expensify/issues/670780
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Needs an iOS device or simulator and an account on a domain with SAML enabled.
1. Enter the SAML email on the sign-in page and wait for the in-app browser to open.
2. Cancel the in-app browser with its Cancel button. Verify the app returns to the sign-in page once.
3. Enter the email again. While the loading screen shows, press the back arrow before the browser has answered.
4. Verify the app returns to the sign-in page.
5. Enter the email again. Verify the in-app browser opens a fresh session instead of bouncing back to the sign-in page.
6. Complete the IdP sign-in. Verify the app signs in.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go offline on the sign-in page, enter the SAML email.
2. Verify the offline view shows on the loading page and going back returns to the sign-in page.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests, on iOS with an account whose domain has SAML enabled.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
