### PR TITLE
[No QA] Consolidate TypeScript projects under a root project with subproject references

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -15,7 +15,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'patches/**'
-      - 'tsconfig.json'
+      - '**/tsconfig*.json'
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('{0}-{1}', github.ref, github.sha) || github.ref }}-knip

--- a/.github/workflows/validateGithubActions.yml
+++ b/.github/workflows/validateGithubActions.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
-    paths: ['.github/**', 'scripts/**', 'package.json', 'package-lock.json', 'tsconfig.json']
+    paths: ['.github/**', 'scripts/**', 'package.json', 'package-lock.json', '**/tsconfig*.json']
 
 jobs:
   verify:

--- a/config/eslint/eslint.config.mjs
+++ b/config/eslint/eslint.config.mjs
@@ -304,7 +304,9 @@ const config = defineConfig([
 
         languageOptions: {
             parserOptions: {
-                project: path.resolve(projectRoot, 'tsconfig.json'),
+                // The app project, not the root solution: the solution owns no files, so typed linting
+                // has nothing to resolve against there.
+                project: path.resolve(projectRoot, 'tsconfig.app.json'),
                 projectService: false,
             },
 
@@ -746,7 +748,10 @@ const config = defineConfig([
     },
 
     {
-        files: ['scripts/**/*.ts', 'tests/tooling/**/*.ts', 'server/{libs,plugins,stubs}/**/*.{ts,tsx}', 'evals/**/*.ts'],
+        // `prompts` is not Bun code, but the Bun program is the one that owns it: `scripts`,
+        // `evals` and `tests/tooling` are its callers. (The Node program lists it too, for the
+        // Proposal Police GitHub Action.)
+        files: ['scripts/**/*.ts', 'tests/tooling/**/*.ts', 'server/{libs,plugins,stubs}/**/*.{ts,tsx}', 'evals/**/*.ts', 'prompts/**/*.ts'],
         languageOptions: {
             parserOptions: {
                 project: path.resolve(projectRoot, 'tsconfig.bun.json'),

--- a/modules/ExpensifyNitroUtils/tsconfig.json
+++ b/modules/ExpensifyNitroUtils/tsconfig.json
@@ -1,6 +1,10 @@
 {
-    "extends": "../../tsconfig.json",
+    // The app project, not the root solution: the solution owns no compiler options.
+    "extends": "../../tsconfig.app.json",
     "compilerOptions": {
+        // Without this the app project's build info path is inherited and this module would write
+        // over it.
+        "tsBuildInfoFile": "./tsconfig.ts7.tsbuildinfo",
         "outDir": "./lib"
     },
     "include": ["src/**/*"]

--- a/scripts/postInstall.sh
+++ b/scripts/postInstall.sh
@@ -33,5 +33,9 @@ bun scripts/applyPatches.ts
 
 # `@typescript/old` (pulled in by `@typescript/typescript6`) also ships a `tsc` bin.
 # npm's last-writer-wins linking can point `node_modules/.bin/tsc` at TypeScript 6.
-# Force the TypeScript 7 native compiler so a bare `npx tsc` matches `npm run typecheck`.
+# Force the TypeScript 7 native compiler, so `npx tsc` is the compiler `npm run typecheck` runs.
+#
+# It is not the same *command*: the root tsconfig.json is a solution that lists projects and owns no
+# files, and project mode does not follow `references`. `npx tsc` at the repo root therefore checks
+# nothing and exits 0. Use `npx tsc --build`, which walks the references, or `npm run typecheck`.
 ln -sfn ../typescript/bin/tsc "$ROOT_DIR/node_modules/.bin/tsc"

--- a/scripts/typecheck.ts
+++ b/scripts/typecheck.ts
@@ -3,13 +3,20 @@
 /**
  * Type-check the repo with the TypeScript 7 native compiler.
  *
- *   bun scripts/typecheck.ts              -> check every project CI gates on
+ *   bun scripts/typecheck.ts                   -> check every project the root solution references
  *   bun scripts/typecheck.ts tsconfig.bun.json -> check just the named project
  *
+ * The project list comes from the `references` in the root `tsconfig.json`, so a project joins CI by
+ * being referenced there and nowhere else.
+ *
  * Every project is checked even after one fails, so a single run reports every error in the repo.
+ * Projects are checked concurrently, which is why this fans out `tsc --build` per project instead of
+ * running `tsc --build tsconfig.json` once: build mode walks a solution sequentially.
  */
 import {$} from 'bun';
 import CLI from 'expensify-common/CLI';
+import {readdirSync} from 'fs';
+import path from 'path';
 
 const projectRoot = `${import.meta.dir}/..`;
 
@@ -18,8 +25,75 @@ const projectRoot = `${import.meta.dir}/..`;
 // Invoke that bin by path so a leftover `.bin/tsc` from `@typescript/old` cannot win.
 const tsc = `${projectRoot}/node_modules/typescript/bin/tsc`;
 
-/** TypeScript projects, relative to the repo root, that `npm run typecheck` and CI check. */
-const DEFAULT_PROJECTS = ['tsconfig.json', 'tsconfig.jest.json', 'tsconfig.bun.json', 'tsconfig.node.json', 'server/victory-chart-renderer/tsconfig.json'];
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+/** `Array.isArray` narrows to `any[]`, which loses the `unknown` we are trying to validate. */
+function isUnknownArray(value: unknown): value is unknown[] {
+    return Array.isArray(value);
+}
+
+/**
+ * Pull the `references[].path` list out of a `tsc --showConfig` payload.
+ *
+ * Every entry is validated rather than filtered: silently dropping a malformed reference would
+ * silently drop a project out of the typecheck gate.
+ */
+function readReferencePaths(config: unknown): string[] {
+    if (!isRecord(config) || !isUnknownArray(config.references)) {
+        throw new Error('tsconfig.json has no `references` array, so there is nothing to type-check.');
+    }
+    return config.references.map((reference, index) => {
+        if (!isRecord(reference) || typeof reference.path !== 'string' || reference.path === '') {
+            throw new Error(`tsconfig.json is malformed at references[${index}]: every reference needs a non-empty string "path".`);
+        }
+        return reference.path;
+    });
+}
+
+/**
+ * The projects the root solution references, relative to the repo root.
+ *
+ * `--showConfig` is how we read them: the root config carries comments, so it is not plain JSON, and
+ * TypeScript 7 does not yet expose a compiler API we could parse it with.
+ */
+async function getReferencedProjects(): Promise<string[]> {
+    const result = await $`${tsc} -p tsconfig.json --showConfig`.cwd(projectRoot).quiet().nothrow();
+    if (result.exitCode !== 0) {
+        throw new Error(`Could not read the projects referenced by tsconfig.json:\n${result.stderr.toString()}`);
+    }
+    const references = readReferencePaths(JSON.parse(result.stdout.toString()));
+    if (references.length === 0) {
+        throw new Error('tsconfig.json references no projects, so there is nothing to type-check.');
+    }
+    assertEveryRootProjectIsReferenced(references);
+    return references;
+}
+
+/**
+ * Fail loudly when a root-level project is missing from `tsconfig.json`'s `references`.
+ *
+ * `tsc --showConfig` drops a malformed reference (say, a misspelled `path` key) without reporting
+ * anything, which would quietly take that project out of the typecheck gate. This turns both that
+ * and "added a project but forgot to reference it" into an error.
+ */
+function assertEveryRootProjectIsReferenced(references: string[]) {
+    const referenced = new Set(references.map((reference) => path.basename(reference)));
+    const unreferenced = readdirSync(projectRoot)
+        // `tsconfig.base.json` holds shared options rather than files, so it is not a project.
+        .filter((entry) => /^tsconfig\..+\.json$/.test(entry) && entry !== 'tsconfig.base.json')
+        .filter((entry) => !referenced.has(entry));
+    if (unreferenced.length > 0) {
+        throw new Error(`These projects are not referenced by tsconfig.json, so nothing type-checks them: ${unreferenced.join(', ')}`);
+    }
+}
+
+/** Type-check one project. Build mode skips it entirely when its build info file is already current. */
+async function typecheckProject(project: string) {
+    const result = await $`${tsc} --build ${project}`.cwd(projectRoot).quiet().nothrow();
+    return {project, result};
+}
 
 const cli = new CLI({
     positionalArgs: [
@@ -27,36 +101,27 @@ const cli = new CLI({
             name: 'projects',
             description: 'tsconfig paths to type-check, relative to the repo root',
             variadic: true,
-            default: DEFAULT_PROJECTS,
+            default: [],
         },
     ],
 });
 
-const {projects} = cli.positionalArgs;
+const projects = cli.positionalArgs.projects.length > 0 ? cli.positionalArgs.projects : await getReferencedProjects();
 
-// All projects are checked concurrently.
-const results = await Promise.all(
-    projects.map(async (project) => {
-        const tsconfig = project.endsWith('.json') ? project : `${project}/tsconfig.json`;
-
-        // The build info file lets repeat runs skip unchanged projects. It is named apart from the
-        // `tsconfig.tsbuildinfo` that `incremental` defaults to so that running TypeScript 7 by hand in
-        // the same worktree can't feed it a build info file written by a different compiler.
-        const tsBuildInfoFile = `${tsconfig.replace(/\.json$/, '')}.ts7.tsbuildinfo`;
-        const result = await $`${tsc} --noEmit --incremental -p ${tsconfig} --tsBuildInfoFile ${tsBuildInfoFile}`.cwd(projectRoot).quiet().nothrow();
-        return {tsconfig, result};
-    }),
-);
+// All projects are checked concurrently. Projects share source files but each writes its own build
+// info file (`tsBuildInfoFile`), so there is nothing for concurrent builds to race over.
+// `--noEmit` lives in the configs because build mode rejects it as a flag.
+const results = await Promise.all(projects.map(typecheckProject));
 
 const failed: string[] = [];
-for (const {tsconfig, result} of results) {
-    console.log(`\nType checking ${tsconfig}...`);
+for (const {project, result} of results) {
+    console.log(`\nType checking ${project}...`);
     const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
     if (output) {
         console.log(output);
     }
     if (result.exitCode !== 0) {
-        failed.push(tsconfig);
+        failed.push(project);
     }
 }
 

--- a/server/victory-chart-renderer/tsconfig.json
+++ b/server/victory-chart-renderer/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
+        "tsBuildInfoFile": "./tsconfig.ts7.tsbuildinfo",
         "types": ["react-native", "react-native-web", "node"]
     },
     "include": ["src", "tests", "scripts", "../../src/types"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "tsBuildInfoFile": "./tsconfig.app.ts7.tsbuildinfo",
+        "types": ["react-native", "react-native-web"],
+        "lib": ["DOM", "ESNext"]
+    },
+    "include": [
+        "src",
+        "assets",
+        "modules",
+        ".storybook/**/*",
+        // Not app directories, but the app program reaches into them: `src/App.tsx` imports
+        // `wdyr`, `src/libs/ApiUtils` imports `config/proxyConfig`, `.storybook` imports the
+        // Rsbuild config, and the Storybook stories import the shared report fixtures. They were
+        // already being type-checked here via those imports; listing them makes that visible.
+        "wdyr.ts",
+        "config/proxyConfig.ts",
+        "config/rsbuild",
+        "__mocks__/reportData"
+    ],
+    "exclude": ["**/node_modules/*", "**/dist/*", "src/**/__mocks__/**"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,10 @@
     "compilerOptions": {
         "isolatedModules": true,
         "strict": true,
+        // Every project under the root solution is type-check only. `expo/tsconfig.base` happens to
+        // set this too, but it is restated here because `tsc --build` rejects `--noEmit` as a command
+        // line flag: the whole typecheck gate now depends on this option coming from a config file.
+        "noEmit": true,
         "incremental": true,
         "paths": {
             "@assets/*": ["./assets/*"],

--- a/tsconfig.bun.json
+++ b/tsconfig.bun.json
@@ -1,9 +1,13 @@
 {
+    "$schema": "https://json.schemastore.org/tsconfig",
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
+        "tsBuildInfoFile": "./tsconfig.bun.ts7.tsbuildinfo",
         "types": ["bun"],
         "lib": ["ESNext"]
     },
-    "include": ["scripts", "tests/tooling", "server/libs", "server/plugins", "server/stubs", "evals"],
+    // `prompts` and `.github/libs` are not Bun directories, but `scripts`, `evals` and
+    // `tests/tooling` import them, so this program has to list them.
+    "include": ["scripts", "tests/tooling", "server/libs", "server/plugins", "server/stubs", "evals", "prompts", ".github/libs"],
     "exclude": ["**/node_modules/*", "**/dist/*", "server/victory-chart-renderer/**"]
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,9 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "./tsconfig.json",
-    "include": ["src", "assets", "tests", "jest", "prompts", "__mocks__", "modules"],
+    "extends": "./tsconfig.app.json",
+    "compilerOptions": {
+        "tsBuildInfoFile": "./tsconfig.jest.ts7.tsbuildinfo"
+    },
+    "include": ["src", "assets", "modules", "tests", "jest", "__mocks__"],
     "exclude": ["**/node_modules/*", "**/dist/*", "tests/tooling"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,21 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "./tsconfig.base.json",
+
+    // This is a solution-style config: it owns no files of its own, it just names every project in
+    // the repo. Two things read it:
+    //
+    //   1. Editors. A language service resolves a file to the *closest* `tsconfig.json`, so every
+    //      file in the repo lands here first. Because this config has no files, the editor walks
+    //      `references` to find the project that does own the file, and type-checks it with that
+    //      project's options. Without the references a file outside the app program (a Jest test, a
+    //      Bun script) falls into an inferred project, which has no `paths`, which is why `@libs`
+    //      and friends stopped resolving in `tests/` when the Jest project was split out.
+    //   2. `npm run typecheck`, which type-checks exactly the projects listed here. Adding a project
+    //      to `references` is all it takes to put it in CI.
+    //
+    // `paths` is duplicated here from `tsconfig.base.json` because tools that read this file
+    // directly do not resolve its `extends` chain.
     "compilerOptions": {
-        "types": ["react-native", "react-native-web"],
-        "lib": ["DOM", "ESNext"],
-        // Babel reads this config directly and does not resolve its `extends` chain.
         "paths": {
             "@assets/*": ["./assets/*"],
             "@components/*": ["./src/components/*"],
@@ -23,21 +34,14 @@
             "tests/*": ["./tests/*"]
         }
     },
-    "include": ["src", "website", "docs", "assets", "prompts", ".storybook/**/*", ".claude/**/*", "modules", "**/*.nitro/*.ts", "**/*.nitro/*.tsx"],
-    "exclude": [
-        "**/node_modules/*",
-        "**/dist/*",
-        ".github/actions/**/index.js",
-        "**/docs/*",
-        ".claude/worktrees/**",
-        "tests/tooling",
-        "src/**/__mocks__/**",
-        "server/libs",
-        "server/plugins",
-        "server/stubs",
-        "evals",
-        ".github",
-        "web/proxy.ts",
-        "config"
+    "files": [],
+    // Order matters for editors: a file that appears in more than one project (all of `src` is in
+    // both the app and Jest programs) resolves to the first project here that lists it.
+    "references": [
+        {"path": "./tsconfig.app.json"},
+        {"path": "./tsconfig.jest.json"},
+        {"path": "./tsconfig.bun.json"},
+        {"path": "./tsconfig.node.json"},
+        {"path": "./server/victory-chart-renderer"}
     ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,9 +1,14 @@
 {
+    "$schema": "https://json.schemastore.org/tsconfig",
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
+        "tsBuildInfoFile": "./tsconfig.node.ts7.tsbuildinfo",
         "types": ["node"],
         "lib": ["ESNext"]
     },
+    // `prompts` is deliberately not listed even though the Proposal Police action imports it: the Bun
+    // program owns those files, and listing them in two referenced projects would give editors two
+    // candidate owners for one file. The action's imports still pull them into this program.
     "include": [".github/**/*", "web/proxy.ts", "config/**/*", "config/**/*.d.mts"],
     "exclude": ["**/node_modules/*", "**/dist/*", ".github/actions/**/index.js"]
 }


### PR DESCRIPTION
### Explanation of Change

Consolidate the per-runtime TypeScript projects under the root `tsconfig.json` using [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html).

#### The bug this fixes

Splitting the Jest project out of the root config in #100124 removed `tests`, `jest` and `__mocks__` from the root `tsconfig.json`'s `include`. A language service resolves a file to the **closest** `tsconfig.json`, so those files still landed on the root config, did not appear in it, and fell back to an *inferred project* — which has no `paths`. That is why `@libs` stopped resolving in `tests/`.

Reproduced by driving `tsserver` directly, before and after. The fix is a root project that owns no files, only project references. So the language service walks `references` to the project that does own the file, and type-checks it with that project's options.

#### Changes

- `npm run typecheck` takes its project list from those `references`. It still runs each project in parallel for performance (tsc by default is sequential).
- Drops the dead includes phase 3 asked for but did not land: `website` (does not exist), `docs` (already excluded), `.claude` (was pulling two unrelated `.mjs` files into the app program), `**/*.nitro/*` (already covered by `modules`).
- Lists the files the app import graph already reached but the config did not admit to: `wdyr.ts` (from `src/App.tsx`), `config/proxyConfig.ts` (from `src/libs/ApiUtils.ts`), `config/rsbuild` (from `.storybook`), `__mocks__/reportData` (from the Storybook stories).
- Moves `prompts` out of the app and Jest programs into the Bun program. Nothing in `src/` imports it; `scripts/`, `evals/` and `tests/tooling/` do.
- Each project names its own `tsBuildInfoFile`. `modules/ExpensifyNitroUtils` now extends `tsconfig.app.json` and sets its own, so it cannot clobber the app's.

#### Timings

| | before | after |
| --- | --- | --- |
| cold | 34.8s / 46.7s | 41.5s / 47.3s |
| warm | 4.5s / 4.1s | 1.16s / 1.13s |

Cold is a wash; warm is ~4× faster because build mode skips a project whose build info is current instead of rebuilding its program.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99291
PROPOSAL: N/A

### Tests

Automated tests / CI only.

- [x] Verify that no errors appear in the JS console (not applicable: tooling-only change)

### Offline tests

Not applicable: tooling-only change.

### QA Steps

n/a - tooling-only change.

- [x] Verify that no errors appear in the JS console (not applicable: tooling-only change)

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (not applicable: tooling-only change)
    - [x] I turned off my network connection and tested it while offline (not applicable: tooling-only change)
    - [x] I tested this PR with a High Traffic account (not applicable: tooling-only change)
- [x] I included screenshots or videos for tests on all platforms (not applicable: tooling-only change)
- [x] I ran the tests on all platforms & verified they passed on (not applicable: tooling-only change):
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (not applicable: tooling-only change)
- [x] I followed proper code patterns
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained why
    - [x] I verified any copy/text added to the app is grammatically correct (not applicable)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the Review Guidelines
- [x] I tested other components that can be impacted by my changes (not applicable)
- [x] If a new CSS style is added I verified it (not applicable)
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing StyleUtils function
- [x] If new assets were added or existing ones were modified (not applicable)
    - [x] The assets are optimized and compressed
    - [x] The assets load correctly across all supported platforms
- [x] If the PR modifies code that runs when editing or sending messages, I tested markdown behavior (not applicable)
- [x] If the PR modifies a generic component, I tested impacted usages (not applicable)
- [x] If the PR modifies a component related to Storybook stories, I verified stories (not applicable)
- [x] If the PR modifies a page accessible by deeplink, I verified deeplinks (not applicable)
- [x] If the PR modifies UI or form input styles, I verified alignment and design review (not applicable)
- [x] I added unit tests for any new feature or bug fix (not applicable: configuration-only change)
- [x] If main was merged after review, I tested again (not applicable)

### Screenshots/Videos

Not applicable: tooling-only change.
