### PR TITLE
Remove the noRightMarginOnSubscriptContainer prop from ReportAvatar

### DIFF
--- a/src/components/Avatar/connected/ReportAvatar.tsx
+++ b/src/components/Avatar/connected/ReportAvatar.tsx
@@ -32,11 +32,11 @@ type ReportAvatarProps = {
     /** Style for the second avatar */
     secondaryAvatarContainerStyle?: StyleProp<ViewStyle>;
 
+    /** Subscript avatar container styles */
+    subscriptAvatarContainerStyle?: StyleProp<ViewStyle>;
+
     /** Border color for the subscript avatar */
     subscriptAvatarBorderColor?: ColorValue;
-
-    /** Whether to show the subscript avatar without margin */
-    noRightMarginOnSubscriptContainer?: boolean;
 
     /** Whether (and how) to stack the avatars horizontally */
     horizontalStacking?: HorizontalStackingOptions | boolean;

--- a/src/components/ReportActionAvatars/index.tsx
+++ b/src/components/ReportActionAvatars/index.tsx
@@ -11,7 +11,6 @@ import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useStyleUtils from '@hooks/useStyleUtils';
-import useThemeStyles from '@hooks/useThemeStyles';
 
 import {sortIconsByName} from '@libs/ReportUtils';
 
@@ -65,11 +64,11 @@ type ReportActionAvatarsProps = {
     /** Style for Second Avatar */
     secondaryAvatarContainerStyle?: StyleProp<ViewStyle>;
 
+    /** Subscript avatar container styles */
+    subscriptAvatarContainerStyle?: StyleProp<ViewStyle>;
+
     /** Whether avatars are displayed within a reportAction */
     isInReportAction?: boolean;
-
-    /** Whether to show the subscript avatar without margin */
-    noRightMarginOnSubscriptContainer?: boolean;
 
     /** Border color for the subscript avatar */
     subscriptAvatarBorderColor?: ColorValue;
@@ -114,7 +113,7 @@ function ReportActionAvatars({
     sort: sortAvatars,
     singleAvatarContainerStyle,
     subscriptAvatarBorderColor,
-    noRightMarginOnSubscriptContainer = false,
+    subscriptAvatarContainerStyle,
     subscriptCardFeed,
     subscriptCardFeedIconSize,
     secondaryAvatarContainerStyle,
@@ -127,7 +126,6 @@ function ReportActionAvatars({
     const accountIDs = passedAccountIDs.filter((accountID) => accountID !== CONST.DEFAULT_NUMBER_ID);
     const allPersonalDetails = usePersonalDetails();
     const {localeCompare} = useLocalize();
-    const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
 
     const reportID =
@@ -217,7 +215,7 @@ function ReportActionAvatars({
                 cardFeed={subscriptCardFeed}
                 cardFeedIconSize={subscriptCardFeedIconSize}
                 size={size}
-                containerStyle={noRightMarginOnSubscriptContainer ? styles.mr0 : {}}
+                containerStyle={subscriptAvatarContainerStyle}
                 subscriptAvatarBorderColor={subscriptAvatarBorderColor}
                 fallbackDisplayName={fallbackDisplayName}
             />
@@ -230,7 +228,7 @@ function ReportActionAvatars({
                 primaryAvatar={primaryAvatar}
                 secondaryAvatar={secondaryAvatar}
                 size={size}
-                containerStyle={noRightMarginOnSubscriptContainer ? styles.mr0 : {}}
+                containerStyle={subscriptAvatarContainerStyle}
                 subscriptAvatarBorderColor={subscriptAvatarBorderColor}
                 fallbackDisplayName={fallbackDisplayName}
             />

--- a/src/components/Tables/WorkspaceRoomsTable/WorkspaceRoomsTableRow.tsx
+++ b/src/components/Tables/WorkspaceRoomsTable/WorkspaceRoomsTableRow.tsx
@@ -65,8 +65,8 @@ function WorkspaceRoomsTableRow({item, rowIndex, shouldUseNarrowTableLayout}: Wo
                     {shouldUseNarrowTableLayout && (
                         <View style={[styles.flex1, styles.flexRow, styles.gap3, styles.alignItemsCenter]}>
                             <ReportAvatar
-                                noRightMarginOnSubscriptContainer
                                 singleAvatarContainerStyle={styles.mr0}
+                                subscriptAvatarContainerStyle={styles.mr0}
                                 subscriptAvatarBorderColor={hovered ? theme.hoverComponentBG : theme.highlightBG}
                                 reportID={item.reportID}
                                 size={CONST.AVATAR_SIZE.DEFAULT}
@@ -101,8 +101,8 @@ function WorkspaceRoomsTableRow({item, rowIndex, shouldUseNarrowTableLayout}: Wo
                                 {...getCellAccessibilityProps(isTableSemanticsEnabled)}
                             >
                                 <ReportAvatar
-                                    noRightMarginOnSubscriptContainer
                                     singleAvatarContainerStyle={styles.mr0}
+                                    subscriptAvatarContainerStyle={styles.mr0}
                                     subscriptAvatarBorderColor={hovered ? theme.hoverComponentBG : theme.highlightBG}
                                     reportID={item.reportID}
                                     size={CONST.AVATAR_SIZE.SMALL}

--- a/src/pages/inbox/report/ReportActionItemSingle.tsx
+++ b/src/pages/inbox/report/ReportActionItemSingle.tsx
@@ -169,9 +169,9 @@ function ReportActionItemSingle({
             >
                 <OfflineWithFeedback pendingAction={details.pendingFields?.avatar ?? undefined}>
                     <ReportActionAvatars
-                        singleAvatarContainerStyle={[styles.actionAvatar]}
+                        singleAvatarContainerStyle={styles.actionAvatar}
+                        subscriptAvatarContainerStyle={styles.mr0}
                         subscriptAvatarBorderColor={getBackgroundColor()}
-                        noRightMarginOnSubscriptContainer
                         isInReportAction
                         secondaryAvatarContainerStyle={[
                             StyleUtils.getBackgroundAndBorderStyle(theme.appBG),

--- a/src/pages/tasks/DynamicNewTaskPage.tsx
+++ b/src/pages/tasks/DynamicNewTaskPage.tsx
@@ -58,10 +58,10 @@ function TaskFieldAvatar({reportID}: {reportID?: string}) {
 
     return (
         <ReportActionAvatars
-            singleAvatarContainerStyle={[styles.actionAvatar]}
+            singleAvatarContainerStyle={styles.actionAvatar}
+            subscriptAvatarContainerStyle={styles.mr0}
             subscriptAvatarBorderColor={isInteractive && (isHovered || isPressed) ? borderColor : undefined}
             reportID={reportID}
-            noRightMarginOnSubscriptContainer
         />
     );
 }

--- a/tests/ui/ReportActionAvatarsTest.tsx
+++ b/tests/ui/ReportActionAvatarsTest.tsx
@@ -456,6 +456,12 @@ describe('ReportActionAvatars', () => {
             isSubscriptAvatarRendered({...retrievedData, negate: true});
             isMultipleAvatarRendered({...retrievedData, stacked: true});
         });
+
+        it('applies the subscript container style on top of the default subscript layout', async () => {
+            await retrieveDataFromAvatarView({reportID: chatReport.reportID, subscriptAvatarContainerStyle: {marginRight: 0}});
+
+            expect(screen.getByTestId('ReportActionAvatars-Subscript')).toHaveStyle({marginRight: 0});
+        });
     });
 
     describe('renders properly multiple and single avatars', () => {

--- a/tests/unit/components/Avatar/connected/ReportAvatarTest.tsx
+++ b/tests/unit/components/Avatar/connected/ReportAvatarTest.tsx
@@ -129,6 +129,7 @@ describe('ReportAvatar (connected)', () => {
 
         const singleAvatarContainerStyle = [{marginRight: 12}];
         const secondaryAvatarContainerStyle = [{borderColor: '#00ff00'}];
+        const subscriptAvatarContainerStyle = [{marginRight: 0}];
         const horizontalStacking = {maxRows: 2, maxAvatarsPerRow: 4, overlapDivider: 4};
 
         render(
@@ -137,8 +138,8 @@ describe('ReportAvatar (connected)', () => {
                 size={CONST.AVATAR_SIZE.SMALL}
                 singleAvatarContainerStyle={singleAvatarContainerStyle}
                 secondaryAvatarContainerStyle={secondaryAvatarContainerStyle}
+                subscriptAvatarContainerStyle={subscriptAvatarContainerStyle}
                 subscriptAvatarBorderColor="#ff0000"
-                noRightMarginOnSubscriptContainer
                 horizontalStacking={horizontalStacking}
                 sort={CONST.REPORT_ACTION_AVATARS.SORT_BY.REVERSE}
                 fallbackDisplayName={FALLBACK_NAME}
@@ -150,8 +151,8 @@ describe('ReportAvatar (connected)', () => {
             size: CONST.AVATAR_SIZE.SMALL,
             singleAvatarContainerStyle,
             secondaryAvatarContainerStyle,
+            subscriptAvatarContainerStyle,
             subscriptAvatarBorderColor: '#ff0000',
-            noRightMarginOnSubscriptContainer: true,
             horizontalStacking,
             sort: CONST.REPORT_ACTION_AVATARS.SORT_BY.REVERSE,
             fallbackDisplayName: FALLBACK_NAME,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Replaces the boolean `noRightMarginOnSubscriptContainer` prop on `ReportActionAvatars` and `ReportAvatar` with a generic `subscriptAvatarContainerStyle` style prop.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/99941
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open app, sign in to an account with a workspace.
2. Navigate to Workspaces > [workspace] > Rooms.
3. Verify that room avatars in the table render with no extra right margin.


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="363" height="771" alt="image" src="https://github.com/user-attachments/assets/3b2c2768-c601-402c-92dd-f41f03e93aba" />
</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="357" height="756" alt="image" src="https://github.com/user-attachments/assets/c7ef56c8-ee81-4bba-af6c-c52e499d8203" />
</details>

<details>
<summary>iOS: Native</summary>

<img width="402" height="852" alt="image" src="https://github.com/user-attachments/assets/cf9a7ed4-aa51-4fdf-9452-e096ed3a23ac" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="404" height="864" alt="image" src="https://github.com/user-attachments/assets/ac6fb1e0-2eb1-4b9c-b514-c78bb9d88c0c" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/337aa8bc-1e3b-4fe6-ab80-9c272fc68921" />

</details>
