### PR TITLE
Flag the group's own snapshot entry when a whole-group delete removes it

### DIFF
--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -36,11 +36,7 @@ type ExpenseGroupedSearchViewProps = CommonSearchViewProps & TransactionViewExtr
 
 const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ?? `${index}`;
 
-const EMPTY_GROUP_KEYS: ReadonlySet<string> = new Set<string>();
-
 const isRowDeleted = (item: SearchListItem) => item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
-
-const isGroupFullyDeleted = (item: SearchListItem) => isTransactionGroupListItemType(item) && item.transactions.length > 0 && item.transactions.every(isRowDeleted);
 
 const isRowSelected = (key: string | undefined, selectedTransactions: SelectedTransactions) => !!(key && selectedTransactions[key]?.isSelected);
 
@@ -121,40 +117,9 @@ function ExpenseGroupedSearchView({
     const {isLargeScreenWidth} = useResponsiveLayout();
     const {isOffline} = useNetwork();
 
-    // A group row carries no pendingAction of its own: its delete state is read off its child transactions.
-    // Deleting every expense in a group therefore leaves a window where the children have already been cleared
-    // from the snapshot but the group entry has not, and the group would read as "not deleted" again until the
-    // next Search response drops it. Carrying the group keys last seen fully pending-delete forward keeps the row
-    // out of the list across that window. A key is dropped as soon as the group has a child that is not pending
-    // delete (the delete failed and was rolled back) or the group leaves the snapshot.
-    const [lastSeen, setLastSeen] = useState<{data: SearchListItem[] | undefined; keys: ReadonlySet<string>}>({data: undefined, keys: EMPTY_GROUP_KEYS});
-    let groupKeysPendingDelete = lastSeen.keys;
-    if (lastSeen.data !== sourceData) {
-        const nextKeys = new Set<string>();
-        for (const item of sourceData) {
-            const key = item.keyForList;
-            if (!key || !isTransactionGroupListItemType(item)) {
-                continue;
-            }
-            if (item.transactions.length === 0 ? lastSeen.keys.has(key) : item.transactions.every(isRowDeleted)) {
-                nextKeys.add(key);
-            }
-        }
-        groupKeysPendingDelete = nextKeys;
-        setLastSeen({data: sourceData, keys: nextKeys});
-    }
-
-    const isGroupPendingDelete = (item: SearchListItem) => isRowDeleted(item) || isGroupFullyDeleted(item) || (!!item.keyForList && groupKeysPendingDelete.has(item.keyForList));
-
-    // Once a deleted group's children are gone the row has nothing left to render, so drop it from the list and
-    // let its exit animation play. Offline the row stays put with its pending-delete styling, as elsewhere.
-    const data = useMemo(
-        () =>
-            isOffline
-                ? sourceData
-                : sourceData.filter((item) => !(isTransactionGroupListItemType(item) && item.transactions.length === 0 && groupKeysPendingDelete.has(item.keyForList ?? ''))),
-        [sourceData, isOffline, groupKeysPendingDelete],
-    );
+    // Deleting every expense in a group flags the group's own snapshot entry, so drop the row from the list and let
+    // its exit animation play. Offline the row stays put with its pending-delete styling, as elsewhere.
+    const data = useMemo(() => (isOffline ? sourceData : sourceData.filter((item) => !isRowDeleted(item))), [sourceData, isOffline]);
 
     // Wide web layouts split each group into a sticky header row plus an expandable children-container row.
     // Computed here (not from the shared hook) because the split list feeds back into the hook as `listData`.
@@ -308,7 +273,7 @@ function ExpenseGroupedSearchView({
             <AnimatedExitRow
                 shouldApplyAnimation={type === CONST.SEARCH.DATA_TYPES.EXPENSE && index < listData.length - 1}
                 hasItemsBeingRemoved={hasItemsBeingRemoved}
-                isRowExiting={isGroupPendingDelete(item)}
+                isRowExiting={isRowDeleted(item)}
             >
                 <TransactionGroupListItem
                     showTooltip

--- a/src/components/Search/ExpenseGroupedSearchView.tsx
+++ b/src/components/Search/ExpenseGroupedSearchView.tsx
@@ -1,5 +1,6 @@
 import type {ExtendedTargetedEvent} from '@components/SelectionList/ListItem/types';
 
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
@@ -15,7 +16,7 @@ import type {Transaction} from '@src/types/onyx';
 
 import type {NativeSyntheticEvent} from 'react-native';
 
-import React, {useImperativeHandle, useState} from 'react';
+import React, {useImperativeHandle, useMemo, useState} from 'react';
 
 import type {SearchListItem} from './SearchList/ListItem/types';
 import type {CommonSearchViewProps, TransactionViewExtras} from './searchViewProps';
@@ -35,9 +36,11 @@ type ExpenseGroupedSearchViewProps = CommonSearchViewProps & TransactionViewExtr
 
 const keyExtractor = (item: SearchListItem, index: number) => item.keyForList ?? `${index}`;
 
+const EMPTY_GROUP_KEYS: ReadonlySet<string> = new Set<string>();
+
 const isRowDeleted = (item: SearchListItem) => item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
 
-const isGroupRowExiting = (item: SearchListItem) => isRowDeleted(item) || (isTransactionGroupListItemType(item) && item.transactions.length > 0 && item.transactions.every(isRowDeleted));
+const isGroupFullyDeleted = (item: SearchListItem) => isTransactionGroupListItemType(item) && item.transactions.length > 0 && item.transactions.every(isRowDeleted);
 
 const isRowSelected = (key: string | undefined, selectedTransactions: SelectedTransactions) => !!(key && selectedTransactions[key]?.isSelected);
 
@@ -94,7 +97,7 @@ function buildNewTransactionIDMap(data: SearchListItem[], newTransactions: Trans
  */
 function ExpenseGroupedSearchView({
     queryJSON,
-    data,
+    data: sourceData,
     columns,
     canSelectMultiple,
     isActionColumnWide,
@@ -116,6 +119,42 @@ function ExpenseGroupedSearchView({
 }: ExpenseGroupedSearchViewProps) {
     const {type, groupBy} = queryJSON;
     const {isLargeScreenWidth} = useResponsiveLayout();
+    const {isOffline} = useNetwork();
+
+    // A group row carries no pendingAction of its own: its delete state is read off its child transactions.
+    // Deleting every expense in a group therefore leaves a window where the children have already been cleared
+    // from the snapshot but the group entry has not, and the group would read as "not deleted" again until the
+    // next Search response drops it. Carrying the group keys last seen fully pending-delete forward keeps the row
+    // out of the list across that window. A key is dropped as soon as the group has a child that is not pending
+    // delete (the delete failed and was rolled back) or the group leaves the snapshot.
+    const [lastSeen, setLastSeen] = useState<{data: SearchListItem[] | undefined; keys: ReadonlySet<string>}>({data: undefined, keys: EMPTY_GROUP_KEYS});
+    let groupKeysPendingDelete = lastSeen.keys;
+    if (lastSeen.data !== sourceData) {
+        const nextKeys = new Set<string>();
+        for (const item of sourceData) {
+            const key = item.keyForList;
+            if (!key || !isTransactionGroupListItemType(item)) {
+                continue;
+            }
+            if (item.transactions.length === 0 ? lastSeen.keys.has(key) : item.transactions.every(isRowDeleted)) {
+                nextKeys.add(key);
+            }
+        }
+        groupKeysPendingDelete = nextKeys;
+        setLastSeen({data: sourceData, keys: nextKeys});
+    }
+
+    const isGroupPendingDelete = (item: SearchListItem) => isRowDeleted(item) || isGroupFullyDeleted(item) || (!!item.keyForList && groupKeysPendingDelete.has(item.keyForList));
+
+    // Once a deleted group's children are gone the row has nothing left to render, so drop it from the list and
+    // let its exit animation play. Offline the row stays put with its pending-delete styling, as elsewhere.
+    const data = useMemo(
+        () =>
+            isOffline
+                ? sourceData
+                : sourceData.filter((item) => !(isTransactionGroupListItemType(item) && item.transactions.length === 0 && groupKeysPendingDelete.has(item.keyForList ?? ''))),
+        [sourceData, isOffline, groupKeysPendingDelete],
+    );
 
     // Wide web layouts split each group into a sticky header row plus an expandable children-container row.
     // Computed here (not from the shared hook) because the split list feeds back into the hook as `listData`.
@@ -137,7 +176,6 @@ function ExpenseGroupedSearchView({
     const [visibleColumns] = useOnyx(ONYXKEYS.FORMS.SEARCH_ADVANCED_FILTERS_FORM, {selector: columnsSelector});
 
     const {
-        isOffline,
         isKeyboardShown,
         safeAreaPaddingBottomStyle,
         toggle,
@@ -270,7 +308,7 @@ function ExpenseGroupedSearchView({
             <AnimatedExitRow
                 shouldApplyAnimation={type === CONST.SEARCH.DATA_TYPES.EXPENSE && index < listData.length - 1}
                 hasItemsBeingRemoved={hasItemsBeingRemoved}
-                isRowExiting={isGroupRowExiting(item)}
+                isRowExiting={isGroupPendingDelete(item)}
             >
                 <TransactionGroupListItem
                     showTooltip

--- a/src/components/Search/SearchList/ListItem/TransactionGroupListItem.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionGroupListItem.tsx
@@ -462,12 +462,6 @@ function TransactionGroupListItemImpl({
 
     useSyncFocus(pressableRef, !!isFocused, shouldSyncFocus);
 
-    const pendingAction =
-        item.pendingAction ??
-        (groupItem.transactions.length > 0 && groupItem.transactions.every((transaction) => isTransactionPendingDelete(transaction))
-            ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE
-            : undefined);
-
     const snapshotData = transactionsSnapshot?.data;
     const groupViolations: Record<string, TransactionViolations | undefined> = {};
     if (snapshotData) {
@@ -513,7 +507,7 @@ function TransactionGroupListItemImpl({
     }
 
     return (
-        <OfflineWithFeedback pendingAction={pendingAction}>
+        <OfflineWithFeedback pendingAction={item.pendingAction}>
             <PressableWithFeedback
                 ref={pressableRef}
                 onLongPress={onLongPress}

--- a/src/hooks/useDeleteTransactions.ts
+++ b/src/hooks/useDeleteTransactions.ts
@@ -11,6 +11,7 @@ import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {calculateAmount as calculateIOUAmount} from '@libs/IOUUtils';
 import {getOriginalMessage, isActionableTrackExpense, isMoneyRequestAction, isTrackExpenseAction} from '@libs/ReportActionsUtils';
 import {isArchivedReport, isExpenseReport, isInvoiceReport, isIOUReport, isSelfDM} from '@libs/ReportUtils';
+import type {SearchGroupKey} from '@libs/SearchUIUtils';
 import {getActiveGroupSearchHashes} from '@libs/SearchUIUtils';
 import {
     getChildTransactions,
@@ -147,6 +148,7 @@ function useDeleteTransactions({report, reportActions, policy}: UseDeleteTransac
      * @param duplicateTransactionViolations - Collection of duplicate transaction violations
      * @param currentSearchHash - Current search hash for updating split transactions
      * @param isSingleTransactionView - Optional flag indicating if the deletion is from a single transaction view
+     * @param fullyDeletedGroupKeys - Grouped-search group rows this delete wipes out entirely
      * @returns Result describing whether the delete redirected or deleted transaction threads
      */
     const deleteTransactions = useCallback(
@@ -156,6 +158,7 @@ function useDeleteTransactions({report, reportActions, policy}: UseDeleteTransac
             duplicateTransactionViolations: OnyxCollection<TransactionViolations>,
             currentSearchHash?: number,
             isSingleTransactionView?: boolean,
+            fullyDeletedGroupKeys?: SearchGroupKey[],
         ): DeleteTransactionsResult => {
             if (!transactionIDs.length) {
                 return {
@@ -402,6 +405,8 @@ function useDeleteTransactions({report, reportActions, policy}: UseDeleteTransac
                     isSingleTransactionView,
                     transactionIDsPendingDeletion: deletedTransactionIDs,
                     selectedTransactionIDs: transactionIDs,
+                    searchHash: currentSearchHash,
+                    fullyDeletedGroupKeys,
                     allTransactionViolationsParam: transactionViolations,
                     currentUserAccountID: currentUserPersonalDetails.accountID,
                     currentUserEmail: currentUserPersonalDetails.email ?? '',

--- a/src/hooks/useSearchBulkActions.ts
+++ b/src/hooks/useSearchBulkActions.ts
@@ -79,6 +79,7 @@ import {
     serializeQueryJSONForBackend,
 } from '@libs/SearchQueryUtils';
 import refreshSearchAfterReportAction from '@libs/SearchRefreshUtils';
+import type {SearchGroupKey} from '@libs/SearchUIUtils';
 import {
     getColumnsToShow,
     getSearchColumnTranslationKey,
@@ -201,25 +202,35 @@ function isGroupSelection(key: string, transaction: SelectedTransactions[string]
     return key.startsWith(CONST.SEARCH.GROUP_PREFIX) || (!!transaction.isSelectedViaGroup && !!transaction.groupKey);
 }
 
+/**
+ * The group rows a selection covers in full.
+ *
+ * Selecting a whole group row stamps `isSelectedViaGroup` + `groupKey` on every one of its transactions, and
+ * deselecting any single child clears that flag for the rest of the group. So a selection entry still carrying the
+ * flag means "the user selected this entire group", and an empty group row is selected under its own group key.
+ */
+function getSelectedGroupKeys(selectedTransactions: SelectedTransactions): SearchGroupKey[] {
+    const groupKeys = new Set<SearchGroupKey>();
+    for (const [key, transaction] of Object.entries(selectedTransactions)) {
+        if (!isGroupSelection(key, transaction)) {
+            continue;
+        }
+        const groupKey = isGroupEntry(key) ? key : transaction.groupKey;
+        if (groupKey && isGroupEntry(groupKey)) {
+            groupKeys.add(groupKey);
+        }
+    }
+    return [...groupKeys];
+}
+
 function addSelectedGroupsFilter(queryJSON: SearchQueryJSON, selectedTransactions: SelectedTransactions, searchData: SearchResultDataType | undefined): SearchQueryJSON {
     const {groupBy} = queryJSON;
     if (!groupBy || !searchData) {
         return queryJSON;
     }
 
-    const groupKeys = new Set<string>();
-    for (const [key, transaction] of Object.entries(selectedTransactions)) {
-        if (!isGroupSelection(key, transaction)) {
-            continue;
-        }
-        if (key.startsWith(CONST.SEARCH.GROUP_PREFIX)) {
-            groupKeys.add(key);
-        } else if (transaction.groupKey) {
-            groupKeys.add(transaction.groupKey);
-        }
-    }
-
-    if (groupKeys.size === 0) {
+    const groupKeys = getSelectedGroupKeys(selectedTransactions);
+    if (groupKeys.length === 0) {
         return queryJSON;
     }
 
@@ -1262,11 +1273,17 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
                 }
             }
 
+            // A group row's snapshot entry outlives its child transactions, so the row would read as "not deleted"
+            // again between the children being cleared and the next Search response dropping the group. Selecting a
+            // whole group records that on every one of its transactions, so the group rows this delete wipes out are
+            // already known: flag them so the row leaves the list once and stays out.
+            const fullyDeletedGroupKeys = queryJSON?.groupBy ? getSelectedGroupKeys(selectedTransactions) : [];
+
             // Route individual transactions through the split-aware hook so that deleting a
             // split child triggers updateSplitTransactions (e.g. reverse-split) instead of a
             // bare deleteMoneyRequest.
             if (transactionIDsToDelete.length > 0) {
-                deleteTransactionsFromHook(transactionIDsToDelete, duplicateTransactions, duplicateTransactionViolations, hash);
+                deleteTransactionsFromHook(transactionIDsToDelete, duplicateTransactions, duplicateTransactionViolations, hash, undefined, fullyDeletedGroupKeys);
             }
 
             // Whole-report deletions keep their existing path.
@@ -1295,6 +1312,7 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
         showConfirmModal,
         deleteModalTitle,
         deleteModalPrompt,
+        queryJSON?.groupBy,
         translate,
         allTransactions,
         allTransactionViolations,
@@ -2975,5 +2993,5 @@ function useSearchBulkActions({queryJSON}: UseSearchBulkActionsParams) {
 }
 
 export default useSearchBulkActions;
-export {shouldShowBulkDuplicateOption};
+export {getSelectedGroupKeys, shouldShowBulkDuplicateOption};
 export type {SearchHeaderOptionValue};

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -7313,4 +7313,4 @@ export {
     SKIPPED_SEARCH_FILTERS,
     SEARCH_TYPE_MENU_ICON_NAMES,
 };
-export type {SavedSearchMenuItem, SearchTypeMenuSection, SearchTypeMenuItem, SearchDateModifier, SearchDateModifierLower, SearchKey, GroupBySection, SearchFilter};
+export type {SavedSearchMenuItem, SearchTypeMenuSection, SearchTypeMenuItem, SearchDateModifier, SearchDateModifierLower, SearchKey, SearchGroupKey, GroupBySection, SearchFilter};

--- a/src/libs/actions/IOU/DeleteMoneyRequest.ts
+++ b/src/libs/actions/IOU/DeleteMoneyRequest.ts
@@ -24,6 +24,7 @@ import {
     isReportTotalPending,
     updateOptimisticParentReportAction,
 } from '@libs/ReportUtils';
+import type {SearchGroupKey} from '@libs/SearchUIUtils';
 import {getAmount, getCurrency, isOnHold, removeTransactionFromDuplicateTransactionViolation} from '@libs/TransactionUtils';
 
 import {clearByKey as clearPdfByOnyxKey} from '@userActions/CachedPDFPaths';
@@ -44,6 +45,7 @@ import Onyx from 'react-native-onyx';
 
 import {getAllReportActionsFromIOU, getAllReportNameValuePairs, getAllReports, getAllTransactions, getAllTransactionViolations} from '.';
 import {getReportPreviewReportAction, maybeUpdateReportNameForFormulaTitle} from './MoneyRequestBuilder';
+import {getGroupPendingDeleteOnyxUpdate} from './SearchUpdate';
 
 type PrepareToCleanUpMoneyRequestResult = {
     shouldDeleteTransactionThread: boolean;
@@ -71,6 +73,9 @@ type DeleteMoneyRequestFunctionParams = {
     isSingleTransactionView?: boolean;
     transactionIDsPendingDeletion?: string[];
     selectedTransactionIDs?: string[];
+    /** The grouped-search snapshot hash the delete was fired from, and the group rows it wipes out entirely. */
+    searchHash?: number;
+    fullyDeletedGroupKeys?: SearchGroupKey[];
     allTransactionViolationsParam: OnyxCollection<OnyxTypes.TransactionViolations>;
     currentUserAccountID: number;
     currentUserEmail: string;
@@ -784,6 +789,8 @@ function deleteMoneyRequest({
     isSingleTransactionView = false,
     transactionIDsPendingDeletion,
     selectedTransactionIDs,
+    searchHash,
+    fullyDeletedGroupKeys,
     allTransactionViolationsParam,
     currentUserAccountID,
     currentUserEmail,
@@ -836,7 +843,13 @@ function deleteMoneyRequest({
     // STEP 2: Build Onyx data
     // The logic mostly resembles the cleanUpMoneyRequest function
     const optimisticData: Array<
-        OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS | typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS>
+        OnyxUpdate<
+            | typeof ONYXKEYS.COLLECTION.TRANSACTION
+            | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS
+            | typeof ONYXKEYS.COLLECTION.REPORT
+            | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS
+            | typeof ONYXKEYS.COLLECTION.SNAPSHOT
+        >
     > = [
         {
             onyxMethod: Onyx.METHOD.SET,
@@ -852,7 +865,13 @@ function deleteMoneyRequest({
     });
 
     const failureData: Array<
-        OnyxUpdate<typeof ONYXKEYS.COLLECTION.TRANSACTION | typeof ONYXKEYS.COLLECTION.REPORT | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS>
+        OnyxUpdate<
+            | typeof ONYXKEYS.COLLECTION.TRANSACTION
+            | typeof ONYXKEYS.COLLECTION.REPORT
+            | typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS
+            | typeof ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS
+            | typeof ONYXKEYS.COLLECTION.SNAPSHOT
+        >
     > = [
         {
             onyxMethod: Onyx.METHOD.SET,
@@ -1090,6 +1109,15 @@ function deleteMoneyRequest({
         transactionID,
         reportActionID: reportAction.reportActionID,
     };
+
+    // A group row in a grouped search outlives its child transactions, so flagging the group's own snapshot entry
+    // is what keeps the row out of the list until the next Search response drops it. Riding along with this request
+    // is what puts the row back if the delete fails.
+    const groupPendingDeleteData = getGroupPendingDeleteOnyxUpdate(searchHash, fullyDeletedGroupKeys ?? []);
+    if (groupPendingDeleteData) {
+        optimisticData.push(...(groupPendingDeleteData.optimisticData ?? []));
+        failureData.push(...(groupPendingDeleteData.failureData ?? []));
+    }
 
     // STEP 3: Make the API request
     API.write(WRITE_COMMANDS.DELETE_MONEY_REQUEST, parameters, {optimisticData, successData, failureData});

--- a/src/libs/actions/IOU/SearchUpdate.ts
+++ b/src/libs/actions/IOU/SearchUpdate.ts
@@ -2,6 +2,7 @@ import type {SearchQueryJSON} from '@components/Search/types';
 
 import {isExpenseReport, isOptimisticPersonalDetail} from '@libs/ReportUtils';
 import {buildCannedSearchQuery, buildSearchQueryJSON, buildSearchQueryString, getCurrentSearchQueryJSON, getFilterFromQuery} from '@libs/SearchQueryUtils';
+import type {SearchGroupKey} from '@libs/SearchUIUtils';
 import {getSuggestedSearches, isEligibleForStatus} from '@libs/SearchUIUtils';
 import {isInvalidMerchantValue} from '@libs/ValidationUtils';
 
@@ -9,6 +10,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type * as OnyxTypes from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/IOU';
+import type * as OnyxCommon from '@src/types/onyx/OnyxCommon';
 import type {OnyxData} from '@src/types/onyx/Request';
 import type {SearchResultDataType} from '@src/types/onyx/SearchResults';
 
@@ -340,4 +342,44 @@ function getSearchOnyxUpdate({
     };
 }
 
-export {getSearchOnyxUpdate, shouldOptimisticallyUpdateSearch};
+/**
+ * Marks whole group rows as pending delete in a grouped search snapshot.
+ *
+ * A group row's own snapshot entry is the only thing that outlives its child transactions: the children are
+ * cleared from their per-group sub-snapshot as soon as the delete succeeds, while the group entry survives until
+ * the next Search response drops it. Flagging the entry is what keeps the row out of the list across that gap.
+ *
+ * The flag needs no successData: the Search response replaces the whole snapshot, so it clears itself.
+ */
+function getGroupPendingDeleteOnyxUpdate(hash: number | undefined, groupKeys: SearchGroupKey[]): OnyxData<typeof ONYXKEYS.COLLECTION.SNAPSHOT> | undefined {
+    if (hash === undefined || groupKeys.length === 0) {
+        return;
+    }
+
+    const buildGroupData = (pendingAction: OnyxCommon.PendingAction | null): NullishDeep<SearchResultDataType> => {
+        const groupData: NullishDeep<SearchResultDataType> = {};
+        for (const groupKey of groupKeys) {
+            groupData[groupKey] = {pendingAction};
+        }
+        return groupData;
+    };
+
+    return {
+        optimisticData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.SNAPSHOT}${hash}` as const,
+                value: {data: buildGroupData(CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE)},
+            },
+        ],
+        failureData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.SNAPSHOT}${hash}` as const,
+                value: {data: buildGroupData(null)},
+            },
+        ],
+    };
+}
+
+export {getGroupPendingDeleteOnyxUpdate, getSearchOnyxUpdate, shouldOptimisticallyUpdateSearch};

--- a/src/types/onyx/SearchResults.ts
+++ b/src/types/onyx/SearchResults.ts
@@ -134,11 +134,8 @@ type SearchTask = {
     statusNum: ValueOf<typeof CONST.REPORT.STATUS_NUM>;
 };
 
-/** Model of member grouped search result */
-type SearchMemberGroup = {
-    /** Account ID */
-    accountID: number;
-
+/** Fields every grouped search result carries, whatever it is grouped by */
+type SearchGroupBase = {
     /** Number of transactions */
     count: number;
 
@@ -147,21 +144,21 @@ type SearchMemberGroup = {
 
     /** Currency of total value */
     currency: string;
+
+    /** Set to `delete` while every expense in the group is being deleted, so the row can leave the list before the next Search response drops the group */
+    pendingAction?: OnyxCommon.PendingAction;
+};
+
+/** Model of member grouped search result */
+type SearchMemberGroup = SearchGroupBase & {
+    /** Account ID */
+    accountID: number;
 };
 
 /** Model of card grouped search result */
-type SearchCardGroup = {
+type SearchCardGroup = SearchGroupBase & {
     /** Cardholder account ID */
     accountID: number;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 
     /** Bank name */
     bank: string;
@@ -180,18 +177,9 @@ type SearchCardGroup = {
 };
 
 /** Model of withdrawal ID grouped search result */
-type SearchWithdrawalIDGroup = {
+type SearchWithdrawalIDGroup = SearchGroupBase & {
     /** Withdrawal ID */
     entryID: number;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 
     /** Masked account number */
     accountNumber: string;
@@ -231,114 +219,51 @@ type SearchWithdrawalIDGroup = {
 };
 
 /** Model of category grouped search result */
-type SearchCategoryGroup = {
+type SearchCategoryGroup = SearchGroupBase & {
     /** Category name */
     category: string;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** Model of merchant grouped search result */
-type SearchMerchantGroup = {
+type SearchMerchantGroup = SearchGroupBase & {
     /** Merchant name */
     merchant: string;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** Model of tag grouped search result */
-type SearchTagGroup = {
+type SearchTagGroup = SearchGroupBase & {
     /** Tag name */
     tag: string;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** Model of month grouped search result */
-type SearchMonthGroup = {
+type SearchMonthGroup = SearchGroupBase & {
     /** Year */
     year: number;
 
     /** Month (1-12) */
     month: number;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** Model of week grouped search result */
-type SearchWeekGroup = {
+type SearchWeekGroup = SearchGroupBase & {
     /** Week start date in YYYY-MM-DD format */
     week: string;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** Model of year grouped search result */
-type SearchYearGroup = {
+type SearchYearGroup = SearchGroupBase & {
     /** Year */
     year: number;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** Model of quarter grouped search result */
-type SearchQuarterGroup = {
+type SearchQuarterGroup = SearchGroupBase & {
     /** Year */
     year: number;
 
     /** Quarter (1-4) */
     quarter: number;
-
-    /** Number of transactions */
-    count: number;
-
-    /** Total value of transactions */
-    total: number;
-
-    /** Currency of total value */
-    currency: string;
 };
 
 /** SearchResultDataType */

--- a/tests/actions/IOU/SearchUpdateTest.ts
+++ b/tests/actions/IOU/SearchUpdateTest.ts
@@ -1,6 +1,6 @@
 import type {SearchQueryJSON} from '@components/Search/types';
 
-import {getSearchOnyxUpdate, shouldOptimisticallyUpdateSearch} from '@libs/actions/IOU/SearchUpdate';
+import {getGroupPendingDeleteOnyxUpdate, getSearchOnyxUpdate, shouldOptimisticallyUpdateSearch} from '@libs/actions/IOU/SearchUpdate';
 import initOnyxDerivedValues from '@libs/actions/OnyxDerived';
 import '@libs/actions/IOU/MoneyRequest';
 import type * as PolicyUtils from '@libs/PolicyUtils';
@@ -646,6 +646,30 @@ describe('actions/IOU', () => {
             const {update, transactionKey} = getSnapshotUpdateForModifiedMerchant('Edited Merchant');
             expect(update).toBeDefined();
             expect(update?.value).toHaveProperty(['data', transactionKey, 'modifiedMerchant'], 'Edited Merchant');
+        });
+    });
+
+    describe('getGroupPendingDeleteOnyxUpdate', () => {
+        const groupKey = `${CONST.SEARCH.GROUP_PREFIX}42` as const;
+        const otherGroupKey = `${CONST.SEARCH.GROUP_PREFIX}43` as const;
+
+        it('flags each group optimistically and clears the flag on failure', () => {
+            // A group row's snapshot entry outlives its child transactions, so the flag has to ride in the delete
+            // request itself: without the failureData a failed delete would hide the group row for good.
+            const result = getGroupPendingDeleteOnyxUpdate(1234, [groupKey, otherGroupKey]);
+
+            expect(result?.optimisticData?.at(0)?.key).toBe(`${ONYXKEYS.COLLECTION.SNAPSHOT}1234`);
+            expect(result?.optimisticData?.at(0)?.value).toHaveProperty(['data', groupKey, 'pendingAction'], CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+            expect(result?.optimisticData?.at(0)?.value).toHaveProperty(['data', otherGroupKey, 'pendingAction'], CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+
+            expect(result?.failureData?.at(0)?.key).toBe(`${ONYXKEYS.COLLECTION.SNAPSHOT}1234`);
+            expect(result?.failureData?.at(0)?.value).toHaveProperty(['data', groupKey, 'pendingAction'], null);
+            expect(result?.failureData?.at(0)?.value).toHaveProperty(['data', otherGroupKey, 'pendingAction'], null);
+        });
+
+        it('returns undefined for a delete that wipes out no whole group', () => {
+            expect(getGroupPendingDeleteOnyxUpdate(1234, [])).toBeUndefined();
+            expect(getGroupPendingDeleteOnyxUpdate(undefined, [groupKey])).toBeUndefined();
         });
     });
 });

--- a/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
+++ b/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
@@ -146,13 +146,17 @@ function countArmedExitAnimations(root: ReturnType<typeof render>['UNSAFE_root']
     return root.findAll((node) => typeof node.type !== 'string' && !!node.props && 'entering' in node.props && node.props.exiting != null).length;
 }
 
-/** Builds group rows, each carrying child transactions; `deletedTransactions` marks transaction indices as pending-delete. */
-function createMockGroupData(groups: Array<{transactionCount: number; deletedTransactions?: Set<number>}>): SearchListItem[] {
+/**
+ * Builds group rows, each carrying child transactions. `deletedTransactions` marks transaction indices as
+ * pending-delete; `isPendingDelete` flags the group row itself, which is what a whole-group delete does.
+ */
+function createMockGroupData(groups: Array<{transactionCount: number; deletedTransactions?: Set<number>; isPendingDelete?: boolean}>): SearchListItem[] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test fixtures are intentionally partial group rows
     return groups.map((group, i) => ({
         keyForList: `group-${i}`,
         cardID: i,
         action: CONST.SEARCH.ACTION_TYPES.VIEW,
+        pendingAction: group.isPendingDelete ? CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE : undefined,
         transactions: Array.from({length: group.transactionCount}, (_, j) => ({
             keyForList: `txn-${i}-${j}`,
             transactionID: `${i}-${j}`,
@@ -333,68 +337,60 @@ describe('ExpenseGroupedSearchView', () => {
         expect(countArmedExitAnimations(root)).toBe(0);
     });
 
-    it('keeps the FadeOutUp exit armed for a group whose every child transaction is pending delete', async () => {
-        // The group carries no pendingAction of its own; the pending delete lives on its children, and once they are all
-        // deleted the group row itself leaves the list, so it must arm its exit.
-        const {UNSAFE_root: root} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
-        await waitForBatchedUpdates();
-
-        expect(countArmedExitAnimations(root)).toBe(1);
-    });
-
-    it('keeps a fully deleted group row out of the list once its child transactions are cleared', async () => {
-        // Deleting every expense in a group clears the children from the snapshot before the group entry itself is
-        // dropped by the next Search response. Across that window the group has no pending-delete child left to read
-        // its state from, so without the remembered key the row would reappear and then vanish again.
-        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
-        await waitForBatchedUpdates();
-
-        act(() => setData(createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])));
+    it('drops a group row flagged pending delete from the list', async () => {
+        renderView({data: createMockGroupData([{transactionCount: 2, isPendingDelete: true}, {transactionCount: 1}])});
         await waitForBatchedUpdates();
 
         expect(screen.queryByTestId('row-group-0')).toBeNull();
         expect(screen.getByTestId('row-group-1')).toBeOnTheScreen();
     });
 
-    it('keeps a group row whose transactions have not loaded yet', async () => {
-        // An empty transaction list also means "this group's sub-snapshot has not arrived", so an empty group that was
-        // never deleting must still render.
-        renderView({data: createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])});
+    it('keeps a group row flagged pending delete out of the list after its child transactions are cleared', async () => {
+        // Deleting every expense in a group clears the children from their sub-snapshot before the next Search
+        // response drops the group entry. The row must not come back across that window.
+        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, isPendingDelete: true}, {transactionCount: 1}])});
         await waitForBatchedUpdates();
 
-        expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
+        act(() => setData(createMockGroupData([{transactionCount: 0, isPendingDelete: true}, {transactionCount: 1}])));
+        await waitForBatchedUpdates();
+
+        expect(screen.queryByTestId('row-group-0')).toBeNull();
     });
 
-    it('brings a group row back when a failed delete restores its child transactions', async () => {
-        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
-        await waitForBatchedUpdates();
-
-        act(() => setData(createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])));
+    it('brings a group row back when a failed delete clears its pending-delete flag', async () => {
+        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, isPendingDelete: true}, {transactionCount: 1}])});
         await waitForBatchedUpdates();
         expect(screen.queryByTestId('row-group-0')).toBeNull();
 
         act(() => setData(createMockGroupData([{transactionCount: 2}, {transactionCount: 1}])));
         await waitForBatchedUpdates();
+
         expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
     });
 
-    it('keeps a fully deleted group row visible while offline so its pending-delete styling shows', async () => {
+    it('keeps a group row flagged pending delete visible while offline so its pending-delete styling shows', async () => {
         mockIsOffline.current = true;
-        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
-        await waitForBatchedUpdates();
-
-        act(() => setData(createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])));
+        renderView({data: createMockGroupData([{transactionCount: 2, isPendingDelete: true}, {transactionCount: 1}])});
         await waitForBatchedUpdates();
 
         expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
     });
 
-    it('does not arm the FadeOutUp exit on a group that survives a partial delete', async () => {
-        // Only one of the group's transactions is pending delete, so the group row stays mounted: arming its exit would
-        // bring the flicker back for that group on remount.
-        const {UNSAFE_root: root} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0])}, {transactionCount: 1}])});
+    it('keeps a group row whose child transactions are all pending delete, since only the group flag removes a row', async () => {
+        // A group is deleted by flagging its own snapshot entry. Reading the state off the children instead is what
+        // made the row flicker, because the children are cleared before the group entry is.
+        renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
         await waitForBatchedUpdates();
 
-        expect(countArmedExitAnimations(root)).toBe(0);
+        expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
+    });
+
+    it('keeps a group row whose transactions have not loaded yet', async () => {
+        // An empty transaction list also means "this group's sub-snapshot has not arrived", so an empty group that is
+        // not flagged must still render.
+        renderView({data: createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])});
+        await waitForBatchedUpdates();
+
+        expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
     });
 });

--- a/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
+++ b/tests/unit/Search/ExpenseGroupedSearchViewTest.tsx
@@ -29,9 +29,10 @@ jest.mock('@hooks/useLocalize', () =>
     })),
 );
 
+const mockIsOffline = {current: false};
 jest.mock('@hooks/useNetwork', () =>
     jest.fn(() => ({
-        isOffline: false,
+        isOffline: mockIsOffline.current,
     })),
 );
 
@@ -179,7 +180,7 @@ type RenderOverrides = {
 };
 
 function renderView(overrides: RenderOverrides = {}) {
-    const data = overrides.data ?? createMockGroupData([{transactionCount: 1}, {transactionCount: 1}, {transactionCount: 1}]);
+    let data = overrides.data ?? createMockGroupData([{transactionCount: 1}, {transactionCount: 1}, {transactionCount: 1}]);
 
     function Wrapper() {
         const onSelectRow = useCallback((item: SearchListItem) => overrides.onSelectRow?.(item), []);
@@ -222,11 +223,19 @@ function renderView(overrides: RenderOverrides = {}) {
         );
     }
 
-    return render(
+    const buildTree = () => (
         <ComposeProviders components={[ThemeProviderWithLight, ThemeStylesProvider, OnyxListItemProvider, LocaleContextProvider, ScrollOffsetContextProvider]}>
             <Wrapper />
-        </ComposeProviders>,
+        </ComposeProviders>
     );
+    const result = render(buildTree());
+    return {
+        ...result,
+        setData: (nextData: SearchListItem[]) => {
+            data = nextData;
+            result.rerender(buildTree());
+        },
+    };
 }
 
 beforeAll(() => Onyx.init({keys: ONYXKEYS, evictableKeys: [ONYXKEYS.COLLECTION.REPORT]}));
@@ -239,6 +248,7 @@ beforeEach(() => {
     mockToggleAll.mockClear();
     mockSelectedTransactions.current = {};
     mockTopBar.current = null;
+    mockIsOffline.current = false;
     for (const key of Object.keys(mockRowSelect)) {
         delete mockRowSelect[key];
     }
@@ -330,6 +340,53 @@ describe('ExpenseGroupedSearchView', () => {
         await waitForBatchedUpdates();
 
         expect(countArmedExitAnimations(root)).toBe(1);
+    });
+
+    it('keeps a fully deleted group row out of the list once its child transactions are cleared', async () => {
+        // Deleting every expense in a group clears the children from the snapshot before the group entry itself is
+        // dropped by the next Search response. Across that window the group has no pending-delete child left to read
+        // its state from, so without the remembered key the row would reappear and then vanish again.
+        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
+        await waitForBatchedUpdates();
+
+        act(() => setData(createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])));
+        await waitForBatchedUpdates();
+
+        expect(screen.queryByTestId('row-group-0')).toBeNull();
+        expect(screen.getByTestId('row-group-1')).toBeOnTheScreen();
+    });
+
+    it('keeps a group row whose transactions have not loaded yet', async () => {
+        // An empty transaction list also means "this group's sub-snapshot has not arrived", so an empty group that was
+        // never deleting must still render.
+        renderView({data: createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])});
+        await waitForBatchedUpdates();
+
+        expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
+    });
+
+    it('brings a group row back when a failed delete restores its child transactions', async () => {
+        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
+        await waitForBatchedUpdates();
+
+        act(() => setData(createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])));
+        await waitForBatchedUpdates();
+        expect(screen.queryByTestId('row-group-0')).toBeNull();
+
+        act(() => setData(createMockGroupData([{transactionCount: 2}, {transactionCount: 1}])));
+        await waitForBatchedUpdates();
+        expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
+    });
+
+    it('keeps a fully deleted group row visible while offline so its pending-delete styling shows', async () => {
+        mockIsOffline.current = true;
+        const {setData} = renderView({data: createMockGroupData([{transactionCount: 2, deletedTransactions: new Set([0, 1])}, {transactionCount: 1}])});
+        await waitForBatchedUpdates();
+
+        act(() => setData(createMockGroupData([{transactionCount: 0}, {transactionCount: 1}])));
+        await waitForBatchedUpdates();
+
+        expect(screen.getByTestId('row-group-0')).toBeOnTheScreen();
     });
 
     it('does not arm the FadeOutUp exit on a group that survives a partial delete', async () => {

--- a/tests/unit/Search/getSelectedGroupKeysTest.ts
+++ b/tests/unit/Search/getSelectedGroupKeysTest.ts
@@ -1,0 +1,48 @@
+import type {SelectedTransactions} from '@components/Search/types';
+
+import {getSelectedGroupKeys} from '@hooks/useSearchBulkActions';
+
+import CONST from '@src/CONST';
+
+const groupKey = `${CONST.SEARCH.GROUP_PREFIX}42` as const;
+const otherGroupKey = `${CONST.SEARCH.GROUP_PREFIX}43` as const;
+
+function buildSelection(entries: Record<string, Partial<SelectedTransactions[string]>>): SelectedTransactions {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test fixtures are intentionally partial selection entries
+    return Object.fromEntries(Object.entries(entries).map(([key, entry]) => [key, {isSelected: true, ...entry}])) as SelectedTransactions;
+}
+
+describe('getSelectedGroupKeys', () => {
+    it('returns each group whose transactions were all selected via the group row', () => {
+        const keys = getSelectedGroupKeys(
+            buildSelection({
+                txn1: {isSelectedViaGroup: true, groupKey},
+                txn2: {isSelectedViaGroup: true, groupKey},
+                txn3: {isSelectedViaGroup: true, groupKey: otherGroupKey},
+            }),
+        );
+
+        expect(keys).toEqual([groupKey, otherGroupKey]);
+    });
+
+    it('returns an empty group row selected under its own group key', () => {
+        expect(getSelectedGroupKeys(buildSelection({[groupKey]: {}}))).toEqual([groupKey]);
+    });
+
+    it('skips a group left only partially selected', () => {
+        // Deselecting any child clears isSelectedViaGroup for the rest of the group, so the group survives the
+        // delete and must not be flagged.
+        const keys = getSelectedGroupKeys(
+            buildSelection({
+                txn1: {isSelectedViaGroup: false, groupKey},
+                txn2: {isSelectedViaGroup: false, groupKey},
+            }),
+        );
+
+        expect(keys).toEqual([]);
+    });
+
+    it('skips transactions selected outside of any group', () => {
+        expect(getSelectedGroupKeys(buildSelection({txn1: {}, txn2: {}}))).toEqual([]);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

(Neil's AI agent)

Deleting every expense in a group made the group row flash: it disappeared, came back, then disappeared again.

A grouped search reads from **two** Onyx keys. The main snapshot holds one `group_<id>` entry per group and nothing else — [`getMemberSections` builds one row per group entry](https://github.com/Expensify/App/blob/87f18aa9cc2/src/libs/SearchUIUtils.ts#L3586-L3612) with `transactions: []`. Each group's children live under a **separate hash**, [pulled in by `useSearchSnapshot`](https://github.com/Expensify/App/blob/87f18aa9cc2/src/components/Search/hooks/useSearchSnapshot.ts#L258-L285) via `useMultipleSnapshots`.

The group row had no `pendingAction` of its own — it [derived one from its children](https://github.com/Expensify/App/blob/87f18aa9cc2/src/components/Search/SearchList/ListItem/TransactionGroupListItem.tsx#L465-L469), and that derivation required `transactions.length > 0`. Since the two keys are cleared at different times, that produced three states:

1. All children pending delete → group derives `DELETE` → [`OfflineWithFeedback` hides the row's content](https://github.com/Expensify/App/blob/87f18aa9cc2/src/components/OfflineWithFeedback.tsx#L108). **Row gone.**
2. Delete succeeds, children cleared from the sub-snapshot → `transactions.length === 0`, nothing left to derive from → `pendingAction` is `undefined`. **Row back — the flash.**
3. The next `Search` response drops the group entry. **Row gone for good.**

The fix moves the delete state onto the group's own snapshot entry, which is the only thing that outlives its children:

- `pendingAction` moves to a new shared `SearchGroupBase` in [SearchResults.ts](https://github.com/Expensify/App/blob/87f18aa9cc2/src/types/onyx/SearchResults.ts#L136-L150), which also folds up the `count`/`total`/`currency` that all ten group models repeated.
- `getMemberSections` already spreads the group entry into the row, so `item.pendingAction` lights up and the existing `isRowDeleted` checks just work. The children-derived fallback is gone.
- Which groups a delete wipes out is already recorded on the selection: toggling a whole group row stamps `isSelectedViaGroup` + `groupKey` on every child, and deselecting any child clears it for the rest. `getSelectedGroupKeys` reads that, shared with the export path that already did the same thing inline.
- The flag rides in the delete request's own `optimisticData`/`failureData`, so a failed delete puts the row back. Delete runs once per transaction, so all of a group's requests carry the same idempotent merge and any one failing restores the row.
- No `successData` is needed: the `Search` response replaces the whole snapshot, so a surviving group loses the flag and a deleted group loses its entry.
- The view drops flagged rows from the list when online so the row collapses away instead of leaving a zero-height wrapper; offline it stays put with the usual pending-delete styling.

One deliberate trade-off: the group row now pops out rather than playing `FadeOutUp`, because it leaves the list on the same render the flag arrives. The surviving rows still slide up via `LinearTransition`, and the fade was mostly invisible anyway — `hideChildren` had already collapsed the row's content a step earlier.

### Fixed Issues
$ https://github.com/Expensify/App/issues/100122
PROPOSAL:

### Tests

(Neil's AI agent)

1. On a workspace with submissions and approvals enabled, have a member create at least two expenses with violations and submit them. Create two of your own too, so there are at least two submitters.
2. Go to Spend > Violations by submitter and set the Date exposed filter to This month. You should see one row per submitter.
3. Expand and collapse your own row.
4. Long press that row, select it, then choose Delete from the dropdown.
5. Verify the row animates out once and does not come back at any point. The other submitter's row stays fully rendered.
6. Repeat with a partial delete: expand a group, select only one of its expenses, and delete it. Verify the group row stays visible with its remaining expenses.
7. Repeat the whole-group delete on a regular expense search with `group-by:from` in the search query, and verify the same behavior.
- [ ] Verify that no errors appear in the JS console

### Offline tests

(Neil's AI agent)

1. Go offline.
2. Delete a whole group row from Spend > Violations by submitter.
3. Verify the row stays visible with the greyed-out/strikethrough pending-delete styling rather than disappearing.
4. Go back online and verify the row animates out once and stays gone.

### QA Steps

(Neil's AI agent)

Same as tests.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English.
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
