### PR TITLE
Fix duplicate OpenApp on deep link by recording full reconnect time immediately

### DIFF
--- a/src/libs/FullReconnectUtils.ts
+++ b/src/libs/FullReconnectUtils.ts
@@ -1,5 +1,4 @@
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
 
 import Onyx from 'react-native-onyx';
 
@@ -53,22 +52,4 @@ function getLastFullReconnectTimeToRecord(serverReconnectCutoff: string): string
     return now >= serverReconnectCutoff ? now : serverReconnectCutoff;
 }
 
-/**
- * The response can deliver a newer cutoff than the one known when the request was built, and the
- * held cutoff can be newer still (a Pusher update can overtake an in-flight response), so the
- * recorded time satisfies whichever of the two is later. A time below either would read as stale
- * and fire an extra reconnect right after the full download.
- *
- * The time is written directly to Onyx (not spliced into the deferred response batch) so
- * subscribeToFullReconnect sees it before any cutoff from the same response can land.
- */
-function recordFullReconnectTimeFromResponse(responseOnyxData: AnyOnyxUpdate[] | undefined, knownServerReconnectCutoff: string): Promise<void> {
-    const deliveredCutoffValue: unknown = responseOnyxData?.find((update) => update.key === ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE)?.value;
-    const deliveredCutoff = typeof deliveredCutoffValue === 'string' ? deliveredCutoffValue : '';
-    const cutoffToSatisfy = deliveredCutoff > knownServerReconnectCutoff ? deliveredCutoff : knownServerReconnectCutoff;
-    // Written directly to Onyx (not via an action) so subscribeToFullReconnect observes LAST_FULL_RECONNECT_TIME before any cutoff from the same response can land.
-    // eslint-disable-next-line rulesdir/prefer-actions-set-data
-    return Onyx.merge(ONYXKEYS.LAST_FULL_RECONNECT_TIME, getLastFullReconnectTimeToRecord(cutoffToSatisfy));
-}
-
-export {shouldTriggerFullReconnect, getLastFullReconnectTimeToRecord, getServerReconnectCutoff, recordFullReconnectTimeFromResponse};
+export {shouldTriggerFullReconnect, getLastFullReconnectTimeToRecord, getServerReconnectCutoff};

--- a/src/libs/FullReconnectUtils.ts
+++ b/src/libs/FullReconnectUtils.ts
@@ -66,6 +66,7 @@ function recordFullReconnectTimeFromResponse(responseOnyxData: AnyOnyxUpdate[] |
     const deliveredCutoffValue: unknown = responseOnyxData?.find((update) => update.key === ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE)?.value;
     const deliveredCutoff = typeof deliveredCutoffValue === 'string' ? deliveredCutoffValue : '';
     const cutoffToSatisfy = deliveredCutoff > knownServerReconnectCutoff ? deliveredCutoff : knownServerReconnectCutoff;
+    // Written directly to Onyx (not via an action) so subscribeToFullReconnect observes LAST_FULL_RECONNECT_TIME before any cutoff from the same response can land.
     // eslint-disable-next-line rulesdir/prefer-actions-set-data
     return Onyx.merge(ONYXKEYS.LAST_FULL_RECONNECT_TIME, getLastFullReconnectTimeToRecord(cutoffToSatisfy));
 }

--- a/src/libs/FullReconnectUtils.ts
+++ b/src/libs/FullReconnectUtils.ts
@@ -59,19 +59,15 @@ function getLastFullReconnectTimeToRecord(serverReconnectCutoff: string): string
  * recorded time satisfies whichever of the two is later. A time below either would read as stale
  * and fire an extra reconnect right after the full download.
  *
- * The entry goes right before the delivered cutoff entry, so the reconnect subscription never sees
- * a new cutoff next to an old reconnect time. That assumes Onyx broadcasts a batch's merges in
- * array order: true today because both keys are cache-resident (see subscribeToFullReconnect.ts),
- * and pinned by the SubscribeToFullReconnect e2e test. If it ever broke, the worst case is one
- * transient extra reconnect, never a loop.
+ * The time is written directly to Onyx (not spliced into the deferred response batch) so
+ * subscribeToFullReconnect sees it before any cutoff from the same response can land.
  */
