### PR TITLE
Fix Save button unreachable behind keyboard on EditPromptPage in landscape

### DIFF
--- a/src/pages/settings/Agents/Fields/EditPromptPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditPromptPage.tsx
@@ -107,7 +107,7 @@ function EditPromptPage({route}: EditPromptPageProps) {
                 keyboardSubmitBehavior={CONST.KEYBOARD_SUBMIT_BEHAVIOR.SUBMIT_ONLY}
             >
                 <View
-                    style={shouldShrinkPromptInput ? StyleUtils.getHeight(PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE) : [styles.flex1]}
+                    style={shouldShrinkPromptInput ? [StyleUtils.getHeight(PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE), styles.overflowHidden] : [styles.flex1]}
                     onLayout={(event) => {
                         promptTopOffsetRef.current = event.nativeEvent.layout.y;
                     }}

--- a/src/pages/settings/Agents/Fields/EditPromptPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditPromptPage.tsx
@@ -1,7 +1,7 @@
 import CollapsibleHeaderOnKeyboard from '@components/CollapsibleHeaderOnKeyboard';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
-import type {FormInputErrors, FormOnyxValues} from '@components/Form/types';
+import type {FormInputErrors, FormOnyxValues, FormRef} from '@components/Form/types';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
@@ -21,6 +21,7 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 
 import {PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE} from '@pages/settings/Agents/const';
+import scrollToMultilineInput from '@pages/settings/Agents/scrollToMultilineInput';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -28,7 +29,7 @@ import type SCREENS from '@src/SCREENS';
 import INPUT_IDS from '@src/types/form/EditAgentPromptForm';
 
 import {Str} from 'expensify-common';
-import React from 'react';
+import React, {useRef} from 'react';
 import {Platform, View} from 'react-native';
 
 type EditPromptPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.AGENTS.EDIT_PROMPT>;
@@ -42,6 +43,9 @@ function EditPromptPage({route}: EditPromptPageProps) {
     const shouldShrinkPromptInput = isInLandscapeMode && isKeyboardActive;
     const accountID = route.params.accountID;
     const [agentPrompt] = useOnyx(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${accountID}`);
+    const formRef = useRef<FormRef>(null);
+    const promptTopOffsetRef = useRef(0);
+    const handleInputFocus = () => scrollToMultilineInput(formRef, isInLandscapeMode, promptTopOffsetRef.current);
 
     const validate = (values: FormOnyxValues<typeof ONYXKEYS.FORMS.EDIT_AGENT_PROMPT_FORM>): FormInputErrors<typeof ONYXKEYS.FORMS.EDIT_AGENT_PROMPT_FORM> => {
         const errors: FormInputErrors<typeof ONYXKEYS.FORMS.EDIT_AGENT_PROMPT_FORM> = {};
@@ -88,12 +92,13 @@ function EditPromptPage({route}: EditPromptPageProps) {
                 />
             </CollapsibleHeaderOnKeyboard>
             <FormProvider
+                ref={formRef}
                 formID={ONYXKEYS.FORMS.EDIT_AGENT_PROMPT_FORM}
                 validate={validate}
                 onSubmit={handleSubmit}
                 submitButtonText={translate('common.save')}
                 style={[styles.flex1, styles.ph5]}
-                shouldUseScrollView={false}
+                shouldUseScrollView={isInLandscapeMode}
                 submitFlexEnabled={false}
                 enabledWhenOffline
                 shouldHideFixErrorsAlert
@@ -101,7 +106,12 @@ function EditPromptPage({route}: EditPromptPageProps) {
                 shouldValidateOnBlur
                 keyboardSubmitBehavior={CONST.KEYBOARD_SUBMIT_BEHAVIOR.SUBMIT_ONLY}
             >
-                <View style={shouldShrinkPromptInput ? StyleUtils.getHeight(PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE) : [styles.flex1]}>
+                <View
+                    style={shouldShrinkPromptInput ? StyleUtils.getHeight(PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE) : [styles.flex1]}
+                    onLayout={(event) => {
+                        promptTopOffsetRef.current = event.nativeEvent.layout.y;
+                    }}
+                >
                     <InputWrapper
                         InputComponent={TextInput}
                         inputID={INPUT_IDS.PROMPT}
@@ -115,6 +125,7 @@ function EditPromptPage({route}: EditPromptPageProps) {
                         containerStyles={[styles.h100]}
                         touchableInputWrapperStyle={[styles.flex1]}
                         inputStyle={[styles.flex1, styles.textAlignVerticalTop]}
+                        onFocus={handleInputFocus}
                     />
                 </View>
                 <Text style={[styles.textMicroSupporting, styles.textAlignCenter, styles.mt2]}>{translate('workspace.rules.agentRules.disclaimer')}</Text>

--- a/src/pages/settings/Agents/Fields/EditPromptPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditPromptPage.tsx
@@ -106,29 +106,31 @@ function EditPromptPage({route}: EditPromptPageProps) {
                 shouldValidateOnBlur
                 keyboardSubmitBehavior={CONST.KEYBOARD_SUBMIT_BEHAVIOR.SUBMIT_ONLY}
             >
-                <View
-                    style={shouldShrinkPromptInput ? [StyleUtils.getHeight(PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE), styles.overflowHidden] : [styles.flex1]}
-                    onLayout={(event) => {
-                        promptTopOffsetRef.current = event.nativeEvent.layout.y;
-                    }}
-                >
-                    <InputWrapper
-                        InputComponent={TextInput}
-                        inputID={INPUT_IDS.PROMPT}
-                        label={translate('editAgentPage.instructions')}
-                        accessibilityLabel={translate('editAgentPage.instructions')}
-                        role={CONST.ROLE.PRESENTATION}
-                        type="markdown"
-                        excludedMarkdownStyles={['mentionReport']}
-                        defaultValue={Str.htmlDecode(agentPrompt?.prompt ?? '')}
-                        multiline
-                        containerStyles={[styles.h100]}
-                        touchableInputWrapperStyle={[styles.flex1]}
-                        inputStyle={[styles.flex1, styles.textAlignVerticalTop]}
-                        onFocus={handleInputFocus}
-                    />
+                <View style={[styles.flex1, styles.flexColumn, styles.gap5]}>
+                    <View
+                        style={shouldShrinkPromptInput ? StyleUtils.getHeight(PROMPT_MAX_HEIGHT_ON_KEYBOARD_OPEN_LANDSCAPE_MODE) : [styles.flex1]}
+                        onLayout={(event) => {
+                            promptTopOffsetRef.current = event.nativeEvent.layout.y;
+                        }}
+                    >
+                        <InputWrapper
+                            InputComponent={TextInput}
+                            inputID={INPUT_IDS.PROMPT}
+                            label={translate('editAgentPage.instructions')}
+                            accessibilityLabel={translate('editAgentPage.instructions')}
+                            role={CONST.ROLE.PRESENTATION}
+                            type="markdown"
+                            excludedMarkdownStyles={['mentionReport']}
+                            defaultValue={Str.htmlDecode(agentPrompt?.prompt ?? '')}
+                            multiline
+                            containerStyles={[styles.h100]}
+                            touchableInputWrapperStyle={[styles.flex1]}
+                            inputStyle={[styles.flex1, styles.textAlignVerticalTop]}
+                            onFocus={handleInputFocus}
+                        />
+                    </View>
+                    <Text style={[styles.textMicroSupporting, styles.textAlignCenter]}>{translate('workspace.rules.agentRules.disclaimer')}</Text>
                 </View>
-                <Text style={[styles.textMicroSupporting, styles.textAlignCenter, styles.mt2]}>{translate('workspace.rules.agentRules.disclaimer')}</Text>
             </FormProvider>
         </ScreenWrapper>
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
[#97782](https://github.com/Expensify/App/pull/97782) replaced `EditPromptPage`'s landscape scroll fallback with a hardcoded-height keyboard-avoidance strategy, but only wired the new mechanism up on `AddAgentPage`. On `EditPromptPage`:

- `shouldUseScrollView` was hardcoded to `false` (previously landscape-aware)
- the `scrollToMultilineInput` helper added by the same PR was never wired to this page's `onFocus`
- `CollapsibleHeaderOnKeyboard` only budgets space for the input itself, not the disclaimer text and Save button below it — the shrunk input alone already exceeds that budget

With no `ScrollView` and no scroll-into-view on focus, the disclaimer text and Save button land behind the keyboard in landscape mode with nothing to scroll them into view (partially hidden on iOS, fully hidden on Android).

This change mirrors the pattern already used and working on `AddAgentPage` in the same PR: `shouldUseScrollView={isInLandscapeMode}` and an `onFocus` handler that calls `scrollToMultilineInput`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/100640
PROPOSAL:


### Tests
1. Go to Account > Agents.
2. Create an agent, open it.
3. Tap "Write custom instructions".
4. Switch device to landscape mode.
5. Tap the input field to focus it and bring up the keyboard.
6. Scroll down.
7. Verify the Save button is reachable and not blocked by the keyboard.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests — this screen loads from cached Onyx data and does not require a network request to reproduce or verify the fix.

### QA Steps
1. Go to Account > Agents.
2. Create an agent, open it.
3. Tap "Write custom instructions".
4. Switch device to landscape mode.
5. Tap the input field to focus it and bring up the keyboard.
6. Scroll down.
7. Verify the Save button is reachable and not blocked by the keyboard.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/748584b1-2f58-4633-a9c3-03d8c2b70ad7


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

