### PR TITLE
[CP Staging] Revert "Fix: prevent dynamic route crash when "action" query param exists in both base path and suffix"

### DIFF
--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute.ts
@@ -7,14 +7,8 @@ import isDynamicRouteSuffix from './isDynamicRouteSuffix';
 import splitPathAndQuery from './splitPathAndQuery';
 
 /**
- * Merges two query strings into one. When both contain the same key, the suffix value wins
- * (it is the intended destination of the navigation).
- *
- * Sibling dynamic suffixes deliberately share param names (every money-request step declares
- * `action`, `iouType`, `transactionID` and `reportID`), so a collision is expected and must not be
- * fatal. A collision on *differing* values is still reported via `Log.alert` (forwarded to Sentry),
- * logging only the param name because a value can carry private data.
- *
+ * Merges two query strings into one. If both contain the same key,
+ * the error is thrown.
  * @param baseQuery - The query string of the base path
  * @param suffixQuery - The query string of the suffix
  * @returns The merged query string or an empty string if both are empty
@@ -22,8 +16,8 @@ import splitPathAndQuery from './splitPathAndQuery';
  * @private - Internal helper. Do not export or use outside this file.
  *
  * @example
- * mergeQueryStrings('foo=bar', 'baz=qux') => '?foo=bar&baz=qux'
- * mergeQueryStrings('action=edit', 'action=create') => '?action=create' (suffix wins, reported to Sentry)
+ * mergeQueryStrings('foo=bar', 'foo=baz') => '?foo=bar&baz=qux'
+ * mergeQueryStrings('foo=bar', 'foo=baz') => throws an error
  */
 const mergeQueryStrings = (baseQuery = '', suffixQuery = ''): string => {
     if (!baseQuery && !suffixQuery) {
@@ -33,8 +27,8 @@ const mergeQueryStrings = (baseQuery = '', suffixQuery = ''): string => {
     const suffixParams = new URLSearchParams(suffixQuery);
     const suffixParamsEntries = suffixParams.entries();
     for (const [key, value] of suffixParamsEntries) {
-        if (params.has(key) && params.get(key) !== value) {
-            Log.alert('[createDynamicRoute] Query param exists in both base path and dynamic suffix with different values; suffix value takes precedence', {key});
+        if (params.has(key)) {
+            throw new Error(`[createDynamicRoute] Query param "${key}" exists in both base path and dynamic suffix. This is not allowed.`);
         }
         params.set(key, value);
     }

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix.ts
@@ -1,6 +1,5 @@
 import type {Route} from '@src/ROUTES';
 
-import findAllMatchingDynamicSuffixes from './findAllMatchingDynamicSuffixes';
 import getDynamicRouteQueryParams from './getDynamicRouteQueryParams';
 import splitPathAndQuery from './splitPathAndQuery';
 
@@ -27,16 +26,8 @@ function getPathWithoutDynamicSuffix(fullPath: string, dynamicSuffix: string, pa
     const paramsToStrip = getDynamicRouteQueryParams(patternSuffix ?? dynamicSuffix);
     let filteredQuery = query;
     if (paramsToStrip?.length && query) {
-        // The base path can itself end with a dynamic suffix, and sibling suffixes share param names, so stripping
-        // wholesale would leave that base suffix without the params it needs. We can't tell which of the matching
-        // candidates is the real one without the navigation state, so keep any param one of them could own -
-        // over-keeping is harmless, dropping one breaks the base route.
-        const paramsOwnedByBase = new Set(findAllMatchingDynamicSuffixes(pathWithoutDynamicSuffix).flatMap((match) => getDynamicRouteQueryParams(match.pattern) ?? []));
         const params = new URLSearchParams(query);
         for (const key of paramsToStrip) {
-            if (paramsOwnedByBase.has(key)) {
-                continue;
-            }
             params.delete(key);
         }
         const result = params.toString();

--- a/src/libs/telemetry/forwardLogsToSentry.ts
+++ b/src/libs/telemetry/forwardLogsToSentry.ts
@@ -32,7 +32,7 @@ const PARAMETERS_WHITELIST: ReadonlyArray<string | RegExp> = [
 /**
  * Only log lines whose message contains one of these prefixes are forwarded to Sentry.
  */
-const FORWARDED_LOG_PREFIXES = ['[MFA]', '[OnyxUpdateManagerError]', '[Receipt]', '[PDFStall]', '[OpenReportStall]', '[withNavigationFallback]', '[createDynamicRoute]'] as const;
+const FORWARDED_LOG_PREFIXES = ['[MFA]', '[OnyxUpdateManagerError]', '[Receipt]', '[PDFStall]', '[OpenReportStall]', '[withNavigationFallback]'] as const;
 
 type ForwardedLogPrefix = TupleToUnion<typeof FORWARDED_LOG_PREFIXES>;
 
@@ -46,9 +46,6 @@ const PREFIX_SCOPED_PARAMETERS_WHITELIST = new Map<ForwardedLogPrefix, ReadonlyA
     ['[PDFStall]', ['reportID']],
     ['[OpenReportStall]', ['reportID']],
     ['[withNavigationFallback]', ['method', 'stack']],
-    // The colliding values are never logged in the first place (see `mergeQueryStrings`) because a query param
-    // value can carry private data. The param name and the stack are enough to locate the collision.
-    ['[createDynamicRoute]', ['key', 'stack']],
 ]);
 
 /**

--- a/tests/navigation/createDynamicRouteTests.ts
+++ b/tests/navigation/createDynamicRouteTests.ts
@@ -1,4 +1,3 @@
-import Log from '@libs/Log';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 
@@ -8,7 +7,6 @@ jest.mock('@libs/Navigation/Navigation', () => ({
 
 jest.mock('@libs/Log', () => ({
     warn: jest.fn(),
-    alert: jest.fn(),
 }));
 
 jest.mock('@src/ROUTES', () => ({
@@ -27,8 +25,6 @@ jest.mock('@src/ROUTES', () => ({
 
 describe('createDynamicRoute', () => {
     const mockGetActiveRoute = jest.mocked(Navigation.getActiveRoute);
-    // eslint-disable-next-line @typescript-eslint/unbound-method -- jest.fn() mock doesn't rely on `this` binding
-    const mockLogAlert = jest.mocked(Log.alert);
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -145,43 +141,13 @@ describe('createDynamicRoute', () => {
         expect(result).toBe(expectedPath);
     });
 
-    it('should let the suffix query param win when it collides with a base path query param', () => {
-        const activeRoute = 'settings/profile/address?country=GB';
-        const suffixWithQuery = 'country?country=US';
-        const expectedPath = 'settings/profile/address/country?country=US';
-
-        mockGetActiveRoute.mockReturnValue(activeRoute);
-
-        const result = createDynamicRoute(suffixWithQuery);
-
-        expect(result).toBe(expectedPath);
-    });
-
-    it('should report the name of a colliding query param without its values', () => {
+    it('should throw an error when suffix query param collides with base path query param', () => {
         const activeRoute = 'settings/profile/address?country=GB';
         const suffixWithQuery = 'country?country=US';
 
         mockGetActiveRoute.mockReturnValue(activeRoute);
 
-        createDynamicRoute(suffixWithQuery);
-
-        expect(mockLogAlert).toHaveBeenCalledTimes(1);
-        // The `[createDynamicRoute]` prefix is what routes this line to Sentry, see FORWARDED_LOG_PREFIXES.
-        // Only the param name is logged - a query param value can carry private data, so it must never be logged.
-        expect(mockLogAlert).toHaveBeenCalledWith(expect.stringContaining('[createDynamicRoute]'), {key: 'country'});
-    });
-
-    it('should not report when a colliding query param has the same value in base and suffix', () => {
-        const activeRoute = 'settings/profile/address?country=US';
-        const suffixWithQuery = 'country?country=US';
-        const expectedPath = 'settings/profile/address/country?country=US';
-
-        mockGetActiveRoute.mockReturnValue(activeRoute);
-
-        const result = createDynamicRoute(suffixWithQuery);
-
-        expect(result).toBe(expectedPath);
-        expect(mockLogAlert).not.toHaveBeenCalled();
+        expect(() => createDynamicRoute(suffixWithQuery)).toThrow('[createDynamicRoute] Query param "country" exists in both base path and dynamic suffix. This is not allowed.');
     });
 
     it('should append parametric suffix with single param to path', () => {

--- a/tests/navigation/getPathWithoutDynamicSuffixTests.ts
+++ b/tests/navigation/getPathWithoutDynamicSuffixTests.ts
@@ -73,42 +73,6 @@ describe('getPathWithoutDynamicSuffix', () => {
         expect(result).toBe('');
     });
 
-    describe('stacked dynamic suffixes', () => {
-        it("should keep the query params the base path's own dynamic suffix declares", () => {
-            // `expense-report` and `expense-tag` both declare action/iouType/transactionID/reportID, so stripping
-            // `expense-tag`'s params wholesale would leave the `expense-report` base without the params it needs.
-            const result = getPathWithoutDynamicSuffix('/search/view/123/expense-report/expense-tag?action=edit&iouType=submit&transactionID=1&reportID=2&orderWeight=0', 'expense-tag');
-
-            expect(result).toBe('/search/view/123/expense-report?action=edit&iouType=submit&transactionID=1&reportID=2');
-        });
-
-        it('should still strip the params only the suffix declares', () => {
-            // `orderWeight` belongs to `expense-tag` alone, so it must not survive on the `expense-report` base.
-            const result = getPathWithoutDynamicSuffix(
-                '/search/view/123/expense-report/expense-tag?action=edit&iouType=submit&transactionID=1&reportID=2&orderWeight=0&reportActionID=9',
-                'expense-tag',
-            );
-
-            expect(result).toBe('/search/view/123/expense-report?action=edit&iouType=submit&transactionID=1&reportID=2&reportActionID=9');
-        });
-
-        it('should strip every suffix param when the base path is not itself a dynamic route', () => {
-            const result = getPathWithoutDynamicSuffix('/r/123/expense-tag?action=edit&iouType=submit&transactionID=1&reportID=2&orderWeight=0', 'expense-tag');
-
-            expect(result).toBe('/r/123');
-        });
-
-        it('should keep params owned by any suffix the base path could match, not just the first one', () => {
-            // `/r/123/merge/1/details` matches several registered suffixes: `details` (owns `reportID`) comes first,
-            // but `merge/:transactionID/details` is the one that owns `isOnSearch`. We can't tell which candidate is
-            // the real one without the navigation state, so we keep the union - dropping `isOnSearch` here would
-            // strip a param the base path still needs.
-            const result = getPathWithoutDynamicSuffix('/r/123/merge/1/details/merge/2/confirmation?isOnSearch=true&reportID=5', 'merge/2/confirmation', 'merge/:transactionID/confirmation');
-
-            expect(result).toBe('/r/123/merge/1/details?isOnSearch=true&reportID=5');
-        });
-    });
-
     describe('actualSuffix shorter than registered pattern (optional absent)', () => {
         it('strips only the actualSuffix length when trailing optional is absent', () => {
             const result = getPathWithoutDynamicSuffix('/r/123/opt-page', 'opt-page', 'opt-page/:id?');

--- a/tests/unit/forwardLogsToSentryTest.ts
+++ b/tests/unit/forwardLogsToSentryTest.ts
@@ -78,32 +78,6 @@ describe('forwardLogsToSentry', () => {
         );
     });
 
-    it('forwards a dynamic route query param collision without the colliding values', () => {
-        // Given a [createDynamicRoute] collision whose values are user data (an email address and a full URL).
-        // `mergeQueryStrings` no longer logs those values at all - this locks the whitelist as a second guard,
-        // so re-adding them at the call site still would not leak them to Sentry.
-        const packet = packetWith('[alrt] [createDynamicRoute] Query param exists in both base path and dynamic suffix with different values; suffix value takes precedence', {
-            key: 'contactMethod',
-            baseValue: 'user@example.com',
-            suffixValue: 'https://www.expensify.com/secret',
-            stack: 'Error\n    at MoneyRequestConfirmationList',
-        });
-
-        // When the packet is mirrored to Sentry
-        forwardLogsToSentry(packet);
-
-        // Then the param name and the call site are forwarded, so the collision is still locatable...
-        expect(Sentry.logger.error).toHaveBeenCalledWith(
-            expect.stringContaining('[createDynamicRoute]'),
-            expect.objectContaining({key: 'contactMethod', stack: 'Error\n    at MoneyRequestConfirmationList'}),
-        );
-
-        // ...but the colliding values never leave the device
-        const data = jest.mocked(Sentry.logger.error).mock.calls.at(0)?.[1];
-        expect(data).not.toHaveProperty('baseValue');
-        expect(data).not.toHaveProperty('suffixValue');
-    });
-
     it('does not add a breadcrumb for log lines that are not forwarded', () => {
         // Given a log line without a forwarded prefix
         const packet = packetWith('[info] [SequentialQueue] push() called', {command: 'OpenReport'});


### PR DESCRIPTION
Reverts Expensify/App#98949 cc @thelullabyy 

### Fixed issues

$ https://github.com/Expensify/App/issues/100505