### PR TITLE
Fix "Email not found" when opening a DM with a brand-new email after creating an expense

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2935,33 +2935,21 @@ function isOneOnOneChat(report: OnyxEntry<Report>, currentUserAccountID?: number
  * resolve a stale/optimistic reportID to the real chat (returned as preexistingReportID) instead of
  * failing with "Report not found". Returns an empty list for any report that is not a 1:1 DM.
  *
- * Only the login is returned. The other participant may still be an invited user whose accountID was
- * generated locally (see generateAccountID) and does not exist on the server yet, and sending that ID
- * in accountIDList makes OpenReport fail with "Email not found". The server resolves a DM from the
- * emailList alone, the same way navigateToAndOpenReport creates one.
+ * Only the login is returned, never the accountID. The other participant may be an invited user whose
+ * accountID was generated locally (see generateAccountID) and does not exist on the server yet, and sending
+ * that ID in accountIDList makes OpenReport fail with "Email not found". This cannot be gated on
+ * isOptimisticPersonalDetail because not every flow sets it (sendMoney writes the recipient's optimistic
+ * detail without it). The login alone is enough for the server to resolve a 1:1 DM, the same way
+ * navigateToAndOpenReport creates one, so a real accountID adds nothing here.
  */
-function getOneOnOneChatParticipants(
-    report: OnyxEntry<Report>,
-    personalDetails: OnyxEntry<PersonalDetailsList>,
-    currentUserAccountID: number | undefined,
-): Array<{login: string; accountID?: number}> {
+function getOneOnOneChatParticipants(report: OnyxEntry<Report>, personalDetails: OnyxEntry<PersonalDetailsList>, currentUserAccountID: number | undefined): Array<{login: string}> {
     if (!currentUserAccountID || !isOneOnOneChat(report, currentUserAccountID)) {
         return [];
     }
     return Object.keys(report?.participants ?? {})
         .map(Number)
         .filter((accountID) => accountID !== currentUserAccountID)
-        .map((accountID) => {
-            const personalDetail = personalDetails?.[accountID];
-            // An invited user's accountID is generated locally (see generateAccountID) and does not exist on
-            // the server yet, so sending it in accountIDList makes OpenReport fail with "Email not found".
-            // A real accountID is still sent so the server can resolve the DM unambiguously when the cached
-            // login is stale or is a secondary login.
-            return {
-                login: personalDetail?.login ?? '',
-                ...(personalDetail?.isOptimisticPersonalDetail ? {} : {accountID}),
-            };
-        })
+        .map((accountID) => ({login: personalDetails?.[accountID]?.login ?? ''}))
         .filter((participant) => !!participant.login);
 }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2940,14 +2940,28 @@ function isOneOnOneChat(report: OnyxEntry<Report>, currentUserAccountID?: number
  * in accountIDList makes OpenReport fail with "Email not found". The server resolves a DM from the
  * emailList alone, the same way navigateToAndOpenReport creates one.
  */
-function getOneOnOneChatParticipants(report: OnyxEntry<Report>, personalDetails: OnyxEntry<PersonalDetailsList>, currentUserAccountID: number | undefined): Array<{login: string}> {
+function getOneOnOneChatParticipants(
+    report: OnyxEntry<Report>,
+    personalDetails: OnyxEntry<PersonalDetailsList>,
+    currentUserAccountID: number | undefined,
+): Array<{login: string; accountID?: number}> {
     if (!currentUserAccountID || !isOneOnOneChat(report, currentUserAccountID)) {
         return [];
     }
     return Object.keys(report?.participants ?? {})
         .map(Number)
         .filter((accountID) => accountID !== currentUserAccountID)
-        .map((accountID) => ({login: personalDetails?.[accountID]?.login ?? ''}))
+        .map((accountID) => {
+            const personalDetail = personalDetails?.[accountID];
+            // An invited user's accountID is generated locally (see generateAccountID) and does not exist on
+            // the server yet, so sending it in accountIDList makes OpenReport fail with "Email not found".
+            // A real accountID is still sent so the server can resolve the DM unambiguously when the cached
+            // login is stale or is a secondary login.
+            return {
+                login: personalDetail?.login ?? '',
+                ...(personalDetail?.isOptimisticPersonalDetail ? {} : {accountID}),
+            };
+        })
         .filter((participant) => !!participant.login);
 }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2934,19 +2934,20 @@ function isOneOnOneChat(report: OnyxEntry<Report>, currentUserAccountID?: number
  * Returns the other participant of a cached 1:1 DM as OpenReport participant info, so the server can
  * resolve a stale/optimistic reportID to the real chat (returned as preexistingReportID) instead of
  * failing with "Report not found". Returns an empty list for any report that is not a 1:1 DM.
+ *
+ * Only the login is returned. The other participant may still be an invited user whose accountID was
+ * generated locally (see generateAccountID) and does not exist on the server yet, and sending that ID
+ * in accountIDList makes OpenReport fail with "Email not found". The server resolves a DM from the
+ * emailList alone, the same way navigateToAndOpenReport creates one.
  */
-function getOneOnOneChatParticipants(
-    report: OnyxEntry<Report>,
-    personalDetails: OnyxEntry<PersonalDetailsList>,
-    currentUserAccountID: number | undefined,
-): Array<{login: string; accountID: number}> {
+function getOneOnOneChatParticipants(report: OnyxEntry<Report>, personalDetails: OnyxEntry<PersonalDetailsList>, currentUserAccountID: number | undefined): Array<{login: string}> {
     if (!currentUserAccountID || !isOneOnOneChat(report, currentUserAccountID)) {
         return [];
     }
     return Object.keys(report?.participants ?? {})
         .map(Number)
         .filter((accountID) => accountID !== currentUserAccountID)
-        .map((accountID) => ({login: personalDetails?.[accountID]?.login ?? '', accountID}))
+        .map((accountID) => ({login: personalDetails?.[accountID]?.login ?? ''}))
         .filter((participant) => !!participant.login);
 }
 

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -5286,10 +5286,10 @@ describe('actions/Report', () => {
             global.fetch = TestHelper.createGlobalFetchMock();
             const REPORT_ID = 'dm2';
             const optimisticAccountID = generateAccountID('new@user.com');
-            const optimisticPersonalDetails = {
+            const optimisticPersonalDetails: OnyxTypes.PersonalDetailsList = {
                 [optimisticAccountID]: {accountID: optimisticAccountID, login: 'new@user.com', isOptimisticPersonalDetail: true},
             };
-            const dmReport = {
+            const dmReport: OnyxTypes.Report = {
                 reportID: REPORT_ID,
                 type: CONST.REPORT.TYPE.CHAT,
                 policyID: CONST.POLICY.ID_FAKE,

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -37,6 +37,7 @@ import * as SequentialQueue from '@src/libs/Network/SequentialQueue';
 import {setHasRadio} from '@src/libs/NetworkState';
 import * as ReportUtils from '@src/libs/ReportUtils';
 import type * as SearchQueryUtilsType from '@src/libs/SearchQueryUtils';
+import {generateAccountID} from '@src/libs/UserUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -5278,6 +5279,38 @@ describe('actions/Report', () => {
                 reportID: REPORT_ID,
                 emailList: 'other@test.com',
                 accountIDList: '2',
+            });
+        });
+
+        it('should send an empty accountIDList for a DM with an invited user who has no account yet', async () => {
+            global.fetch = TestHelper.createGlobalFetchMock();
+            const REPORT_ID = 'dm2';
+            const optimisticAccountID = generateAccountID('new@user.com');
+            const optimisticPersonalDetails = {
+                [optimisticAccountID]: {accountID: optimisticAccountID, login: 'new@user.com', isOptimisticPersonalDetail: true},
+            };
+            const dmReport = {
+                reportID: REPORT_ID,
+                type: CONST.REPORT.TYPE.CHAT,
+                policyID: CONST.POLICY.ID_FAKE,
+                participants: ReportUtils.buildParticipantsFromAccountIDs([1, optimisticAccountID]),
+            };
+
+            Report.openReport({
+                conciergeChat: undefined,
+                reportID: REPORT_ID,
+                introSelected: undefined,
+                betas: undefined,
+                hasReportActions: true,
+                currentUserAccountID: 1,
+                participants: ReportUtils.getOneOnOneChatParticipants(dmReport, optimisticPersonalDetails, 1),
+            });
+            await waitForBatchedUpdates();
+
+            TestHelper.expectAPICommandToHaveBeenCalledWith(WRITE_COMMANDS.OPEN_REPORT, 0, {
+                reportID: REPORT_ID,
+                emailList: 'new@user.com',
+                accountIDList: '',
             });
         });
     });

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -12102,8 +12102,8 @@ describe('ReportUtils', () => {
             participants: buildParticipantsFromAccountIDs([currentUserAccountID, OTHER_ACCOUNT_ID]),
         };
 
-        it('should return the other participant of a 1:1 DM with their login only', () => {
-            expect(getOneOnOneChatParticipants(dmReport, personalDetailsList, currentUserAccountID)).toEqual([{login: 'other@test.com'}]);
+        it('should return the other participant of a 1:1 DM with their login and real accountID', () => {
+            expect(getOneOnOneChatParticipants(dmReport, personalDetailsList, currentUserAccountID)).toStrictEqual([{login: 'other@test.com', accountID: OTHER_ACCOUNT_ID}]);
         });
 
         it('should not send a locally generated accountID for an invited user who has no account yet', () => {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -12102,8 +12102,8 @@ describe('ReportUtils', () => {
             participants: buildParticipantsFromAccountIDs([currentUserAccountID, OTHER_ACCOUNT_ID]),
         };
 
-        it('should return the other participant of a 1:1 DM with their login and real accountID', () => {
-            expect(getOneOnOneChatParticipants(dmReport, personalDetailsList, currentUserAccountID)).toStrictEqual([{login: 'other@test.com', accountID: OTHER_ACCOUNT_ID}]);
+        it('should return the other participant of a 1:1 DM with their login only, even when they have a real accountID', () => {
+            expect(getOneOnOneChatParticipants(dmReport, personalDetailsList, currentUserAccountID)).toStrictEqual([{login: 'other@test.com'}]);
         });
 
         it('should not send a locally generated accountID for an invited user who has no account yet', () => {
@@ -12117,9 +12117,21 @@ describe('ReportUtils', () => {
                 ...dmReport,
                 participants: buildParticipantsFromAccountIDs([currentUserAccountID, optimisticAccountID]),
             };
-            const participants = getOneOnOneChatParticipants(optimisticDMReport, optimisticPersonalDetails, currentUserAccountID);
-            expect(participants).toEqual([{login: 'new@user.com'}]);
-            expect(participants.at(0)).not.toHaveProperty('accountID');
+            expect(getOneOnOneChatParticipants(optimisticDMReport, optimisticPersonalDetails, currentUserAccountID)).toStrictEqual([{login: 'new@user.com'}]);
+        });
+
+        it('should not send a locally generated accountID when the optimistic detail carries no flag', () => {
+            // sendMoney (Pay someone) writes the recipient's optimistic detail without
+            // isOptimisticPersonalDetail - see src/libs/actions/IOU/SendMoney.ts
+            const optimisticAccountID = generateAccountID('new@user.com');
+            const unflaggedPersonalDetails: PersonalDetailsList = {
+                [optimisticAccountID]: {accountID: optimisticAccountID, login: 'new@user.com'},
+            };
+            const optimisticDMReport: Report = {
+                ...dmReport,
+                participants: buildParticipantsFromAccountIDs([currentUserAccountID, optimisticAccountID]),
+            };
+            expect(getOneOnOneChatParticipants(optimisticDMReport, unflaggedPersonalDetails, currentUserAccountID)).toStrictEqual([{login: 'new@user.com'}]);
         });
 
         it('should return an empty list for reports that are not 1:1 DMs', () => {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -224,6 +224,7 @@ import {
 } from '@libs/ReportUtils';
 import {buildTransactionsByReportID} from '@libs/TodosUtils';
 import {buildOptimisticTransaction} from '@libs/TransactionUtils';
+import {generateAccountID} from '@libs/UserUtils';
 import ViolationsUtils from '@libs/Violations/ViolationsUtils';
 
 import CONST from '@src/CONST';
@@ -12101,8 +12102,24 @@ describe('ReportUtils', () => {
             participants: buildParticipantsFromAccountIDs([currentUserAccountID, OTHER_ACCOUNT_ID]),
         };
 
-        it('should return the other participant of a 1:1 DM with their login and accountID', () => {
-            expect(getOneOnOneChatParticipants(dmReport, personalDetailsList, currentUserAccountID)).toEqual([{login: 'other@test.com', accountID: OTHER_ACCOUNT_ID}]);
+        it('should return the other participant of a 1:1 DM with their login only', () => {
+            expect(getOneOnOneChatParticipants(dmReport, personalDetailsList, currentUserAccountID)).toEqual([{login: 'other@test.com'}]);
+        });
+
+        it('should not send a locally generated accountID for an invited user who has no account yet', () => {
+            // An invited (brand-new) email gets a client-generated accountID and an optimistic personal detail.
+            // That accountID does not exist on the server, so only the login may be passed to OpenReport.
+            const optimisticAccountID = generateAccountID('new@user.com');
+            const optimisticPersonalDetails: PersonalDetailsList = {
+                [optimisticAccountID]: {accountID: optimisticAccountID, login: 'new@user.com', isOptimisticPersonalDetail: true},
+            };
+            const optimisticDMReport: Report = {
+                ...dmReport,
+                participants: buildParticipantsFromAccountIDs([currentUserAccountID, optimisticAccountID]),
+            };
+            const participants = getOneOnOneChatParticipants(optimisticDMReport, optimisticPersonalDetails, currentUserAccountID);
+            expect(participants).toEqual([{login: 'new@user.com'}]);
+            expect(participants.at(0)).not.toHaveProperty('accountID');
         });
 
         it('should return an empty list for reports that are not 1:1 DMs', () => {


### PR DESCRIPTION
### Explanation of Change

When a manual expense is created for an email that has no Expensify account yet, the invited recipient is stored with a client-generated accountID (`generateAccountID(email)`) and an optimistic personal detail that carries the login. Once `RequestMoney` resolves and the optimistic DM is no longer flagged optimistic, `ReportFetchHandler` calls `openReport` and passes the other participant from `getOneOnOneChatParticipants`.

That helper returned `{login, accountID}` for every participant that has a login, so the locally generated ID was sent to the server in `accountIDList`. The server has never seen that ID and fails `OpenReport` with "Email not found", which lands in `report.errorFields.createChat` and is displayed in the newly created DM.

This was introduced in #98855, which started passing the DM participants to `OpenReport` so a stale/optimistic reportID can self-heal into the real chat. Before that, `fetchReport` sent no participants, so `accountIDList` was always empty here.

The fix is to have `getOneOnOneChatParticipants` return the **login only**:

- `accountID` is already optional on `ParticipantInfo`, so `openReport` filters it out and `accountIDList` goes out empty while `emailList` still carries the login.
- The server resolves a 1:1 DM from `emailList` alone. This is the same payload `navigateToAndOpenReport` sends when creating a DM, and the same rule #93164 applied for the identical symptom in #92515 (sharing to a new user).
- #98855 stays fixed: the self-heal only needs the participant pair to be resolvable, and that works by email.
- This is deliberately not gated on `isOptimisticPersonalDetail`: not every flow sets that flag (`sendMoney` writes the recipient's optimistic personal detail without it), so a flag-gated helper would still send the locally generated ID from **Pay someone**. Email-only is sufficient for a 1:1 DM, and we accept not sending an accountID here.

`getOneOnOneChatParticipants` has a single caller (`ReportFetchHandler`), so no other `OpenReport` payload changes. Unit tests in `tests/unit/ReportUtilsTest.ts` were updated: a real account's accountID is no longer returned, and two new cases assert that an invited user's locally generated accountID is never returned, with and without the `isOptimisticPersonalDetail` flag. A new integration test in `tests/actions/ReportTest.ts` builds the DM participants through the helper and asserts `OpenReport` is called with `emailList: 'new@user.com'` and `accountIDList: ''`. All fail against the pre-fix helper and pass with the fix.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99276
PROPOSAL: https://github.com/Expensify/App/issues/99276#issuecomment-5523490337

### Tests

1. Sign in and open the Inbox.
2. Go to FAB → Create expense → Manual and enter any amount.
3. Tap **Choose recipient** and type a brand-new email address that has never been used with Expensify (e.g. `newuser+<random>@example.com`).
4. Select the invite row for that email, then tap **Create expense**.
5. Verify the app navigates to the new DM with that user, the expense preview is shown, and **no "Email not found" error** appears in the chat (before the fix it shows under the report as a `createChat` error).
6. Reload the page while on that DM and verify it still opens cleanly with no error.
7. Regression for #98765: open an existing 1:1 DM with a real user from the LHN, reload while on it, and verify it opens normally (no "Report not found").
8. Regression for the invite path elsewhere: FAB → Pay someone → enter an amount → brand-new email → Pay. Verify the DM opens without an error.
9. Open a room, a group chat, a workspace chat and a thread and verify they still open normally (the helper only ever affects 1:1 DMs).

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline.
2. Repeat Tests steps 2–4 with another brand-new email.
3. Verify the optimistic DM and expense are shown greyed out, with no error.
4. Go back online.
5. Verify the expense syncs, the DM stays open and no "Email not found" error appears.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

Notes on the checklist above:

- No styles, assets, copy, UI, Storybook stories, deeplinks or message-editing code are touched, so those items have nothing to verify.
- The change is platform-agnostic: `ReportFetchHandler` has no `.native` variant and no narrow/wide branch, and the helper only affects the `OpenReport` payload for 1:1 DMs.
- Verified the payload directly on web: after `RequestMoney` for the brand-new email, the `OpenReport` request now carries `emailList=<new email>` and `accountIDList=` (empty), and the DM opens with no `createChat` error.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/07421ab8-1d45-4cd4-99d6-41cb2c3610c8



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/cbad53cb-628c-4442-92b8-fa6aaa2fbdac



</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/4de29795-64d0-4cd2-bbbc-8b80322bb6fb



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/c069d832-8c73-4357-a1bc-d255c1442087


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/5ec446f5-5d39-4e05-a5d7-90167055e656


</details>

