### PR TITLE
Show rate out-of-policy violation for disabled Track distance rates

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -602,6 +602,7 @@ function MoneyRequestView({
         unit,
         rate,
         name: rateName,
+        enabled: isSelectedRateEnabled,
     } = DistanceRequestUtils.getRate({
         transaction: updatedTransaction ?? transaction,
         policy: distanceOriginalPolicy ?? policy,
@@ -611,7 +612,9 @@ function MoneyRequestView({
     const currency = transactionCurrency ?? CONST.CURRENCY.USD;
     const hasRequiredCompanyCardViolation = transactionViolations.some((violation) => violation.name === CONST.VIOLATIONS.COMPANY_CARD_REQUIRED);
     const isCustomUnitOutOfPolicy =
-        (transactionViolations.some((violation) => violation.name === CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY) || (isDistanceRequest && !rate)) && !isTrackExpense;
+        transactionViolations.some((violation) => violation.name === CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY) ||
+        (isDistanceRequest && !rate && !isTrackExpense) ||
+        (isDistanceRequest && isSelectedRateEnabled === false);
     const calculateFromTransactionData = isTrackExpense && !rate;
     const distanceUnit = calculateFromTransactionData ? transaction?.comment?.customUnit?.distanceUnit : unit;
     const distanceRate = calculateFromTransactionData ? (transactionAmount ?? 0) / (transaction?.comment?.customUnit?.quantity ?? 1) : rate;

--- a/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
@@ -13,6 +13,7 @@ import type {ListItem} from '@components/SelectionList/types';
 import useConfirmModal from '@hooks/useConfirmModal';
 import {useCurrencyListActions} from '@hooks/useCurrencyList';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useDistanceRateOriginalPolicy from '@hooks/useDistanceRateOriginalPolicy';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import {useReportPaymentContext} from '@hooks/usePaymentContext';
@@ -23,10 +24,11 @@ import type {TransactionPreviewData} from '@libs/actions/Search';
 import {handleActionButtonPress as handleActionButtonPressUtil} from '@libs/actions/Search';
 import {syncMissingAttendeesViolation} from '@libs/AttendeeUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {isAttendeeTrackingEnabled} from '@libs/PolicyUtils';
+import {getDistanceRateCustomUnitRate, isAttendeeTrackingEnabled} from '@libs/PolicyUtils';
 import {isInvoiceReport, shouldShowMarkAsDone} from '@libs/ReportUtils';
 import {
     isDeletedTransaction as isDeletedTransactionUtil,
+    isDistanceRequest,
     isViolationDismissed,
     mergeProhibitedViolations,
     shouldShowAttendees,
@@ -34,6 +36,7 @@ import {
     showHeldExpensesBlockModal,
     showPendingCardTransactionsBlockModal,
 } from '@libs/TransactionUtils';
+import {syncCustomUnitOutOfPolicyViolation} from '@libs/Violations/ViolationsUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -176,11 +179,15 @@ function TransactionListItemInner<TItem extends ListItem>({
     const policyForViolations = parentPolicy ?? snapshotPolicy;
     const rowPolicy = parentPolicy || snapshotPolicy.id || transactionItem.policy ? {...transactionItem.policy, ...snapshotPolicy, ...parentPolicy} : undefined;
     const reportForViolations = parentReport ?? snapshotReport;
-    const shouldShowMarkAsDoneCopy = shouldShowMarkAsDone({
+const shouldShowMarkAsDoneCopy = shouldShowMarkAsDone({
         policy: rowPolicy ?? liveTransactionItem.policy,
         report: liveTransactionItem.report,
         isTrackIntentUser,
     });
+    const liveTransaction = transaction ?? transactionItem;
+    const customUnitRateID = isDistanceRequest(liveTransaction) ? liveTransaction.comment?.customUnit?.customUnitRateID : undefined;
+    const shouldLookupDistancePolicy = !!customUnitRateID && !getDistanceRateCustomUnitRate(policyForViolations, customUnitRateID);
+    const distanceOriginalPolicy = useDistanceRateOriginalPolicy(customUnitRateID, shouldLookupDistancePolicy);
 
     const onyxViolations = (transactionViolationsForRow ?? []).filter(
         (violation: TransactionViolation) =>
@@ -202,7 +209,9 @@ function TransactionListItemInner<TItem extends ListItem>({
         isInvoice,
     );
 
-    const transactionViolations = mergeProhibitedViolations(attendeeOnyxViolations);
+    const rateOnyxViolations = syncCustomUnitOutOfPolicyViolation(attendeeOnyxViolations, liveTransaction, policyForViolations, distanceOriginalPolicy);
+
+    const transactionViolations = mergeProhibitedViolations(rateOnyxViolations);
 
     const {isDelegateAccessRestricted} = useDelegateNoAccessState();
     const {showDelegateNoAccessModal} = useDelegateNoAccessActions();

--- a/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem/index.tsx
@@ -179,7 +179,7 @@ function TransactionListItemInner<TItem extends ListItem>({
     const policyForViolations = parentPolicy ?? snapshotPolicy;
     const rowPolicy = parentPolicy || snapshotPolicy.id || transactionItem.policy ? {...transactionItem.policy, ...snapshotPolicy, ...parentPolicy} : undefined;
     const reportForViolations = parentReport ?? snapshotReport;
-const shouldShowMarkAsDoneCopy = shouldShowMarkAsDone({
+    const shouldShowMarkAsDoneCopy = shouldShowMarkAsDone({
         policy: rowPolicy ?? liveTransactionItem.policy,
         report: liveTransactionItem.report,
         isTrackIntentUser,

--- a/src/hooks/useTransactionViolations.ts
+++ b/src/hooks/useTransactionViolations.ts
@@ -1,7 +1,7 @@
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getDistanceRateCustomUnitRate} from '@libs/PolicyUtils';
 import {getVisibleTransactionViolations, isDistanceRequest} from '@libs/TransactionUtils';
-import {syncCustomUnitRateOutOfDateRangeViolation} from '@libs/Violations/ViolationsUtils';
+import {syncCustomUnitOutOfPolicyViolation, syncCustomUnitRateOutOfDateRangeViolation} from '@libs/Violations/ViolationsUtils';
 
 import ONYXKEYS from '@src/ONYXKEYS';
 import {personalDetailsLoginSelector} from '@src/selectors/PersonalDetails';
@@ -29,7 +29,9 @@ function useTransactionViolations(transactionID?: string, shouldShowRterForSettl
     const currentUserDetails = useCurrentUserPersonalDetails();
 
     return useMemo(() => {
-        const syncedViolations = syncCustomUnitRateOutOfDateRangeViolation(transactionViolations, transaction, policy);
+        const syncedDateRangeViolations = syncCustomUnitRateOutOfDateRangeViolation(transactionViolations, transaction, policy);
+        // `policy` already prefers distanceOriginalPolicy when the report policy lacks the rate.
+        const syncedViolations = syncCustomUnitOutOfPolicyViolation(syncedDateRangeViolations, transaction, policy);
 
         return getVisibleTransactionViolations(
             transaction,

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -453,6 +453,68 @@ function syncCustomUnitRateOutOfDateRangeViolation(violations: TransactionViolat
     );
 }
 
+/**
+ * Syncs the customUnitOutOfPolicy violation with the current policy rate enabled state.
+ * Mirrors syncCustomUnitRateOutOfDateRangeViolation — keeps inbox/Spend previews in sync when
+ * a workspace rate is disabled without waiting for Onyx to be recomputed.
+ */
+function syncCustomUnitOutOfPolicyViolation(
+    violations: TransactionViolation[],
+    transaction: OnyxEntry<Transaction>,
+    policy: OnyxEntry<Policy>,
+    distanceOriginalPolicy?: OnyxEntry<Policy>,
+): TransactionViolation[] {
+    const isPerDiem = !!transaction && TransactionUtils.isPerDiemRequest(transaction);
+    if (!transaction || (!TransactionUtils.isDistanceRequest(transaction) && !isPerDiem)) {
+        return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
+    }
+
+    // Per-diem customUnitOutOfPolicy is owned by the Onyx pipeline; leave it untouched.
+    if (isPerDiem) {
+        return violations;
+    }
+
+    const customUnitRateID = transaction.comment?.customUnit?.customUnitRateID;
+    if (!customUnitRateID) {
+        return violations;
+    }
+
+    const isTransactionOnPolicyExpenseChat = transaction.participants?.some((participant) => participant?.isPolicyExpenseChat);
+    if (TransactionUtils.isCustomUnitRateIDForP2P(transaction) && !isTransactionOnPolicyExpenseChat) {
+        return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
+    }
+
+    let policyForCustomUnitRate = policy;
+    if (!getDistanceRateCustomUnitRate(policy, customUnitRateID)) {
+        policyForCustomUnitRate = distanceOriginalPolicy ?? policy;
+    }
+
+    const customRate = getDistanceRateCustomUnitRate(policyForCustomUnitRate, customUnitRateID);
+    const hasViolation = violations.some((violation) => violation.name === CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
+    const isRateDisabled = !!customRate && customRate.enabled === false;
+
+    if (!isRateDisabled && !hasViolation) {
+        return violations;
+    }
+
+    if (!isRateDisabled && hasViolation) {
+        return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
+    }
+
+    if (isRateDisabled && !hasViolation) {
+        return [
+            ...violations,
+            {
+                name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                type: CONST.VIOLATION_TYPES.VIOLATION,
+                showInReview: true,
+            },
+        ];
+    }
+
+    return violations;
+}
+
 const ViolationsUtils = {
     /**
      * Checks a transaction for policy violations and returns an object with Onyx method, key and updated transaction
@@ -1212,6 +1274,6 @@ const ViolationsUtils = {
     },
 };
 
-export {getIsViolationFixed, isHardViolationOrRateDateWarning, syncCustomUnitRateOutOfDateRangeViolation};
+export {getIsViolationFixed, isHardViolationOrRateDateWarning, syncCustomUnitOutOfPolicyViolation, syncCustomUnitRateOutOfDateRangeViolation};
 export default ViolationsUtils;
 export {filterReceiptViolations};

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -455,8 +455,8 @@ function syncCustomUnitRateOutOfDateRangeViolation(violations: TransactionViolat
 
 /**
  * Syncs the customUnitOutOfPolicy violation with the current policy rate enabled state.
- * Mirrors syncCustomUnitRateOutOfDateRangeViolation — keeps inbox/Spend previews in sync when
- * a workspace rate is disabled without waiting for Onyx to be recomputed.
+ * This mirrors syncCustomUnitRateOutOfDateRangeViolation. It keeps Inbox and Spend previews in sync
+ * when a workspace rate is disabled, without waiting for Onyx to recompute.
  */
 function syncCustomUnitOutOfPolicyViolation(
     violations: TransactionViolation[],
@@ -469,7 +469,7 @@ function syncCustomUnitOutOfPolicyViolation(
         return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
     }
 
-    // Per-diem customUnitOutOfPolicy is owned by the Onyx pipeline; leave it untouched.
+    // Per-diem customUnitOutOfPolicy is owned by the Onyx pipeline. Leave it untouched.
     if (isPerDiem) {
         return violations;
     }
@@ -490,29 +490,30 @@ function syncCustomUnitOutOfPolicyViolation(
     }
 
     const customRate = getDistanceRateCustomUnitRate(policyForCustomUnitRate, customUnitRateID);
-    const hasViolation = violations.some((violation) => violation.name === CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
-    const isRateDisabled = !!customRate && customRate.enabled === false;
 
-    if (!isRateDisabled && !hasViolation) {
+    // The rate does not resolve to a workspace rate, which happens when the rate was deleted or when a
+    // Track expense still holds its P2P rate on a workspace chat. Onyx owns the violation in those cases,
+    // so leave it exactly as it is rather than inventing or dropping one here.
+    if (!customRate) {
         return violations;
     }
 
-    if (!isRateDisabled && hasViolation) {
-        return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
+    const hasViolation = violations.some((violation) => violation.name === CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY);
+
+    if (customRate.enabled === false) {
+        return hasViolation
+            ? violations
+            : [
+                  ...violations,
+                  {
+                      name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                      type: CONST.VIOLATION_TYPES.VIOLATION,
+                      showInReview: true,
+                  },
+              ];
     }
 
-    if (isRateDisabled && !hasViolation) {
-        return [
-            ...violations,
-            {
-                name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
-                type: CONST.VIOLATION_TYPES.VIOLATION,
-                showInReview: true,
-            },
-        ];
-    }
-
-    return violations;
+    return hasViolation ? violations.filter((violation) => violation.name !== CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY) : violations;
 }
 
 const ViolationsUtils = {

--- a/src/libs/actions/Policy/DistanceRate.ts
+++ b/src/libs/actions/Policy/DistanceRate.ts
@@ -1,3 +1,5 @@
+import type PolicyData from '@hooks/usePolicyData/types';
+
 import * as API from '@libs/API';
 import type {
     CreatePolicyDistanceRateParams,
@@ -19,12 +21,13 @@ import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Log from '@libs/Log';
 import {buildOnyxDataForPolicyDistanceRateUpdates, getExpectedUnitForCurrency} from '@libs/PolicyDistanceRatesUtils';
 import {goBackWhenEnableFeature, removePendingFieldsFromCustomUnit} from '@libs/PolicyUtils';
+import {pushTransactionViolationsOnyxData} from '@libs/ReportUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {GovernmentMileageRate, TransactionViolation} from '@src/types/onyx';
 import type {ErrorFields} from '@src/types/onyx/OnyxCommon';
-import type {CommuterExclusions, CustomUnit, Rate} from '@src/types/onyx/Policy';
+import type {CommuterExclusions, CustomUnit, Policy, Rate} from '@src/types/onyx/Policy';
 import type {OnyxData} from '@src/types/onyx/Request';
 
 import type {NullishDeep, OnyxCollection, OnyxUpdate} from 'react-native-onyx';
@@ -343,7 +346,7 @@ function updatePolicyDistanceRate(policyID: string, customUnit: CustomUnit, rate
     API.write(WRITE_COMMANDS.UPDATE_POLICY_DISTANCE_RATE, params, {optimisticData, successData, failureData});
 }
 
-function setPolicyDistanceRatesEnabled(policyID: string, customUnit: CustomUnit, customUnitRates: Rate[]) {
+function setPolicyDistanceRatesEnabled(policyID: string, customUnit: CustomUnit, customUnitRates: Rate[], policyData: PolicyData) {
     const currentRates = customUnit.rates;
     const optimisticRates: Record<string, NullishDeep<Rate>> = {};
     const successRates: Record<string, NullishDeep<Rate>> = {};
@@ -363,47 +366,68 @@ function setPolicyDistanceRatesEnabled(policyID: string, customUnit: CustomUnit,
         }
     }
 
-    const optimisticData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.POLICY>> = [
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-            value: {
-                customUnits: {
-                    [customUnit.customUnitID]: {
-                        rates: optimisticRates,
+    const onyxData: OnyxData<typeof ONYXKEYS.COLLECTION.POLICY | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS> = {
+        optimisticData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                value: {
+                    customUnits: {
+                        [customUnit.customUnitID]: {
+                            rates: optimisticRates,
+                        },
                     },
                 },
             },
-        },
-    ];
+        ],
+        successData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                value: {
+                    customUnits: {
+                        [customUnit.customUnitID]: {
+                            rates: successRates,
+                        },
+                    },
+                },
+            },
+        ],
+        failureData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                value: {
+                    customUnits: {
+                        [customUnit.customUnitID]: {
+                            rates: failureRates,
+                        },
+                    },
+                },
+            },
+        ],
+    };
 
-    const successData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.POLICY>> = [
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-            value: {
-                customUnits: {
-                    [customUnit.customUnitID]: {
-                        rates: successRates,
-                    },
-                },
-            },
-        },
-    ];
+    const existingCustomUnit = policyData.policy?.customUnits?.[customUnit.customUnitID];
+    const mergedRates = {...existingCustomUnit?.rates};
+    for (const rate of customUnitRates) {
+        mergedRates[rate.customUnitRateID] = {
+            ...(mergedRates[rate.customUnitRateID] ?? {}),
+            ...rate,
+        };
+    }
 
-    const failureData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.POLICY>> = [
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-            value: {
-                customUnits: {
-                    [customUnit.customUnitID]: {
-                        rates: failureRates,
-                    },
-                },
+    const policyOptimisticUpdate: Partial<Policy> = {
+        customUnits: {
+            ...policyData.policy?.customUnits,
+            [customUnit.customUnitID]: {
+                ...existingCustomUnit,
+                rates: mergedRates,
             },
         },
-    ];
+    };
+
+    pushTransactionViolationsOnyxData(onyxData, policyData, policyOptimisticUpdate);
 
     const params: SetPolicyDistanceRatesEnabledParams = {
         policyID,
@@ -411,7 +435,7 @@ function setPolicyDistanceRatesEnabled(policyID: string, customUnit: CustomUnit,
         customUnitRateArray: JSON.stringify(prepareCustomUnitRatesArray(customUnitRates)),
     };
 
-    API.write(WRITE_COMMANDS.SET_POLICY_DISTANCE_RATES_ENABLED, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.SET_POLICY_DISTANCE_RATES_ENABLED, params, onyxData);
 }
 
 function deletePolicyDistanceRates(

--- a/src/libs/actions/Policy/DistanceRate.ts
+++ b/src/libs/actions/Policy/DistanceRate.ts
@@ -25,9 +25,9 @@ import {pushTransactionViolationsOnyxData} from '@libs/ReportUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {GovernmentMileageRate, TransactionViolation} from '@src/types/onyx';
+import type {GovernmentMileageRate, Policy, TransactionViolation} from '@src/types/onyx';
 import type {ErrorFields} from '@src/types/onyx/OnyxCommon';
-import type {CommuterExclusions, CustomUnit, Policy, Rate} from '@src/types/onyx/Policy';
+import type {CommuterExclusions, CustomUnit, Rate} from '@src/types/onyx/Policy';
 import type {OnyxData} from '@src/types/onyx/Request';
 
 import type {NullishDeep, OnyxCollection, OnyxUpdate} from 'react-native-onyx';
@@ -421,7 +421,7 @@ function setPolicyDistanceRatesEnabled(policyID: string, customUnit: CustomUnit,
         customUnits: {
             ...policyData.policy?.customUnits,
             [customUnit.customUnitID]: {
-                ...existingCustomUnit,
+                ...customUnit,
                 rates: mergedRates,
             },
         },

--- a/src/pages/workspace/distanceRates/PolicyDistanceRateDetailsPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRateDetailsPage.tsx
@@ -12,6 +12,7 @@ import useConfirmModal from '@hooks/useConfirmModal';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
+import usePolicyData from '@hooks/usePolicyData';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useTransactionViolation from '@hooks/useTransactionViolation';
@@ -50,6 +51,7 @@ function PolicyDistanceRateDetailsPage({route}: PolicyDistanceRateDetailsPagePro
     const {showConfirmModal} = useConfirmModal();
     const policyID = route.params.policyID;
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${route.params.policyID}`);
+    const policyData = usePolicyData(policyID);
     const {canWrite: canWriteDistanceRates, withReadOnlyFallback} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.DISTANCE_RATES);
     const rateID = route.params.rateID;
     const customUnit = useMemo(() => getDistanceRateCustomUnit(policy), [policy]);
@@ -145,7 +147,7 @@ function PolicyDistanceRateDetailsPage({route}: PolicyDistanceRateDetailsPagePro
 
     const toggleRate = () => {
         if (!rate?.enabled || canDisableOrDeleteRate) {
-            setPolicyDistanceRatesEnabled(policyID, customUnit, [{...rate, enabled: !rate?.enabled}]);
+            setPolicyDistanceRatesEnabled(policyID, customUnit, [{...rate, enabled: !rate?.enabled}], policyData);
         } else {
             showWarningModal();
         }

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -17,6 +17,7 @@ import useMobileSelectionMode from '@hooks/useMobileSelectionMode';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePolicy from '@hooks/usePolicy';
+import usePolicyData from '@hooks/usePolicyData';
 import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSearchBackPress from '@hooks/useSearchBackPress';
@@ -68,6 +69,7 @@ function PolicyDistanceRatesPage({
     const {translate} = useLocalize();
     const {showConfirmModal} = useConfirmModal();
     const policy = usePolicy(policyID);
+    const policyData = usePolicyData(policyID);
     useWorkspaceDocumentTitle(policy?.name, 'workspace.common.distanceRates');
     const isMobileSelectionModeEnabled = useMobileSelectionMode();
     const {canWrite: canWriteDistanceRates, showReadOnlyModal} = usePolicyFeatureWriteAccess(policy, CONST.POLICY.POLICY_FEATURE.DISTANCE_RATES);
@@ -206,12 +208,12 @@ function PolicyDistanceRatesPage({
             }
             const rate = customUnit?.rates?.[rateID];
             if (!rate?.enabled || canDisableOrDeleteRate(rateID)) {
-                setPolicyDistanceRatesEnabled(policyID, customUnit, [{...rate, enabled: value}]);
+                setPolicyDistanceRatesEnabled(policyID, customUnit, [{...rate, enabled: value}], policyData);
             } else {
                 showWarningModal();
             }
         },
-        [canDisableOrDeleteRate, canWriteDistanceRates, customUnit, policyID, showReadOnlyModal, showWarningModal],
+        [canDisableOrDeleteRate, canWriteDistanceRates, customUnit, policyData, policyID, showReadOnlyModal, showWarningModal],
     );
 
     const unitTranslation = translate(`common.${customUnit?.attributes?.unit ?? CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES}`);
@@ -236,6 +238,7 @@ function PolicyDistanceRatesPage({
                 .map((rateID) => selectableRates[rateID])
                 .filter((rate) => rate.enabled)
                 .map((rate) => ({...rate, enabled: false})),
+            policyData,
         );
         setSelectedDistanceRates([]);
     };
@@ -252,6 +255,7 @@ function PolicyDistanceRatesPage({
                 .map((rateID) => selectableRates[rateID])
                 .filter((rate) => !rate.enabled)
                 .map((rate) => ({...rate, enabled: true})),
+            policyData,
         );
         setSelectedDistanceRates([]);
     };

--- a/tests/unit/DistanceRateTest.ts
+++ b/tests/unit/DistanceRateTest.ts
@@ -1,15 +1,18 @@
-import {deletePolicyDistanceRates, enablePolicyDistanceRates, setWorkspaceDistanceAutoUpdate} from '@libs/actions/Policy/DistanceRate';
+import type PolicyData from '@hooks/usePolicyData/types';
+
+import {deletePolicyDistanceRates, enablePolicyDistanceRates, setPolicyDistanceRatesEnabled, setWorkspaceDistanceAutoUpdate} from '@libs/actions/Policy/DistanceRate';
 import {pause, resetQueue} from '@libs/Network/SequentialQueue';
 import {isGovernmentRateUnmodified} from '@libs/PolicyDistanceRatesUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {GovernmentMileageRate, Policy, Transaction, TransactionViolations} from '@src/types/onyx';
+import type {GovernmentMileageRate, Policy, Report, Transaction, TransactionViolations} from '@src/types/onyx';
 import type {CustomUnit, Rate, Unit} from '@src/types/onyx/Policy';
 
 import Onyx from 'react-native-onyx';
 
 import createRandomPolicy from '../utils/collections/policies';
+import {createRandomReport} from '../utils/collections/reports';
 import createRandomTransaction from '../utils/collections/transaction';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
@@ -97,6 +100,173 @@ describe('DistanceRate', () => {
                     {name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY, showInReview: true, type: CONST.VIOLATION_TYPES.VIOLATION},
                 ],
             });
+        });
+    });
+
+    describe('setPolicyDistanceRatesEnabled', () => {
+        it('should write customUnitOutOfPolicy into TRANSACTION_VIOLATIONS when disabling an in-use rate', async () => {
+            const customUnitID = '5A55C2B68DDCB';
+            const customUnitRateID = '7255CA72C7E7B';
+            const policy: Policy = {
+                ...createRandomPolicy(3),
+                areDistanceRatesEnabled: true,
+                customUnits: {
+                    [customUnitID]: {
+                        attributes: {
+                            unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
+                        },
+                        customUnitID,
+                        defaultCategory: 'Car',
+                        enabled: true,
+                        name: 'Distance',
+                        rates: {
+                            [customUnitRateID]: {
+                                currency: 'USD',
+                                customUnitRateID,
+                                enabled: true,
+                                name: 'Default Rate',
+                                rate: 70,
+                                subRates: [],
+                            },
+                        },
+                    },
+                },
+            };
+            const report: Report = {
+                ...createRandomReport(1),
+                policyID: policy.id,
+                type: CONST.REPORT.TYPE.IOU,
+            };
+            const transaction: Transaction = {
+                ...createRandomTransaction(1),
+                reportID: report.reportID,
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE,
+                comment: {
+                    customUnit: {
+                        customUnitID,
+                        customUnitRateID,
+                    },
+                },
+            };
+            const policyData: PolicyData = {
+                policy,
+                categories: {},
+                tags: {},
+                reports: [report],
+                transactionsAndViolations: {
+                    [report.reportID]: {
+                        transactions: {
+                            [transaction.transactionID]: transaction,
+                        },
+                        violations: {},
+                    },
+                },
+            };
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+
+            if (policy.customUnits) {
+                setPolicyDistanceRatesEnabled(policy.id, policy.customUnits[customUnitID], [{...policy.customUnits[customUnitID].rates[customUnitRateID], enabled: false}], policyData);
+            }
+            await waitForBatchedUpdates();
+
+            const transactionViolations = await new Promise<Record<string, TransactionViolations | undefined>>((resolve) => {
+                Onyx.connect({
+                    key: ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS,
+                    callback: resolve,
+                });
+            });
+
+            expect(transactionViolations[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction.transactionID}`]).toEqual(
+                expect.arrayContaining([expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY, type: CONST.VIOLATION_TYPES.VIOLATION})]),
+            );
+        });
+
+        it('should clear customUnitOutOfPolicy when re-enabling a previously disabled in-use rate', async () => {
+            const customUnitID = '5A55C2B68DDCB';
+            const customUnitRateID = '7255CA72C7E7B';
+            const policy: Policy = {
+                ...createRandomPolicy(4),
+                areDistanceRatesEnabled: true,
+                customUnits: {
+                    [customUnitID]: {
+                        attributes: {
+                            unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
+                        },
+                        customUnitID,
+                        defaultCategory: 'Car',
+                        enabled: true,
+                        name: 'Distance',
+                        rates: {
+                            [customUnitRateID]: {
+                                currency: 'USD',
+                                customUnitRateID,
+                                enabled: false,
+                                name: 'Default Rate',
+                                rate: 70,
+                                subRates: [],
+                            },
+                        },
+                    },
+                },
+            };
+            const report: Report = {
+                ...createRandomReport(2),
+                policyID: policy.id,
+                type: CONST.REPORT.TYPE.IOU,
+            };
+            const transaction: Transaction = {
+                ...createRandomTransaction(2),
+                reportID: report.reportID,
+                iouRequestType: CONST.IOU.REQUEST_TYPE.DISTANCE,
+                comment: {
+                    customUnit: {
+                        customUnitID,
+                        customUnitRateID,
+                    },
+                },
+            };
+            const policyData: PolicyData = {
+                policy,
+                categories: {},
+                tags: {},
+                reports: [report],
+                transactionsAndViolations: {
+                    [report.reportID]: {
+                        transactions: {
+                            [transaction.transactionID]: transaction,
+                        },
+                        violations: {
+                            [`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction.transactionID}`]: [
+                                {name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY, showInReview: true, type: CONST.VIOLATION_TYPES.VIOLATION},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction.transactionID}`, [
+                {name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY, showInReview: true, type: CONST.VIOLATION_TYPES.VIOLATION},
+            ]);
+
+            if (policy.customUnits) {
+                setPolicyDistanceRatesEnabled(policy.id, policy.customUnits[customUnitID], [{...policy.customUnits[customUnitID].rates[customUnitRateID], enabled: true}], policyData);
+            }
+            await waitForBatchedUpdates();
+
+            const transactionViolations = await new Promise<Record<string, TransactionViolations | undefined>>((resolve) => {
+                Onyx.connect({
+                    key: ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS,
+                    callback: resolve,
+                });
+            });
+
+            expect(transactionViolations[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction.transactionID}`] ?? []).not.toEqual(
+                expect.arrayContaining([expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY})]),
+            );
         });
     });
 

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -2,7 +2,13 @@ import {beforeEach} from '@jest/globals';
 
 import Permissions from '@libs/Permissions';
 import {getTransactionViolations, hasWarningTypeViolation, isViolationDismissed} from '@libs/TransactionUtils';
-import ViolationsUtils, {filterReceiptViolations, getIsViolationFixed, isHardViolationOrRateDateWarning, syncCustomUnitRateOutOfDateRangeViolation} from '@libs/Violations/ViolationsUtils';
+import ViolationsUtils, {
+    filterReceiptViolations,
+    getIsViolationFixed,
+    isHardViolationOrRateDateWarning,
+    syncCustomUnitOutOfPolicyViolation,
+    syncCustomUnitRateOutOfDateRangeViolation,
+} from '@libs/Violations/ViolationsUtils';
 
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
@@ -730,6 +736,135 @@ describe('getViolationsOnyxData', () => {
                     },
                 }),
             );
+        });
+    });
+
+    describe('syncCustomUnitOutOfPolicyViolation', () => {
+        const customUnitRateID = 'rate_id';
+
+        beforeEach(() => {
+            transactionViolations = [];
+            transaction.iouRequestType = CONST.IOU.REQUEST_TYPE.DISTANCE;
+            transaction.comment = {
+                ...transaction.comment,
+                customUnit: {
+                    ...(transaction?.comment?.customUnit ?? {}),
+                    customUnitRateID,
+                },
+            };
+            policy.customUnits = {
+                unitId: {
+                    attributes: {unit: 'mi'},
+                    customUnitID: 'unitId',
+                    defaultCategory: 'Car',
+                    enabled: true,
+                    name: 'Distance',
+                    rates: {
+                        [customUnitRateID]: {
+                            currency: 'USD',
+                            customUnitRateID,
+                            enabled: true,
+                            name: 'Default Rate',
+                            rate: 65.5,
+                        },
+                    },
+                },
+            };
+        });
+
+        it('should add the customUnitOutOfPolicy violation when the distance rate is disabled', () => {
+            const rate = policy.customUnits?.unitId.rates[customUnitRateID];
+            if (rate) {
+                rate.enabled = false;
+            }
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).toContainEqual(
+                expect.objectContaining({
+                    name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                }),
+            );
+        });
+
+        it('should remove the customUnitOutOfPolicy violation when the distance rate is re-enabled', () => {
+            transactionViolations = [
+                {
+                    name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                },
+            ];
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).not.toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
+        });
+
+        it('should leave per-diem customUnitOutOfPolicy violations untouched', () => {
+            transaction.iouRequestType = CONST.IOU.REQUEST_TYPE.PER_DIEM;
+            transaction.comment = {
+                ...transaction.comment,
+                customUnit: {
+                    ...(transaction?.comment?.customUnit ?? {}),
+                    name: CONST.CUSTOM_UNITS.NAME_PER_DIEM_INTERNATIONAL,
+                    customUnitRateID: 'per_diem_rate_id',
+                },
+            };
+            transactionViolations = [
+                {
+                    name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                },
+            ];
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
+        });
+
+        it('should strip customUnitOutOfPolicy for non-distance non-per-diem transactions', () => {
+            transaction.iouRequestType = CONST.IOU.REQUEST_TYPE.MANUAL;
+            transaction.comment = {...transaction.comment, customUnit: undefined};
+            transactionViolations = [
+                {
+                    name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                },
+            ];
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).not.toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
+        });
+
+        it('should not add customUnitOutOfPolicy for a P2P self-DM rate', () => {
+            transaction.comment = {
+                ...transaction.comment,
+                customUnit: {
+                    ...(transaction?.comment?.customUnit ?? {}),
+                    customUnitRateID: CONST.CUSTOM_UNITS.FAKE_P2P_ID,
+                },
+            };
+            transaction.participants = [{accountID: 1, login: 'test@expensify.com'}];
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).not.toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
+        });
+
+        it('should not add customUnitOutOfPolicy when the rate cannot be resolved (Track unresolvable-rate case)', () => {
+            // Self-DM / Track distance expenses often have no resolvable workspace rate.
+            // Sync must not invent a false "Rate not valid" violation in that case.
+            policy.customUnits = {};
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).not.toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
         });
     });
 

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -866,6 +866,44 @@ describe('getViolationsOnyxData', () => {
 
             expect(result).not.toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
         });
+
+        it('should preserve customUnitOutOfPolicy when the workspace rate was deleted', () => {
+            transactionViolations = [
+                {
+                    name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                },
+            ];
+            transaction.participants = [{accountID: 1, login: 'admin@expensify.com', isPolicyExpenseChat: true}];
+            policy.customUnits = {};
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
+        });
+
+        it('should preserve customUnitOutOfPolicy for FAKE_P2P_ID on a policy expense chat', () => {
+            transactionViolations = [
+                {
+                    name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                },
+            ];
+            transaction.comment = {
+                ...transaction.comment,
+                customUnit: {
+                    ...(transaction?.comment?.customUnit ?? {}),
+                    customUnitRateID: CONST.CUSTOM_UNITS.FAKE_P2P_ID,
+                },
+            };
+            transaction.participants = [{accountID: 1, login: 'admin@expensify.com', isPolicyExpenseChat: true}];
+
+            const result = syncCustomUnitOutOfPolicyViolation(transactionViolations, transaction, policy);
+
+            expect(result).toContainEqual(expect.objectContaining({name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY}));
+        });
     });
 
     describe('per diem rate validation', () => {

--- a/tests/unit/useTransactionViolationsTest.ts
+++ b/tests/unit/useTransactionViolationsTest.ts
@@ -21,6 +21,7 @@ jest.mock('@libs/Violations/ViolationsUtils', () => {
     return {
         ...actual,
         syncCustomUnitRateOutOfDateRangeViolation: (violations: TransactionViolation[]) => violations,
+        syncCustomUnitOutOfPolicyViolation: (violations: TransactionViolation[]) => violations,
     };
 });
 


### PR DESCRIPTION
Track distance expenses should surface the same custom unit rate violation as submit expenses on expense details, inbox previews, and Spend when a workspace rate is disabled.

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
When a workspace distance rate is disabled, submit expenses already show a **Rate not valid** violation on expense details, Inbox, and Spend. Track distance expenses did not, because:
1. `MoneyRequestView` suppressed `customUnitOutOfPolicy` for Track expenses.
2. Disabling a distance rate did not push optimistic violations to Onyx (unlike category/tag toggles).
3. Inbox/Spend previews had no render-time sync for disabled rates (unlike the existing date-range rate sync).

This PR mirrors the existing category/tag/tax violation path:
- Show the violation on expense details for Track when the selected rate is disabled (while keeping the self-DM no-rate case exempt).
- Push `customUnitOutOfPolicy` to Onyx when disabling/re-enabling rates via `setPolicyDistanceRatesEnabled`.
- Add `syncCustomUnitOutOfPolicyViolation` for Inbox previews and Spend rows.

### Fixed Issues
$ https://github.com/Expensify/App/issues/93414
PROPOSAL: https://github.com/Expensify/App/issues/93414#issuecomment-4815784135

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Create a workspace with multiple distance rates and submit a **Track distance** expense using Rate A.
2. Disable Rate A in workspace settings > Distance rates.
3. Open the expense details and confirm **Rate not valid** appears under the Rate field.
4. Open the expense from **Inbox** and confirm the preview shows the rate violation.
5. Open the expense from **Spend/Search** and confirm the row shows the rate violation.
6. Re-enable Rate A and confirm the violation clears on expense details, Inbox, and Spend.
7. Create a **self-DM Track distance** expense with no workspace rate and confirm **Rate not valid** does **not** appear.
8. Confirm a **per-diem** expense with an invalid rate still shows its existing violation.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go offline after disabling a workspace distance rate.
2. Open affected Track distance expenses and confirm **Rate not valid** still appears on expense details, Inbox, and Spend.

### QA Steps
1. Create a workspace with multiple distance rates and submit a **Track distance** expense using Rate A.
2. Disable Rate A in workspace settings > Distance rates.
3. Open the expense details and confirm **Rate not valid** appears under the Rate field.
4. Open the expense from **Inbox** and confirm the preview shows the rate violation.
5. Open the expense from **Spend/Search** and confirm the row shows the rate violation.
6. Re-enable Rate A and confirm the violation clears on expense details, Inbox, and Spend.
7. Create a **self-DM Track distance** expense with no workspace rate and confirm **Rate not valid** does **not** appear.
8. Confirm a **per-diem** expense with an invalid rate still shows its existing violation.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/0ebd7b03-eb84-47a4-aa40-c28ff557ce5a



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/8db656f1-8423-4d15-a0fa-b511be94d978



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/f1ff094e-edb0-466e-b20d-9c16845a2f7b




</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/9b748b39-5811-4763-bbfc-33ce667f48c8



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/7c57013c-dde0-492b-9d40-46ace583df05

</details>