### PR TITLE
fix: use `getRootState`, so notification waits until navigation is ready

### DIFF
--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -834,11 +834,11 @@ function waitForProtectedRoutes() {
                 return;
             }
 
-            const unsubscribe = navigationRef.current?.addListener('state', () => {
+            const unsubscribe = navigationRef.addListener('state', () => {
                 if (!navContainsProtectedRoutes(navigationRef.getRootState())) {
                     return;
                 }
-                unsubscribe?.();
+                unsubscribe();
                 resolve();
             });
         });

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -826,18 +826,20 @@ function navContainsProtectedRoutes(state: State | undefined): boolean {
 function waitForProtectedRoutes() {
     return new Promise<void>((resolve) => {
         isNavigationReady().then(() => {
-            const currentState = navigationRef.current?.getState();
-            if (navContainsProtectedRoutes(currentState)) {
+            // `getState()` and the `state` event expose the container's own copy of the state, which has
+            // `routeNames` stripped until a navigator pushes its state up after mounting. Use `getRootState()`,
+            // which reads the hydrated state from the navigator and always carries `routeNames`.
+            if (navContainsProtectedRoutes(navigationRef.getRootState())) {
                 resolve();
                 return;
             }
 
-            const unsubscribe = navigationRef.current?.addListener('state', ({data}) => {
-                const state = data?.state;
-                if (navContainsProtectedRoutes(state)) {
-                    unsubscribe?.();
-                    resolve();
+            const unsubscribe = navigationRef.current?.addListener('state', () => {
+                if (!navContainsProtectedRoutes(navigationRef.getRootState())) {
+                    return;
                 }
+                unsubscribe?.();
+                resolve();
             });
         });
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

`waitForProtectedRoutes` read `navigationRef.current?.getState()` — the container's own copy of the navigation state, which has `routeNames` stripped until a navigator pushes its state up after mounting. The protected-routes check therefore never passed before the user navigated, so a push notification tap stalled indefinitely. Both the initial check and the `state` listener now use `getRootState()`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98520
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

**1. Push notification tap on a killed app navigates to the chat**

1. Sign in on an iOS device/simulator and force-quit the app.
2. From another account, send a message in a 1:1 chat with the signed-in user.
3. Tap the push notification.
4. Verify that the app opens directly on that chat, not on the Inbox/Home page.

On a simulator, steps 2-3 can be replaced with an injected notification (no APNs registration required):

```bash
cat > /tmp/push.apns <<'EOF'
{
  "Simulator Target Bundle": "com.expensify.expensifylite",
  "aps": {"alert": {"title": "Test Sender", "body": "Push navigation test"}},
  "payload": {"app": "new", "type": "reportComment", "title": "Test Sender", "reportID": <REAL_REPORT_ID>, "reportActionID": "1"}
}
EOF
xcrun simctl push booted /tmp/push.apns
```

**2. Push notification tap before any in-app navigation**

1. Launch the app and let it settle on the Inbox. **Do not navigate anywhere** — no tab presses, no opening a chat.
2. Background the app.
3. Have another account send a message in a 1:1 chat, then tap the notification.
4. Verify that the chat opens immediately.
5. Verify that you do **not** have to press a bottom tab or navigate elsewhere before the chat appears.

**3. Regression — normal navigation is unaffected**

1. Sign in and navigate between the Inbox, Search, and Settings tabs.
2. Open a chat from the LHN, then use the back gesture/button.
3. Open a report via deep link (e.g. `new.expensify.com/r/<reportID>`).
4. Verify that every navigation lands on the expected screen and back navigation behaves as before.

### Offline tests

1. Complete step 1 of Test 1 so a notification is already delivered.
2. Turn off the network connection.
3. Tap the notification.
4. Verify that the app still navigates to the chat — the protected-routes check is local, so navigation must not depend on connectivity. Report content may show cached data or a loading state, which is expected.

### QA Steps

Same as tests, using a real push notification on staging rather than the simulator injection

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/d45febc8-5cfe-4112-b7af-26a43fe29717


<!-- add screenshots or videos here -->

</details>