### PR TITLE
fix: bottom-safe-area-padding-in-modals (part 3)

### DIFF
--- a/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
+++ b/src/components/ConnectToQuickbooksOnlineFlow/BaseConnectToQuickbooksOnlineFlow.tsx
@@ -98,6 +98,7 @@ function BaseConnectToQuickbooksOnlineFlow({policyID, isIntuitEnterpriseSuite, o
             anchorPosition={connectionOptionsPopoverPosition}
             anchorAlignment={anchorAlignment}
             anchorRef={connectionButtonRef}
+            enableEdgeToEdgeBottomSafeAreaPadding
         />
     );
 }

--- a/src/components/CountryPicker/CountrySelectorModal.tsx
+++ b/src/components/CountryPicker/CountrySelectorModal.tsx
@@ -82,11 +82,12 @@ function CountrySelectorModal({isVisible, currentCountry, onCountrySelected, onC
             onClose={onClose}
             onModalHide={onClose}
             onBackdropPress={onBackdropPress}
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <ScreenWrapper
                 style={[styles.pb0]}
                 includePaddingTop={false}
-                includeSafeAreaPaddingBottom={false}
+                enableEdgeToEdgeBottomSafeAreaPadding
                 testID="CountrySelectorModal"
             >
                 <HeaderWithBackButton
@@ -103,6 +104,7 @@ function CountrySelectorModal({isVisible, currentCountry, onCountrySelected, onC
                     initiallyFocusedItemKey={initialSelectedValue}
                     shouldSingleExecuteRowSelect
                     shouldStopPropagation
+                    addBottomSafeAreaPadding
                 />
             </ScreenWrapper>
         </Modal>

--- a/src/components/FeatureTraining/hooks/useScrollableWrapper.ts
+++ b/src/components/FeatureTraining/hooks/useScrollableWrapper.ts
@@ -1,8 +1,8 @@
 import ScrollView from '@components/ScrollView';
 
+import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
 import useKeyboardState from '@hooks/useKeyboardState';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
-import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
@@ -25,10 +25,18 @@ function useScrollableWrapper({shouldUseScrollView: shouldUseScrollViewProp = fa
     const StyleUtils = useStyleUtils();
     const {onboardingIsMediumOrLargerScreenWidth, isInLandscapeMode} = useResponsiveLayout();
     const {windowHeight} = useWindowDimensions();
-    const insets = useSafeAreaInsets();
     const {isKeyboardActive} = useKeyboardState();
 
     const shouldUseScrollView = shouldUseScrollViewProp || isInLandscapeMode;
+
+    // The modal runs in edge-to-edge mode, so the bottom inset belongs on the content. It is only needed while the modal is
+    // bottom-docked — which is exactly when `onboardingIsMediumOrLargerScreenWidth` is false — and must be dropped while the
+    // keyboard is up, otherwise a gap appears above it.
+    const shouldAddBottomSafeAreaPadding = !onboardingIsMediumOrLargerScreenWidth && !isKeyboardActive;
+    const bottomSafeAreaPaddingStyle = useBottomSafeSafeAreaPaddingStyle({
+        addBottomSafeAreaPadding: !shouldUseScrollView && shouldAddBottomSafeAreaPadding,
+        addOfflineIndicatorBottomSafeAreaPadding: false,
+    });
 
     const scrollViewRef = useRef<RNScrollView>(null);
     const [containerHeight, setContainerHeight] = useState(0);
@@ -42,14 +50,13 @@ function useScrollableWrapper({shouldUseScrollView: shouldUseScrollViewProp = fa
     }, [contentHeight, containerHeight, onboardingIsMediumOrLargerScreenWidth, shouldUseScrollView]);
 
     const Wrapper = shouldUseScrollView ? ScrollView : View;
-    const wrapperStyles = shouldUseScrollView
-        ? StyleUtils.getScrollableFeatureTrainingModalStyles(insets, isKeyboardActive)
-        : ({} as {style?: StyleProp<ViewStyle>; containerStyle?: StyleProp<ViewStyle>});
+    const wrapperStyles = shouldUseScrollView ? StyleUtils.getScrollableFeatureTrainingModalStyles() : ({} as {style?: StyleProp<ViewStyle>; containerStyle?: StyleProp<ViewStyle>});
 
     const style: StyleProp<ViewStyle> = [
         onboardingIsMediumOrLargerScreenWidth && width !== undefined && StyleUtils.getWidthStyle(width),
         wrapperStyles.style,
         isInLandscapeMode ? {maxHeight: windowHeight * CONST.MODAL_MAX_HEIGHT_TO_WINDOW_HEIGHT_RATIO_LANDSCAPE_MODE} : styles.mh100,
+        bottomSafeAreaPaddingStyle,
     ];
 
     const onLayout = shouldUseScrollView ? (e: LayoutChangeEvent) => setContainerHeight(e.nativeEvent.layout.height) : undefined;
@@ -62,6 +69,7 @@ function useScrollableWrapper({shouldUseScrollView: shouldUseScrollViewProp = fa
             style,
             contentContainerStyle: wrapperStyles.containerStyle,
             keyboardShouldPersistTaps: shouldUseScrollView ? ('handled' as const) : undefined,
+            addBottomSafeAreaPadding: shouldUseScrollView ? shouldAddBottomSafeAreaPadding : undefined,
             ref: shouldUseScrollView ? scrollViewRef : undefined,
             onLayout,
             onContentSizeChange,

--- a/src/components/FeatureTrainingModal.tsx
+++ b/src/components/FeatureTrainingModal.tsx
@@ -110,8 +110,9 @@ function FeatureTrainingModal({
                 ...modalInnerContainerStyle,
             }}
             onModalHide={handleModalHide}
-            shouldDisableBottomSafeAreaPadding={shouldUseScrollView}
             shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode={!shouldUseScrollView}
+            // The bottom safe area padding is applied to the content by `useScrollableWrapper` instead.
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <FeatureTraining
                 shouldUseScrollView={shouldUseScrollViewProp}

--- a/src/components/PopoverMenu/v2/content/BaseContent.tsx
+++ b/src/components/PopoverMenu/v2/content/BaseContent.tsx
@@ -101,6 +101,8 @@ function BaseContentInner({
             restoreFocusType={restoreFocusType}
             innerContainerStyle={innerContainerStyle ?? styles.pv0}
             shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode={shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode}
+            // The bottom safe area padding is applied by `<Content>`/`<ScrollableContent>` instead, see `useShouldAddBottomSafeAreaPadding`.
+            enableEdgeToEdgeBottomSafeAreaPadding
             testID={testID}
         >
             <FocusTrapForModal

--- a/src/components/PopoverMenu/v2/content/Content.tsx
+++ b/src/components/PopoverMenu/v2/content/Content.tsx
@@ -1,5 +1,6 @@
 import {useRootVisibility} from '@components/PopoverMenu/v2/root/RootContext';
 
+import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSuppressSpaceScroll from '@hooks/useSuppressSpaceScroll';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -10,6 +11,7 @@ import type {BasePopoverProps} from './BaseContent';
 
 import BaseContent from './BaseContent';
 import useMaxHeightStyle from './useMaxHeightStyle';
+import useShouldAddBottomSafeAreaPadding from './useShouldAddBottomSafeAreaPadding';
 
 type ContentProps = BasePopoverProps;
 
@@ -23,12 +25,18 @@ function Content({containerStyles, ...rest}: ContentProps): React.ReactElement |
 
     const maxHeightStyle = useMaxHeightStyle();
 
+    const shouldAddBottomSafeAreaPadding = useShouldAddBottomSafeAreaPadding();
+    const bottomSafeAreaPaddingStyle = useBottomSafeSafeAreaPaddingStyle({
+        addBottomSafeAreaPadding: shouldAddBottomSafeAreaPadding,
+        style: [isSmallScreenWidth ? styles.pv4 : styles.pv2, containerStyles],
+    });
+
     return (
         <BaseContent
             {...rest}
             componentName={Content.displayName}
             maxHeightStyle={maxHeightStyle}
-            containerStyles={[isSmallScreenWidth ? styles.pv4 : styles.pv2, containerStyles]}
+            containerStyles={bottomSafeAreaPaddingStyle}
         />
     );
 }

--- a/src/components/PopoverMenu/v2/content/ScrollableContent.tsx
+++ b/src/components/PopoverMenu/v2/content/ScrollableContent.tsx
@@ -19,6 +19,7 @@ import type {BasePopoverProps} from './BaseContent';
 
 import BaseContent from './BaseContent';
 import useMaxHeightStyle from './useMaxHeightStyle';
+import useShouldAddBottomSafeAreaPadding from './useShouldAddBottomSafeAreaPadding';
 
 type ScrollableContentProps = BasePopoverProps & {
     contentContainerStyle?: StyleProp<ViewStyle>;
@@ -32,6 +33,7 @@ function ScrollableContent({contentContainerStyle, children, ...rest}: Scrollabl
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth -- popovers float even in RHP on desktop, so true device width drives sizing
     const {isSmallScreenWidth} = useResponsiveLayout();
     useRootVisibility(ScrollableContent.displayName);
+    const shouldAddBottomSafeAreaPadding = useShouldAddBottomSafeAreaPadding();
     if (__DEV__) {
         const childCount = React.Children.count(children);
         if (childCount > VIRTUALIZATION_RECOMMENDED_THRESHOLD) {
@@ -53,7 +55,12 @@ function ScrollableContent({contentContainerStyle, children, ...rest}: Scrollabl
             maxHeightStyle={maxHeightStyle}
             shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode={false}
         >
-            <ScrollView contentContainerStyle={[isSmallScreenWidth ? styles.pv4 : styles.pv2, contentContainerStyle]}>{children}</ScrollView>
+            <ScrollView
+                contentContainerStyle={[isSmallScreenWidth ? styles.pv4 : styles.pv2, contentContainerStyle]}
+                addBottomSafeAreaPadding={shouldAddBottomSafeAreaPadding}
+            >
+                {children}
+            </ScrollView>
         </BaseContent>
     );
 }

--- a/src/components/PopoverMenu/v2/content/useShouldAddBottomSafeAreaPadding.ts
+++ b/src/components/PopoverMenu/v2/content/useShouldAddBottomSafeAreaPadding.ts
@@ -1,0 +1,18 @@
+import useKeyboardState from '@hooks/useKeyboardState';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+
+/**
+ * Whether the popover content should apply bottom safe area padding itself.
+ * `<BaseContent>` runs in edge-to-edge mode, so the modal no longer pads the bottom inset.
+ * The padding only belongs on the content when the popover is bottom-docked (small screens),
+ * and it must be dropped while the keyboard is up, otherwise a gap appears above the keyboard.
+ */
+function useShouldAddBottomSafeAreaPadding(): boolean {
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth -- must match PopoverWithMeasuredContent's dock decision (bottom-docked only when isSmallScreenWidth)
+    const {isSmallScreenWidth} = useResponsiveLayout();
+    const {isKeyboardActive} = useKeyboardState();
+
+    return isSmallScreenWidth && !isKeyboardActive;
+}
+
+export default useShouldAddBottomSafeAreaPadding;

--- a/src/components/PushRowWithModal/PushRowModal.tsx
+++ b/src/components/PushRowWithModal/PushRowModal.tsx
@@ -97,10 +97,11 @@ function PushRowModal({isVisible, selectedOption, onOptionChange, onClose, optio
             onModalHide={handleClose}
             shouldUseCustomBackdrop
             shouldHandleNavigationBack
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <ScreenWrapper
                 includePaddingTop={false}
-                includeSafeAreaPaddingBottom={false}
+                enableEdgeToEdgeBottomSafeAreaPadding
                 testID="PushRowModal"
             >
                 <HeaderWithBackButton
@@ -117,6 +118,7 @@ function PushRowModal({isVisible, selectedOption, onOptionChange, onClose, optio
                     disableMaintainingScrollPosition
                     shouldShowTooltips={false}
                     showScrollIndicator
+                    addBottomSafeAreaPadding
                 />
             </ScreenWrapper>
         </Modal>

--- a/src/components/StatePicker/StateSelectorModal.tsx
+++ b/src/components/StatePicker/StateSelectorModal.tsx
@@ -85,11 +85,12 @@ function StateSelectorModal({isVisible, currentState, onStateSelected, onClose, 
             onClose={onClose}
             onModalHide={onClose}
             onBackdropPress={onBackdropPress}
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <ScreenWrapper
                 style={[styles.pb0]}
                 includePaddingTop={false}
-                includeSafeAreaPaddingBottom={false}
+                enableEdgeToEdgeBottomSafeAreaPadding
                 testID="StateSelectorModal"
             >
                 <HeaderWithBackButton
@@ -107,6 +108,7 @@ function StateSelectorModal({isVisible, currentState, onStateSelected, onClose, 
                     disableMaintainingScrollPosition
                     shouldSingleExecuteRowSelect
                     shouldStopPropagation
+                    addBottomSafeAreaPadding
                 />
             </ScreenWrapper>
         </Modal>

--- a/src/components/TrialPaymentReminderModal.tsx
+++ b/src/components/TrialPaymentReminderModal.tsx
@@ -1,3 +1,4 @@
+import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -43,6 +44,11 @@ function TrialPaymentReminderModal({isVisible, variant, daysRemaining, countdown
     const styles = useThemeStyles();
     const illustrations = useMemoizedLazyIllustrations(['ArmWithCardPos']);
     const {translate} = useLocalize();
+    const bottomSafeAreaPaddingStyle = useBottomSafeSafeAreaPaddingStyle({
+        addBottomSafeAreaPadding: shouldUseNarrowLayout,
+        addOfflineIndicatorBottomSafeAreaPadding: false,
+        style: styles.m5,
+    });
 
     return (
         <Modal
@@ -53,6 +59,7 @@ function TrialPaymentReminderModal({isVisible, variant, daysRemaining, countdown
             type={shouldUseNarrowLayout ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.CONFIRM}
             innerContainerStyle={styles.pv0}
             shouldHandleNavigationBack
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <View style={[styles.alignItemsCenter, styles.wAuto, styles.trialReminderIllustrationContainer, styles.pb7]}>
                 <ImageSVG
@@ -60,7 +67,7 @@ function TrialPaymentReminderModal({isVisible, variant, daysRemaining, countdown
                     contentFit="contain"
                 />
             </View>
-            <View style={[styles.m5]}>
+            <View style={bottomSafeAreaPaddingStyle}>
                 {variant === CONST.TRIAL_REMINDER_VARIANT.NEAR_END && daysRemaining !== undefined && (
                     <Text style={[styles.textSuccess, styles.textStrong, styles.mb2]}>{translate('trialPaymentReminder.trialEndsInDays', {count: daysRemaining})}</Text>
                 )}

--- a/src/pages/ReimbursementAccount/USD/BusinessInfo/subSteps/TypeBusiness/BusinessTypePicker/BusinessTypeSelectorModal.tsx
+++ b/src/pages/ReimbursementAccount/USD/BusinessInfo/subSteps/TypeBusiness/BusinessTypePicker/BusinessTypeSelectorModal.tsx
@@ -56,11 +56,12 @@ function BusinessTypeSelectorModal({isVisible, currentBusinessType, onBusinessTy
                 onClose();
                 Navigation.dismissModal();
             }}
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <ScreenWrapper
                 style={[styles.pb0]}
                 includePaddingTop={false}
-                includeSafeAreaPaddingBottom={false}
+                enableEdgeToEdgeBottomSafeAreaPadding
                 testID="BusinessTypeSelectorModal"
             >
                 <HeaderWithBackButton
@@ -75,6 +76,7 @@ function BusinessTypeSelectorModal({isVisible, currentBusinessType, onBusinessTy
                     shouldSingleExecuteRowSelect
                     shouldStopPropagation
                     ListItem={SingleSelectListItem}
+                    addBottomSafeAreaPadding
                 />
             </ScreenWrapper>
         </Modal>

--- a/src/pages/home/ForYouSection/ConciergePromptBox.tsx
+++ b/src/pages/home/ForYouSection/ConciergePromptBox.tsx
@@ -277,6 +277,7 @@ function ConciergePromptBox({isMenuVisible, setIsMenuVisible}: ConciergePromptBo
                                                         },
                                                     ]}
                                                     anchorRef={actionButtonRef}
+                                                    enableEdgeToEdgeBottomSafeAreaPadding
                                                 />
                                             </>
                                         );

--- a/src/pages/home/InsightsSection/InsightTitleDropdown.tsx
+++ b/src/pages/home/InsightsSection/InsightTitleDropdown.tsx
@@ -97,6 +97,7 @@ function InsightTitleDropdown({configs, selectedKey, onSelect}: InsightTitleDrop
                 anchorPosition={menuPosition}
                 anchorAlignment={ANCHOR_ALIGNMENT}
                 shouldShowRadioButton
+                enableEdgeToEdgeBottomSafeAreaPadding
             />
         </View>
     );

--- a/src/pages/inbox/report/ReactionList/BaseReactionList.tsx
+++ b/src/pages/inbox/report/ReactionList/BaseReactionList.tsx
@@ -1,5 +1,6 @@
 import OptionRow from '@components/OptionRow';
 
+import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -41,6 +42,9 @@ type BaseReactionListProps = ReactionListProps & {
      * Returns true if the reaction list is visible
      */
     isVisible?: boolean;
+
+    /** Whether to add bottom safe area padding to the list content */
+    addBottomSafeAreaPadding?: boolean;
 };
 
 const keyExtractor: FlatListProps<PersonalDetails>['keyExtractor'] = (item, index) => `${item.login}+${index}`;
@@ -51,12 +55,13 @@ const getItemLayout = (data: ArrayLike<PersonalDetails> | null | undefined, inde
     offset: variables.listItemHeightNormal * index,
 });
 
-function BaseReactionList({hasUserReacted = false, users, isVisible = false, emojiCodes, emojiCount, emojiName, onClose}: BaseReactionListProps) {
+function BaseReactionList({hasUserReacted = false, users, isVisible = false, addBottomSafeAreaPadding = false, emojiCodes, emojiCount, emojiName, onClose}: BaseReactionListProps) {
     const icons = useMemoizedLazyExpensifyIcons(['FallbackAvatar']);
     const {translate} = useLocalize();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const {hoveredComponentBG, reactionListContainer, reactionListContainerFixedWidth, pv2} = useThemeStyles();
     const {accountID} = useCurrentUserPersonalDetails();
+    const contentContainerStyle = useBottomSafeSafeAreaPaddingStyle({addBottomSafeAreaPadding, style: pv2});
 
     if (!isVisible) {
         return null;
@@ -110,7 +115,7 @@ function BaseReactionList({hasUserReacted = false, users, isVisible = false, emo
                 renderItem={renderItem}
                 keyExtractor={keyExtractor}
                 getItemLayout={getItemLayout}
-                contentContainerStyle={pv2}
+                contentContainerStyle={contentContainerStyle}
                 style={[reactionListContainer, !shouldUseNarrowLayout && reactionListContainerFixedWidth]}
             />
         </>

--- a/src/pages/inbox/report/ReactionList/PopoverReactionList.tsx
+++ b/src/pages/inbox/report/ReactionList/PopoverReactionList.tsx
@@ -2,6 +2,7 @@ import PopoverWithMeasuredContent from '@components/PopoverWithMeasuredContent';
 
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
 import {getEmojiReactionDetails, mergeReactionsByEmoji} from '@libs/EmojiUtils';
 
@@ -29,6 +30,8 @@ type PopoverReactionListProps = {
 
 function PopoverReactionList({isVisible, emojiName, reportActionID, anchorPosition, anchorRef, onClose}: PopoverReactionListProps) {
     const {accountID} = useCurrentUserPersonalDetails();
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth -- must match PopoverWithMeasuredContent's dock decision (bottom-docked only when isSmallScreenWidth)
+    const {isSmallScreenWidth} = useResponsiveLayout();
 
     const [emojiReactions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_REACTIONS}${reportActionID}`);
 
@@ -66,9 +69,11 @@ function PopoverReactionList({isVisible, emojiName, reportActionID, anchorPositi
             fullscreen
             anchorRef={anchorRef}
             shouldWrapModalChildrenInScrollViewIfBottomDockedInLandscapeMode={false}
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <BaseReactionList
                 isVisible
+                addBottomSafeAreaPadding={isSmallScreenWidth}
                 users={users}
                 emojiName={emojiName}
                 emojiCodes={emojiCodes}

--- a/src/pages/inbox/sidebar/InboxTabSelector.tsx
+++ b/src/pages/inbox/sidebar/InboxTabSelector.tsx
@@ -132,6 +132,7 @@ function InboxTabSelector() {
                 // Safari ignores shouldCallAfterModalHide by default, which would show the confirmation modal while the
                 // popover is still dismissing and its focus trap is active. Avoid that exception so the sequencing holds on Safari too.
                 shouldAvoidSafariException
+                enableEdgeToEdgeBottomSafeAreaPadding
             />
         </View>
     );

--- a/src/pages/inbox/sidebar/SupportalSwitcherButton/index.tsx
+++ b/src/pages/inbox/sidebar/SupportalSwitcherButton/index.tsx
@@ -5,11 +5,14 @@ import {PressableWithoutFeedback} from '@components/Pressable';
 import TextInput from '@components/TextInput';
 import Tooltip from '@components/Tooltip';
 
+import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
+import useKeyboardState from '@hooks/useKeyboardState';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePopoverPosition from '@hooks/usePopoverPosition';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -48,6 +51,13 @@ function SupportalSwitcherButton({isSidebarHovered}: SupportalSwitcherButtonProp
     const icons = useMemoizedLazyExpensifyIcons(['UserSearch']);
     const {calculatePopoverPosition} = usePopoverPosition();
     const {isOffline} = useNetwork();
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth -- must match PopoverWithMeasuredContent's dock decision (bottom-docked only when isSmallScreenWidth)
+    const {isSmallScreenWidth} = useResponsiveLayout();
+    const {isKeyboardActive} = useKeyboardState();
+    const bottomSafeAreaPaddingStyle = useBottomSafeSafeAreaPaddingStyle({
+        addBottomSafeAreaPadding: isSmallScreenWidth && !isKeyboardActive,
+        style: [styles.createMenuContainer, styles.ph5],
+    });
 
     const anchorRef = useRef<HTMLDivElement | null>(null);
     const [anchorPosition, setAnchorPosition] = useState<AnchorPosition>({horizontal: 0, vertical: 0});
@@ -156,8 +166,9 @@ function SupportalSwitcherButton({isSidebarHovered}: SupportalSwitcherButtonProp
                 anchorRef={anchorRef}
                 anchorPosition={anchorPosition}
                 anchorAlignment={ANCHOR_ALIGNMENT}
+                enableEdgeToEdgeBottomSafeAreaPadding
             >
-                <View style={[styles.createMenuContainer, styles.ph5]}>
+                <View style={bottomSafeAreaPaddingStyle}>
                     <TextInput
                         label={translate('supportalSwitcher.title')}
                         accessibilityLabel={translate('supportalSwitcher.emailLabel')}

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -2248,26 +2248,19 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
         bottom: bottomOffset,
     }),
 
-    getScrollableFeatureTrainingModalStyles: (
-        insets: EdgeInsets,
-        isKeyboardOpen = false,
-    ): {
+    /** The bottom safe area padding is applied by `useScrollableWrapper` in edge-to-edge mode, so it is not baked in here. */
+    getScrollableFeatureTrainingModalStyles: (): {
         style?: ViewStyle;
         containerStyle?: ViewStyle;
-    } => {
-        const {paddingBottom: safeAreaPaddingBottom} = getPlatformSafeAreaPadding(insets);
-        // When keyboard is open and we want to disregard safeAreaPaddingBottom.
-        const paddingBottom = getCombinedSpacing(styles.pb5.paddingBottom, safeAreaPaddingBottom, !isKeyboardOpen);
+    } => ({
         // Forces scroll on modal when keyboard is open and the modal larger than remaining screen height.
-        return {
-            style: isMobileChrome()
-                ? {
-                      maxHeight: '100dvh',
-                  }
-                : {},
-            containerStyle: {paddingBottom},
-        };
-    },
+        style: isMobileChrome()
+            ? {
+                  maxHeight: '100dvh',
+              }
+            : {},
+        containerStyle: styles.pb5,
+    }),
 
     /**
      * Returns a single crop view style by key. Use this from useAnimatedStyle to avoid building all 14 styles per frame.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Part 3 of #64241, following #88578 and #97031. No new infrastructure; reuses
the enableEdgeToEdgeBottomSafeAreaPadding plumbing from part 1.

- PopoverMenu v2: BaseContent runs edge-to-edge, with the bottom inset applied
  by Content/ScrollableContent via a new useShouldAddBottomSafeAreaPadding hook.
  This covers the VideoPlayer playback menu, its only consumer.
- Remaining v1 PopoverMenu call sites: BaseConnectToQuickbooksOnlineFlow,
  InsightTitleDropdown, ConciergePromptBox, InboxTabSelector.
- Remaining PopoverWithMeasuredContent call sites: SupportalSwitcherButton
  (keyboard-gated, it hosts text inputs) and PopoverReactionList, which gains
  an addBottomSafeAreaPadding prop on BaseReactionList for its FlatList.
- TrialPaymentReminderModal, the last un-migrated bottom-docked modal.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/64241
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. ""offline"", ""spotty connection"", ""slow internet"", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write ""Same as tests"" if the QA team is able to run the tests in the above ""Tests"" section.
--->
// TODO: These must be filled out, or the issue title must include ""[No QA].""

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained ""why"" the code was doing something instead of only explaining ""what"" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named ""index.js"". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>