-function recordFullReconnectTimeFromResponse(responseOnyxData: AnyOnyxUpdate[], knownServerReconnectCutoff: string): void {
-    const cutoffIndex = responseOnyxData.findIndex((update) => update.key === ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE);
-    const deliveredCutoffValue: unknown = cutoffIndex === -1 ? undefined : responseOnyxData.at(cutoffIndex)?.value;
+function recordFullReconnectTimeFromResponse(responseOnyxData: AnyOnyxUpdate[] | undefined, knownServerReconnectCutoff: string): Promise<void> {
+    const deliveredCutoffValue: unknown = responseOnyxData?.find((update) => update.key === ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE)?.value;
     const deliveredCutoff = typeof deliveredCutoffValue === 'string' ? deliveredCutoffValue : '';
     const cutoffToSatisfy = deliveredCutoff > knownServerReconnectCutoff ? deliveredCutoff : knownServerReconnectCutoff;
-    const insertionIndex = cutoffIndex === -1 ? responseOnyxData.length : cutoffIndex;
-    responseOnyxData.splice(insertionIndex, 0, {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.LAST_FULL_RECONNECT_TIME, value: getLastFullReconnectTimeToRecord(cutoffToSatisfy)});
+    // eslint-disable-next-line rulesdir/prefer-actions-set-data
+    return Onyx.merge(ONYXKEYS.LAST_FULL_RECONNECT_TIME, getLastFullReconnectTimeToRecord(cutoffToSatisfy));
 }
 
 export {shouldTriggerFullReconnect, getLastFullReconnectTimeToRecord, getServerReconnectCutoff, recordFullReconnectTimeFromResponse};

--- a/src/libs/Middleware/RecordFullReconnectTime.ts
+++ b/src/libs/Middleware/RecordFullReconnectTime.ts
@@ -1,5 +1,6 @@
+import recordFullReconnectTimeFromResponse from '@libs/actions/recordFullReconnectTimeFromResponse';
 import {isFullDownloadRequest} from '@libs/actions/RequestConflictUtils';
-import {getServerReconnectCutoff, recordFullReconnectTimeFromResponse} from '@libs/FullReconnectUtils';
+import {getServerReconnectCutoff} from '@libs/FullReconnectUtils';
 
 import CONST from '@src/CONST';
 import type {AnyOnyxUpdate} from '@src/types/onyx/Request';

--- a/src/libs/Middleware/RecordFullReconnectTime.ts
+++ b/src/libs/Middleware/RecordFullReconnectTime.ts
@@ -13,13 +13,12 @@ import type Middleware from './types';
  * can land below it and fire extra full reconnects right after downloading everything.
  */
 const recordFullReconnectTime: Middleware = (requestResponse, request) =>
-    requestResponse.then((response) => {
+    requestResponse.then(async (response) => {
         if (!isFullDownloadRequest(request) || response?.jsonCode !== CONST.JSON_CODE.SUCCESS) {
             return response;
         }
 
-        response.onyxData ??= [];
-        recordFullReconnectTimeFromResponse(response.onyxData as AnyOnyxUpdate[], getServerReconnectCutoff());
+        await recordFullReconnectTimeFromResponse(response.onyxData as AnyOnyxUpdate[] | undefined, getServerReconnectCutoff());
         return response;
     });
 

--- a/src/libs/actions/recordFullReconnectTimeFromResponse.ts
+++ b/src/libs/actions/recordFullReconnectTimeFromResponse.ts
@@ -1,0 +1,26 @@
+import {getLastFullReconnectTimeToRecord} from '@libs/FullReconnectUtils';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
+
+import Onyx from 'react-native-onyx';
+
+/**
+ * Records LAST_FULL_RECONNECT_TIME after a successful full download.
+ *
+ * The response can deliver a newer cutoff than the one known when the request was built, and the
+ * held cutoff can be newer still (a Pusher update can overtake an in-flight response), so the
+ * recorded time satisfies whichever of the two is later. A time below either would read as stale
+ * and fire an extra reconnect right after the full download.
+ *
+ * The caller awaits this before the response reaches Onyx, so subscribeToFullReconnect sees the
+ * recorded time before any cutoff from the same response can land.
+ */
+function recordFullReconnectTimeFromResponse(responseOnyxData: AnyOnyxUpdate[] | undefined, knownServerReconnectCutoff: string): Promise<void> {
+    const deliveredCutoffValue: unknown = responseOnyxData?.find((update) => update.key === ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE)?.value;
+    const deliveredCutoff = typeof deliveredCutoffValue === 'string' ? deliveredCutoffValue : '';
+    const cutoffToSatisfy = deliveredCutoff > knownServerReconnectCutoff ? deliveredCutoff : knownServerReconnectCutoff;
+    return Onyx.merge(ONYXKEYS.LAST_FULL_RECONNECT_TIME, getLastFullReconnectTimeToRecord(cutoffToSatisfy));
+}
+
+export default recordFullReconnectTimeFromResponse;

--- a/tests/actions/RecordFullReconnectTimeFromResponseTest.ts
+++ b/tests/actions/RecordFullReconnectTimeFromResponseTest.ts
@@ -1,0 +1,91 @@
+import recordFullReconnectTimeFromResponse from '@libs/actions/recordFullReconnectTimeFromResponse';
+import DateUtils from '@libs/DateUtils';
+import {shouldTriggerFullReconnect} from '@libs/FullReconnectUtils';
+
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
+
+import Onyx from 'react-native-onyx';
+
+import getOnyxValue from '../utils/getOnyxValue';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+const CLIENT_NOW = '2026-06-12 10:00:00.000';
+const BEFORE_CLIENT_NOW = '2026-06-12 09:59:00.000';
+const AFTER_CLIENT_NOW = '2026-06-12 10:05:00.000';
+
+function cutoffEntry(cutoff: string): AnyOnyxUpdate {
+    return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE, value: cutoff};
+}
+
+function someOtherEntry(): AnyOnyxUpdate {
+    return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.HAS_LOADED_APP, value: true};
+}
+
+describe('actions/recordFullReconnectTimeFromResponse', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+        jest.spyOn(DateUtils, 'getDBTime').mockReturnValue(CLIENT_NOW);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('writes the reconnect time to Onyx from the delivered cutoff', async () => {
+        const responseOnyxData = [someOtherEntry(), cutoffEntry(AFTER_CLIENT_NOW)];
+
+        await recordFullReconnectTimeFromResponse(responseOnyxData, '');
+
+        expect(responseOnyxData).toEqual([someOtherEntry(), cutoffEntry(AFTER_CLIENT_NOW)]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
+    });
+
+    it('writes client-now to Onyx when the response delivers no cutoff and none is held', async () => {
+        const responseOnyxData = [someOtherEntry()];
+
+        await recordFullReconnectTimeFromResponse(responseOnyxData, '');
+
+        expect(responseOnyxData).toEqual([someOtherEntry()]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(CLIENT_NOW);
+    });
+
+    it('writes the held cutoff to Onyx when the response delivers no cutoff, so an already-held cutoff never reads as stale again', async () => {
+        const responseOnyxData = [someOtherEntry()];
+
+        await recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
+
+        expect(responseOnyxData).toEqual([someOtherEntry()]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
+    });
+
+    it('writes the held cutoff to Onyx when the response delivers an older one, so a Pusher update that overtook the response never reads as stale again', async () => {
+        const responseOnyxData = [cutoffEntry(BEFORE_CLIENT_NOW)];
+
+        await recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
+
+        expect(responseOnyxData).toEqual([cutoffEntry(BEFORE_CLIENT_NOW)]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
+    });
+
+    it('never records a time that would ask for another reconnect at the delivered or the held cutoff', async () => {
+        for (const deliveredCutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
+            for (const heldCutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
+                await Onyx.clear();
+                await waitForBatchedUpdates();
+                const responseOnyxData = deliveredCutoff === '' ? [] : [cutoffEntry(deliveredCutoff)];
+
+                await recordFullReconnectTimeFromResponse(responseOnyxData, heldCutoff);
+
+                const recorded = (await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)) ?? '';
+                expect(shouldTriggerFullReconnect(recorded, deliveredCutoff)).toBe(false);
+                expect(shouldTriggerFullReconnect(recorded, heldCutoff)).toBe(false);
+            }
+        }
+    });
+});

--- a/tests/unit/FullReconnectUtilsTest.ts
+++ b/tests/unit/FullReconnectUtilsTest.ts
@@ -1,25 +1,9 @@
 import DateUtils from '@libs/DateUtils';
-import {getLastFullReconnectTimeToRecord, recordFullReconnectTimeFromResponse, shouldTriggerFullReconnect} from '@libs/FullReconnectUtils';
-
-import ONYXKEYS from '@src/ONYXKEYS';
-import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
-
-import Onyx from 'react-native-onyx';
-
-import getOnyxValue from '../utils/getOnyxValue';
-import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+import {getLastFullReconnectTimeToRecord, shouldTriggerFullReconnect} from '@libs/FullReconnectUtils';
 
 const CLIENT_NOW = '2026-06-12 10:00:00.000';
 const BEFORE_CLIENT_NOW = '2026-06-12 09:59:00.000';
 const AFTER_CLIENT_NOW = '2026-06-12 10:05:00.000';
-
-function cutoffEntry(cutoff: string): AnyOnyxUpdate {
-    return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE, value: cutoff};
-}
-
-function someOtherEntry(): AnyOnyxUpdate {
-    return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.HAS_LOADED_APP, value: true};
-}
 
 describe('FullReconnectUtils', () => {
     describe('shouldTriggerFullReconnect', () => {
@@ -56,74 +40,6 @@ describe('FullReconnectUtils', () => {
         it('never records a time that would ask for another reconnect at the same cutoff', () => {
             for (const cutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
                 expect(shouldTriggerFullReconnect(getLastFullReconnectTimeToRecord(cutoff), cutoff)).toBe(false);
-            }
-        });
-    });
-
-    describe('recordFullReconnectTimeFromResponse', () => {
-        beforeAll(() => {
-            Onyx.init({keys: ONYXKEYS});
-        });
-
-        beforeEach(async () => {
-            await Onyx.clear();
-            await waitForBatchedUpdates();
-            jest.spyOn(DateUtils, 'getDBTime').mockReturnValue(CLIENT_NOW);
-        });
-
-        afterEach(() => {
-            jest.restoreAllMocks();
-        });
-
-        it('writes the reconnect time to Onyx from the delivered cutoff', async () => {
-            const responseOnyxData = [someOtherEntry(), cutoffEntry(AFTER_CLIENT_NOW)];
-
-            await recordFullReconnectTimeFromResponse(responseOnyxData, '');
-
-            expect(responseOnyxData).toEqual([someOtherEntry(), cutoffEntry(AFTER_CLIENT_NOW)]);
-            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
-        });
-
-        it('writes client-now to Onyx when the response delivers no cutoff and none is held', async () => {
-            const responseOnyxData = [someOtherEntry()];
-
-            await recordFullReconnectTimeFromResponse(responseOnyxData, '');
-
-            expect(responseOnyxData).toEqual([someOtherEntry()]);
-            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(CLIENT_NOW);
-        });
-
-        it('writes the held cutoff to Onyx when the response delivers no cutoff, so an already-held cutoff never reads as stale again', async () => {
-            const responseOnyxData = [someOtherEntry()];
-
-            await recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
-
-            expect(responseOnyxData).toEqual([someOtherEntry()]);
-            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
-        });
-
-        it('writes the held cutoff to Onyx when the response delivers an older one, so a Pusher update that overtook the response never reads as stale again', async () => {
-            const responseOnyxData = [cutoffEntry(BEFORE_CLIENT_NOW)];
-
-            await recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
-
-            expect(responseOnyxData).toEqual([cutoffEntry(BEFORE_CLIENT_NOW)]);
-            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
-        });
-
-        it('never records a time that would ask for another reconnect at the delivered or the held cutoff', async () => {
-            for (const deliveredCutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
-                for (const heldCutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
-                    await Onyx.clear();
-                    await waitForBatchedUpdates();
-                    const responseOnyxData = deliveredCutoff === '' ? [] : [cutoffEntry(deliveredCutoff)];
-
-                    await recordFullReconnectTimeFromResponse(responseOnyxData, heldCutoff);
-
-                    const recorded = (await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)) ?? '';
-                    expect(shouldTriggerFullReconnect(recorded, deliveredCutoff)).toBe(false);
-                    expect(shouldTriggerFullReconnect(recorded, heldCutoff)).toBe(false);
-                }
             }
         });
     });

--- a/tests/unit/FullReconnectUtilsTest.ts
+++ b/tests/unit/FullReconnectUtilsTest.ts
@@ -6,16 +6,15 @@ import type {AnyOnyxUpdate} from '@src/types/onyx/Request';
 
 import Onyx from 'react-native-onyx';
 
+import getOnyxValue from '../utils/getOnyxValue';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
 const CLIENT_NOW = '2026-06-12 10:00:00.000';
 const BEFORE_CLIENT_NOW = '2026-06-12 09:59:00.000';
 const AFTER_CLIENT_NOW = '2026-06-12 10:05:00.000';
 
 function cutoffEntry(cutoff: string): AnyOnyxUpdate {
     return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE, value: cutoff};
-}
-
-function recordedTimeEntry(time: string): AnyOnyxUpdate {
-    return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.LAST_FULL_RECONNECT_TIME, value: time};
 }
 
 function someOtherEntry(): AnyOnyxUpdate {
@@ -62,7 +61,13 @@ describe('FullReconnectUtils', () => {
     });
 
     describe('recordFullReconnectTimeFromResponse', () => {
-        beforeEach(() => {
+        beforeAll(() => {
+            Onyx.init({keys: ONYXKEYS});
+        });
+
+        beforeEach(async () => {
+            await Onyx.clear();
+            await waitForBatchedUpdates();
             jest.spyOn(DateUtils, 'getDBTime').mockReturnValue(CLIENT_NOW);
         });
 
@@ -70,47 +75,52 @@ describe('FullReconnectUtils', () => {
             jest.restoreAllMocks();
         });
 
-        it('records the reconnect time right before the delivered cutoff', () => {
+        it('writes the reconnect time to Onyx from the delivered cutoff', async () => {
             const responseOnyxData = [someOtherEntry(), cutoffEntry(AFTER_CLIENT_NOW)];
 
-            recordFullReconnectTimeFromResponse(responseOnyxData, '');
+            await recordFullReconnectTimeFromResponse(responseOnyxData, '');
 
-            expect(responseOnyxData).toEqual([someOtherEntry(), recordedTimeEntry(AFTER_CLIENT_NOW), cutoffEntry(AFTER_CLIENT_NOW)]);
+            expect(responseOnyxData).toEqual([someOtherEntry(), cutoffEntry(AFTER_CLIENT_NOW)]);
+            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
         });
 
-        it('records client-now when the response delivers no cutoff and none is held', () => {
+        it('writes client-now to Onyx when the response delivers no cutoff and none is held', async () => {
             const responseOnyxData = [someOtherEntry()];
 
-            recordFullReconnectTimeFromResponse(responseOnyxData, '');
+            await recordFullReconnectTimeFromResponse(responseOnyxData, '');
 
-            expect(responseOnyxData).toEqual([someOtherEntry(), recordedTimeEntry(CLIENT_NOW)]);
+            expect(responseOnyxData).toEqual([someOtherEntry()]);
+            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(CLIENT_NOW);
         });
 
-        it('records the held cutoff when the response delivers no cutoff, so an already-held cutoff never reads as stale again', () => {
+        it('writes the held cutoff to Onyx when the response delivers no cutoff, so an already-held cutoff never reads as stale again', async () => {
             const responseOnyxData = [someOtherEntry()];
 
-            recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
+            await recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
 
-            expect(responseOnyxData).toEqual([someOtherEntry(), recordedTimeEntry(AFTER_CLIENT_NOW)]);
+            expect(responseOnyxData).toEqual([someOtherEntry()]);
+            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
         });
 
-        it('records the held cutoff when the response delivers an older one, so a Pusher update that overtook the response never reads as stale again', () => {
+        it('writes the held cutoff to Onyx when the response delivers an older one, so a Pusher update that overtook the response never reads as stale again', async () => {
             const responseOnyxData = [cutoffEntry(BEFORE_CLIENT_NOW)];
 
-            recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
+            await recordFullReconnectTimeFromResponse(responseOnyxData, AFTER_CLIENT_NOW);
 
-            expect(responseOnyxData).toEqual([recordedTimeEntry(AFTER_CLIENT_NOW), cutoffEntry(BEFORE_CLIENT_NOW)]);
+            expect(responseOnyxData).toEqual([cutoffEntry(BEFORE_CLIENT_NOW)]);
+            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(AFTER_CLIENT_NOW);
         });
 
-        it('never records a time that would ask for another reconnect at the delivered or the held cutoff', () => {
+        it('never records a time that would ask for another reconnect at the delivered or the held cutoff', async () => {
             for (const deliveredCutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
                 for (const heldCutoff of ['', BEFORE_CLIENT_NOW, CLIENT_NOW, AFTER_CLIENT_NOW]) {
+                    await Onyx.clear();
+                    await waitForBatchedUpdates();
                     const responseOnyxData = deliveredCutoff === '' ? [] : [cutoffEntry(deliveredCutoff)];
 
-                    recordFullReconnectTimeFromResponse(responseOnyxData, heldCutoff);
+                    await recordFullReconnectTimeFromResponse(responseOnyxData, heldCutoff);
 
-                    const recordedTime: unknown = responseOnyxData.at(0)?.value;
-                    const recorded = typeof recordedTime === 'string' ? recordedTime : '';
+                    const recorded = (await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)) ?? '';
                     expect(shouldTriggerFullReconnect(recorded, deliveredCutoff)).toBe(false);
                     expect(shouldTriggerFullReconnect(recorded, heldCutoff)).toBe(false);
                 }

--- a/tests/unit/RecordFullReconnectTimeMiddlewareTest.ts
+++ b/tests/unit/RecordFullReconnectTimeMiddlewareTest.ts
@@ -10,15 +10,14 @@ import type {OnyxKey} from 'react-native-onyx';
 
 import Onyx from 'react-native-onyx';
 
+import getOnyxValue from '../utils/getOnyxValue';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
 const CLIENT_NOW = '2026-06-12 10:00:00.000';
 const DELIVERED_CUTOFF = '2026-06-12 10:05:00.000';
 
 function cutoffEntry(cutoff: string): AnyOnyxUpdate {
     return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE, value: cutoff};
-}
-
-function recordedTimeEntry(time: string): AnyOnyxUpdate {
-    return {onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.LAST_FULL_RECONNECT_TIME, value: time};
 }
 
 function buildRequest(command: string, data: Record<string, unknown> = {}): Request<OnyxKey> {
@@ -30,7 +29,13 @@ function buildResponse(jsonCode: number): Response<OnyxKey> {
 }
 
 describe('RecordFullReconnectTime middleware', () => {
-    beforeEach(() => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
         jest.spyOn(DateUtils, 'getDBTime').mockReturnValue(CLIENT_NOW);
     });
 
@@ -44,7 +49,8 @@ describe('RecordFullReconnectTime middleware', () => {
 
         await recordFullReconnectTime(Promise.resolve(response), request, false);
 
-        expect(response.onyxData).toEqual([recordedTimeEntry(DELIVERED_CUTOFF), cutoffEntry(DELIVERED_CUTOFF)]);
+        expect(response.onyxData).toEqual([cutoffEntry(DELIVERED_CUTOFF)]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(DELIVERED_CUTOFF);
     });
 
     it('records nothing for a partial ReconnectApp, one that fetches from an update ID', async () => {
@@ -54,6 +60,7 @@ describe('RecordFullReconnectTime middleware', () => {
         await recordFullReconnectTime(Promise.resolve(response), request, false);
 
         expect(response.onyxData).toEqual([cutoffEntry(DELIVERED_CUTOFF)]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBeUndefined();
     });
 
     it('records client-now when a successful response carries no onyxData at all', async () => {
@@ -62,7 +69,8 @@ describe('RecordFullReconnectTime middleware', () => {
 
         await recordFullReconnectTime(Promise.resolve(response), request, false);
 
-        expect(response.onyxData).toEqual([recordedTimeEntry(CLIENT_NOW)]);
+        expect(response.onyxData).toBeUndefined();
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(CLIENT_NOW);
     });
 
     test.each(['OpenReport', 'GetMissingOnyxMessages'])('leaves a %s response untouched', async (command) => {
@@ -72,6 +80,7 @@ describe('RecordFullReconnectTime middleware', () => {
         await recordFullReconnectTime(Promise.resolve(response), request, false);
 
         expect(response.onyxData).toEqual([cutoffEntry(DELIVERED_CUTOFF)]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBeUndefined();
     });
 
     it('leaves failed responses untouched', async () => {
@@ -81,6 +90,7 @@ describe('RecordFullReconnectTime middleware', () => {
         await recordFullReconnectTime(Promise.resolve(response), request, false);
 
         expect(response.onyxData).toEqual([cutoffEntry(DELIVERED_CUTOFF)]);
+        expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBeUndefined();
     });
 
     it('passes the response through unchanged as the middleware result', async () => {

--- a/tests/unit/SubscribeToFullReconnectTest.ts
+++ b/tests/unit/SubscribeToFullReconnectTest.ts
@@ -67,8 +67,20 @@ async function runMiddlewareTransform(callIndex: number, deliveredCutoff: string
     const knownCutoff = (await getOnyxValue(ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE)) ?? '';
     const responseOnyxData: AnyOnyxUpdate[] =
         deliveredCutoff === null ? [] : [{onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE, value: deliveredCutoff}];
-    recordFullReconnectTimeFromResponse(responseOnyxData, knownCutoff);
+    await recordFullReconnectTimeFromResponse(responseOnyxData, knownCutoff);
     return {responseOnyxData, successData};
+}
+
+function getOpenAppRequests() {
+    return capturedCommands.filter((command) => command === WRITE_COMMANDS.OPEN_APP);
+}
+
+// Queues the OpenApp response updates without flushing, so LAST_FULL_RECONNECT_TIME stays invisible until flush.
+async function queueOpenAppResponseWithoutFlush(callIndex: number, deliveredCutoff: string | null): Promise<void> {
+    const {responseOnyxData, successData} = await runMiddlewareTransform(callIndex, deliveredCutoff);
+    await queueOnyxUpdates(responseOnyxData);
+    await queueOnyxUpdates(successData);
+    await waitForBatchedUpdates();
 }
 
 // Mirrors the side-effect ReconnectApp path: onyxData and successData land as two separate, fully-settled Onyx.update calls.
@@ -247,5 +259,44 @@ describe('subscribeToFullReconnect', () => {
 
         expect(capturedCommands).toHaveLength(0);
         expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(CLIENT_NOW);
+    });
+
+    describe('fresh boot (HAS_LOADED_APP unset)', () => {
+        beforeEach(async () => {
+            await Onyx.clear();
+            await waitForBatchedUpdates();
+            jest.clearAllMocks();
+            events = [];
+            capturedOnyxData = [];
+            capturedCommands = [];
+            jest.spyOn(DateUtils, 'getDBTime').mockReturnValue(CLIENT_NOW);
+            mockReconnectWriteCommand.mockImplementation((command, params, onyxData) => {
+                events.push({type: 'request', value: String(command)});
+                capturedCommands.push(String(command));
+                capturedOnyxData.push(onyxData ?? {});
+                return Promise.resolve();
+            });
+            mockOpenAppWriteCommand.mockImplementation((params, onyxData) => {
+                events.push({type: 'request', value: WRITE_COMMANDS.OPEN_APP});
+                capturedCommands.push(WRITE_COMMANDS.OPEN_APP);
+                capturedOnyxData.push(onyxData ?? {});
+                return Promise.resolve();
+            });
+        });
+
+        it('does not fire a second OpenApp when the cutoff arrives while the first OpenApp response is still queued', async () => {
+            openApp();
+            await waitForCondition(() => getOpenAppRequestIndex() > -1, 'first OpenApp request');
+            expect(getOpenAppRequests()).toHaveLength(1);
+
+            await queueOpenAppResponseWithoutFlush(getOpenAppRequestIndex(), SERVER_CUTOFF);
+
+            await Onyx.merge(ONYXKEYS.NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE, SERVER_CUTOFF);
+            await waitForBatchedUpdates();
+            await waitForBatchedUpdates();
+
+            expect(getOpenAppRequests()).toHaveLength(1);
+            expect(await getOnyxValue(ONYXKEYS.LAST_FULL_RECONNECT_TIME)).toBe(SERVER_CUTOFF);
+        });
     });
 });

--- a/tests/unit/SubscribeToFullReconnectTest.ts
+++ b/tests/unit/SubscribeToFullReconnectTest.ts
@@ -1,10 +1,10 @@
 import {openApp} from '@libs/actions/App';
 import clearOnyxAndSeedFullReconnect from '@libs/actions/clearOnyxAndSeedFullReconnect';
 import {flushQueue, queueOnyxUpdates} from '@libs/actions/QueuedOnyxUpdates';
+import recordFullReconnectTimeFromResponse from '@libs/actions/recordFullReconnectTimeFromResponse';
 import {writeWithNoDuplicatesOpenAppConflictAction, writeWithNoDuplicatesReconnectConflictAction} from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
-import {recordFullReconnectTimeFromResponse} from '@libs/FullReconnectUtils';
 
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {AnyOnyxUpdate} from '@src/types/onyx/Request';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
When opening a report via an OldDot `/transition` deep link, `subscribeToFullReconnect` could fire an unnecessary `ReconnectApp` during boot because `LAST_FULL_RECONNECT_TIME` was spliced into the deferred `OpenApp` response batch. The cutoff became visible in Onyx before the recorded reconnect time, so `reconnectApp()` fell back to a second `OpenApp`, leaving the report stuck on a semi-transparent skeleton.

This PR removes the broken splice in `recordFullReconnectTimeFromResponse` and writes `LAST_FULL_RECONNECT_TIME` directly to Onyx inside the `RecordFullReconnectTime` middleware, awaited before `SaveResponseInOnyx` can stage the cutoff. That prevents the duplicate full download without adding a `hasLoadedApp` guard around the reconnect subscription.

### Fixed Issues
$ https://github.com/Expensify/App/issues/97159
PROPOSAL: https://github.com/Expensify/App/issues/97159#issuecomment-5494731271

### Tests
1. Run unit tests:
   - `npm test -- tests/unit/SubscribeToFullReconnectTest.ts tests/unit/FullReconnectUtilsTest.ts tests/unit/RecordFullReconnectTimeMiddlewareTest.ts tests/actions/RecordFullReconnectTimeFromResponseTest.ts`
2. Verify all tests pass, including the fresh-boot regression test that asserts only one `OpenApp` fires when the cutoff arrives while the first response is still queued.
3. In a signed-in browser, open an OldDot report link, e.g. `https://www.expensify.com/report?param={"pageReportID":"<reportID>"}`.
4. As soon as it redirects to `new.expensify.com/transition?...&exitTo=search/r/<reportID>`, quickly copy the full URL and close the tab.
5. Open a fresh incognito window, paste the copied URL, and change the host to `dev.new.expensify.com:8082`.
6. Confirm the app lands on `/search/r/<reportID>` and the report loads with a brief opaque loader (not a stuck semi-transparent skeleton with Home visible behind it).
7. Verify that no errors appear in the JS console.

### Offline tests
N/A — this change affects the OpenApp/reconnect ordering during initial app load over the network. No offline-specific behavior was changed.

### QA Steps

Same flow as Tests, only the host changes:

1. Open https://www.expensify.com/report?param={"pageReportID":"<reportID>"} while signed in.
2. As soon as it redirects to new.expensify.com/transition..., copy the URL and close the tab.
3. Open a new incognito window, paste the URL, and change new.expensify.com to staging.new.expensify.com.
4. Confirm the loader is brief and fully opaque, then goes away, and the report loads on /search/r/<reportID>.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native (N/A)</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>



https://github.com/user-attachments/assets/9d8ae366-0c98-4d99-aff0-905f50b871f8



</details>

<details>
<summary>iOS: Native (N/A)</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/1023385f-d266-4827-9cd1-1435bd2702f8



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/fb4ad58b-15e9-48d6-96da-aa158b310f70

</details>