### PR TITLE
Move pre-selected custom list to top of list in the NetSuite custom list picker

### DIFF
--- a/src/pages/workspace/accounting/netsuite/import/NetSuiteImportCustomFieldNew/NetSuiteCustomListSelectorPage.tsx
+++ b/src/pages/workspace/accounting/netsuite/import/NetSuiteImportCustomFieldNew/NetSuiteCustomListSelectorPage.tsx
@@ -4,6 +4,7 @@ import SelectionList from '@components/SelectionList';
 import SingleSelectListItem from '@components/SelectionList/ListItem/SingleSelectListItem';
 
 import useDebouncedState from '@hooks/useDebouncedState';
+import useInitialSelection from '@hooks/useInitialSelection';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePolicy from '@hooks/usePolicy';
@@ -12,6 +13,7 @@ import {setDraftValues} from '@libs/actions/FormActions';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+import moveInitialSelectionToTop from '@libs/SelectionListOrderUtils';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import type {CustomListSelectorType} from '@pages/workspace/accounting/netsuite/types';
@@ -37,6 +39,8 @@ function NetSuiteCustomListSelectorPage({
     const policy = usePolicy(policyID);
     const [formDraft] = useOnyx(ONYXKEYS.FORMS.NETSUITE_CUSTOM_LIST_ADD_FORM_DRAFT);
     const currentCustomListValue = formDraft?.[INPUT_IDS.LIST_NAME] ?? '';
+    // Freeze the pre-selected custom list when the page opened so it stays pinned to the top for the whole open/focus cycle.
+    const initialCustomListValue = useInitialSelection(currentCustomListValue, {resetOnFocus: true});
 
     const rawCustomLists = policy?.connections?.netsuite?.options?.data?.customLists;
 
@@ -50,15 +54,18 @@ function NetSuiteCustomListSelectorPage({
             id: customListRecord.id,
         }));
 
+        // Pin the frozen pre-selected list to the top of the full list before search filtering, so it stays pinned while searching.
+        const orderedCustomListData = moveInitialSelectionToTop(customListData, initialCustomListValue ? [initialCustomListValue] : []);
+
         const searchRegex = new RegExp(Str.escapeForRegExp(debouncedSearchValue.trim()), 'i');
-        const filteredCustomLists = customListData.filter((customListRecord) => searchRegex.test(customListRecord.text ?? ''));
+        const filteredCustomLists = orderedCustomListData.filter((customListRecord) => searchRegex.test(customListRecord.text ?? ''));
         const isEmpty = debouncedSearchValue.trim() && !filteredCustomLists.length;
 
         return {
             options: isEmpty ? [] : filteredCustomLists,
             showTextInput: customListData.length >= CONST.STANDARD_LIST_ITEM_LIMIT,
         };
-    }, [debouncedSearchValue, rawCustomLists, currentCustomListValue]);
+    }, [debouncedSearchValue, rawCustomLists, currentCustomListValue, initialCustomListValue]);
 
     const textInputOptions = useMemo(
         () => ({
@@ -104,9 +111,11 @@ function NetSuiteCustomListSelectorPage({
                     textInputOptions={textInputOptions}
                     onSelectRow={onSelectRow}
                     ListItem={SingleSelectListItem}
-                    initiallyFocusedItemKey={currentCustomListValue}
+                    initiallyFocusedItemKey={initialCustomListValue}
+                    shouldScrollToFocusedIndexOnMount={false}
                     shouldSingleExecuteRowSelect
                     shouldStopPropagation
+                    shouldUpdateFocusedIndex
                     addBottomSafeAreaPadding
                 />
             </ScreenWrapper>

--- a/tests/ui/NetSuiteCustomListSelectorPageTest.tsx
+++ b/tests/ui/NetSuiteCustomListSelectorPageTest.tsx
@@ -23,24 +23,23 @@ const mockUseState = React.useState;
 
 type NetSuiteCustomListSelectorPageProps = Parameters<typeof NetSuiteCustomListSelectorPage>[0];
 
-const mockCustomLists = [
+const DEFAULT_CUSTOM_LISTS = [
     {id: '123', name: 'Department'},
     {id: '456', name: 'Project'},
 ];
 
-const mockPolicy = {
-    id: 'P1',
-    connections: {
-        netsuite: {
-            options: {
-                data: {
-                    customLists: mockCustomLists,
-                },
-            },
-        },
-    },
-};
+function buildCustomLists(count: number) {
+    return Array.from({length: count}, (_, index) => {
+        const padded = String(index + 1).padStart(2, '0');
+        return {id: padded, name: `List ${padded}`};
+    });
+}
 
+function buildPolicy(customLists: Array<{id: string; name: string}>) {
+    return {id: 'P1', connections: {netsuite: {options: {data: {customLists}}}}};
+}
+
+let mockPolicy: ReturnType<typeof buildPolicy> = buildPolicy(DEFAULT_CUSTOM_LISTS);
 let mockFormDraft: Record<string, unknown> | undefined;
 
 jest.mock('@react-navigation/native', () => {
@@ -88,6 +87,7 @@ describe('NetSuiteCustomListSelectorPage', () => {
         mockedSetDraftValues.mockClear();
         mockedNavigationGoBack.mockClear();
         mockFormDraft = undefined;
+        mockPolicy = buildPolicy(DEFAULT_CUSTOM_LISTS);
     });
 
     it('builds option rows from the policy custom lists and marks the draft value as selected', () => {
@@ -171,5 +171,59 @@ describe('NetSuiteCustomListSelectorPage', () => {
         const filteredProps = mockedSelectionList.mock.lastCall?.[0];
         expect(filteredProps?.data).toEqual([]);
         expect(filteredProps?.textInputOptions?.headerMessage).toBe('common.noResultsFound');
+    });
+
+    it('pins the pre-selected custom list to the top when the list is long enough', () => {
+        mockPolicy = buildPolicy(buildCustomLists(CONST.STANDARD_LIST_ITEM_LIMIT + 2));
+        mockFormDraft = {[INPUT_IDS.LIST_NAME]: 'List 07'};
+
+        render(
+            <NetSuiteCustomListSelectorPage
+                route={createMock<NetSuiteCustomListSelectorPageProps['route']>({params: {policyID: 'P1'}})}
+                navigation={createMock<NetSuiteCustomListSelectorPageProps['navigation']>({})}
+            />,
+        );
+
+        const selectionListProps = mockedSelectionList.mock.lastCall?.[0];
+        // "List 07" sits in the middle, so seeing it first proves pinning (not the natural order) put it there.
+        expect(selectionListProps?.data.at(0)?.value).toBe('List 07');
+        expect(selectionListProps?.data.at(0)?.isSelected).toBe(true);
+        expect(selectionListProps?.initiallyFocusedItemKey).toBe('List 07');
+        expect(selectionListProps?.shouldScrollToFocusedIndexOnMount).toBe(false);
+        expect(selectionListProps?.shouldUpdateFocusedIndex).toBe(true);
+    });
+
+    it('keeps the pinned custom list at the top of the search results', () => {
+        mockPolicy = buildPolicy(buildCustomLists(CONST.STANDARD_LIST_ITEM_LIMIT + 2));
+        mockFormDraft = {[INPUT_IDS.LIST_NAME]: 'List 12'};
+
+        render(
+            <NetSuiteCustomListSelectorPage
+                route={createMock<NetSuiteCustomListSelectorPageProps['route']>({params: {policyID: 'P1'}})}
+                navigation={createMock<NetSuiteCustomListSelectorPageProps['navigation']>({})}
+            />,
+        );
+
+        // Searching "1" also matches "List 01" (which sorts first), so "List 12" leading proves the pin held.
+        act(() => {
+            mockedSelectionList.mock.lastCall?.[0]?.textInputOptions?.onChangeText?.('1');
+        });
+
+        expect(mockedSelectionList.mock.lastCall?.[0]?.data.at(0)?.value).toBe('List 12');
+    });
+
+    it('does not reorder the custom list when it is under the item-limit threshold', () => {
+        mockPolicy = buildPolicy(buildCustomLists(CONST.STANDARD_LIST_ITEM_LIMIT - 2));
+        mockFormDraft = {[INPUT_IDS.LIST_NAME]: 'List 05'};
+
+        render(
+            <NetSuiteCustomListSelectorPage
+                route={createMock<NetSuiteCustomListSelectorPageProps['route']>({params: {policyID: 'P1'}})}
+                navigation={createMock<NetSuiteCustomListSelectorPageProps['navigation']>({})}
+            />,
+        );
+
+        // Below the threshold moveInitialSelectionToTop is a no-op, so the natural order is preserved.
+        expect(mockedSelectionList.mock.lastCall?.[0]?.data.at(0)?.value).toBe('List 01');
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
When opening the NetSuite custom-list picker, the currently-selected list was shown
in its natural position, so on a long list it could sit below the fold. This pins
the pre-selected list to the top on open (and keeps it pinned while searching),
matching the "move pre-selected items to top" pattern used across the app.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #69184
PROPOSAL:https://github.com/Expensify/App/issues/69184#issuecomment-3765294972


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
**Precondition:** A workspace on a Control plan connected to **NetSuite**, where the NetSuite account has **12 or more custom lists** synced. You'll also need one custom field already configured so a custom list is pre-selected (or you'll select one and reopen the picker).

1. Sign in and open the workspace connected to NetSuite.
2. Go to **Workspace settings → Accounting**.
3. On the NetSuite connection, open **Import → Custom fields** (custom segments/lists).
4. Tap **Add** and choose the **Custom list** type, then open the **"List name"** selector (the `NetSuiteCustomListSelectorPage`).
5. Because there are 12+ lists, a **search box** appears at the top. Confirm the list of custom lists renders.
6. **Pin on open:** With no list selected yet, the order is the default (server) order. Now set a custom list, leave the selector, and reopen it (or open the picker for a field that already has a list selected).
7. **Verify:** the **pre-selected custom list is pinned at the very top** of the list (above all others), with its row highlighted/checked — even if alphabetically/naturally it would sit lower and be below the fold.
8. **No jump on select:** tap a *different* custom list in the list.
9. **Verify:** the tapped row is selected in place and the list **does not jump or reorder** while the picker is open (the previously pinned list stays where it is).
10. **Pin held during search:** type part of the pre-selected list's name in the search box.
11. **Verify:** the pre-selected list **stays pinned at the top** of the filtered results (it doesn't drop into its natural position among the matches).
12. Clear the search and confirm the pre-selected list is still pinned at the top.
13. **Below-threshold check:** repeat on a NetSuite workspace/account with **fewer than 12** custom lists.
14. **Verify:** no search box, and the list stays in its **normal (unpinned) order** — the selected list is not floated to the top.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
>


https://github.com/user-attachments/assets/93e90b8e-63e7-4f5d-b90c-f7859834ba65




</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
>



https://github.com/user-attachments/assets/534f8867-0ab9-4c6c-acfa-a88ffe041bf8



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
>


https://github.com/user-attachments/assets/0e88ff0f-b4eb-4076-9c9c-ec624c84bd6e




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
>


https://github.com/user-attachments/assets/321066e1-8b17-47f1-b263-ff773462c588





</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
>



https://github.com/user-attachments/assets/ad2baddf-1188-4e94-ba1d-1dfea6bc6d97



</details>
