### PR TITLE
Automatically launch E-card enrollment after changing workspace to supported currency

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -2853,12 +2853,19 @@ const ROUTES = {
     },
     WORKSPACE_OVERVIEW_CURRENCY: {
         route: 'workspaces/:policyID/overview/currency',
-        getRoute: (policyID: string, isForcedToChangeCurrency?: boolean) => {
-            let queryParams = '';
+        getRoute: (
+            policyID: string,
+            {isForcedToChangeCurrency, shouldStartExpensifyCardEnrollment}: {isForcedToChangeCurrency?: boolean; shouldStartExpensifyCardEnrollment?: boolean} = {},
+        ) => {
+            const params = new URLSearchParams();
             if (isForcedToChangeCurrency) {
-                queryParams += `?isForcedToChangeCurrency=true`;
+                params.set('isForcedToChangeCurrency', 'true');
             }
-            return `workspaces/${policyID}/overview/currency${queryParams}` as const;
+            if (shouldStartExpensifyCardEnrollment) {
+                params.set('shouldStartExpensifyCardEnrollment', 'true');
+            }
+            const query = params.toString();
+            return `workspaces/${policyID}/overview/currency${query ? `?${query}` : ''}` as const;
         },
     },
     POLICY_ACCOUNTING_QUICKBOOKS_ONLINE_EXPORT: {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6255,6 +6255,8 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
             csvColumnType: 'Typ',
             csvColumnLimitType: 'Limittyp',
             csvColumnLimit: 'Limit',
+            noCardFeedsAvailable: 'Keine Kartenfeeds verfügbar',
+            noCardFeedsAvailableDescription: 'Für diesen Workspace sind keine Kartenfeeds verfügbar.',
         },
         categories: {
             deleteCategories: 'Kategorien löschen',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -6368,6 +6368,8 @@ _Για πιο αναλυτικές οδηγίες, [επισκεφθείτε τ
             statusActive: 'Ενεργό',
             statusInactive: 'Ανενεργό',
             remaining: 'Υπόλοιπο',
+            noCardFeedsAvailable: 'Δεν υπάρχουν διαθέσιμες ροές καρτών',
+            noCardFeedsAvailableDescription: 'Δεν υπάρχουν διαθέσιμες ροές καρτών για αυτόν τον χώρο εργασίας.',
         },
         categories: {
             deleteCategories: 'Διαγραφή κατηγοριών',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6254,6 +6254,8 @@ const translations = {
         expensifyCard: {
             issueAndManageCards: 'Issue and manage your Expensify Cards',
             getStartedIssuing: 'Get started by issuing your first virtual or physical card.',
+            noCardFeedsAvailable: 'No card feeds available',
+            noCardFeedsAvailableDescription: 'There are no card feeds available for this workspace.',
             verificationInProgress: 'Verification in progress...',
             verifyingTheDetails: "We're verifying a few details. Concierge will let you know when Expensify Cards are ready to issue.",
             disclaimer:

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -6126,6 +6126,8 @@ ${amount} para ${merchant} - ${date}`,
             oneMoreStepDescription: 'Parece que tenemos que verificar manualmente tu cuenta bancaria. Dirígete a Concierge, donde te esperan las instrucciones.',
             gotIt: 'Entendido',
             goToConcierge: 'Ir a Concierge',
+            noCardFeedsAvailable: 'No hay feeds de tarjetas disponibles',
+            noCardFeedsAvailableDescription: 'No hay feeds de tarjetas disponibles para este espacio de trabajo.',
         },
         categories: {
             deleteCategories: 'Eliminar categorías',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6261,6 +6261,8 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
             csvColumnType: 'Type',
             csvColumnLimitType: 'Type de limite',
             csvColumnLimit: 'Limite',
+            noCardFeedsAvailable: 'Aucun flux de carte disponible',
+            noCardFeedsAvailableDescription: 'Aucun flux de carte n’est disponible pour cet espace de travail.',
         },
         categories: {
             deleteCategories: 'Supprimer des catégories',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -6213,6 +6213,8 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
             csvColumnType: 'Tipo',
             csvColumnLimitType: 'Tipo di limite',
             csvColumnLimit: 'Limite',
+            noCardFeedsAvailable: 'Nessun feed carta disponibile',
+            noCardFeedsAvailableDescription: 'Non sono disponibili flussi di carte per questo spazio di lavoro.',
         },
         categories: {
             deleteCategories: 'Elimina categorie',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6141,6 +6141,8 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
             csvColumnType: 'タイプ',
             csvColumnLimitType: '限度タイプ',
             csvColumnLimit: '限度額',
+            noCardFeedsAvailable: '利用できるカードフィードがありません',
+            noCardFeedsAvailableDescription: 'このワークスペースで利用できるカードフィードはありません。',
         },
         categories: {
             deleteCategories: 'カテゴリを削除',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6204,6 +6204,8 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
             csvColumnType: 'Type',
             csvColumnLimitType: 'Limiettype',
             csvColumnLimit: 'Limiet',
+            noCardFeedsAvailable: 'Geen kaartfeeds beschikbaar',
+            noCardFeedsAvailableDescription: 'Er zijn geen kaartfeeds beschikbaar voor deze workspace.',
         },
         categories: {
             deleteCategories: 'Categorieën verwijderen',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6229,6 +6229,8 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
             csvColumnType: 'Typ',
             csvColumnLimitType: 'Typ limitu',
             csvColumnLimit: 'Limit',
+            noCardFeedsAvailable: 'Brak dostępnych kanałów kart',
+            noCardFeedsAvailableDescription: 'Dla tego obszaru roboczego nie ma dostępnych żadnych kanałów kart.',
         },
         categories: {
             deleteCategories: 'Usuń kategorie',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6204,6 +6204,8 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
             csvColumnType: 'Tipo',
             csvColumnLimitType: 'Tipo de limite',
             csvColumnLimit: 'Limite',
+            noCardFeedsAvailable: 'Nenhum feed de cartão disponível',
+            noCardFeedsAvailableDescription: 'Não há feeds de cartão disponíveis para este workspace.',
         },
         categories: {
             deleteCategories: 'Excluir categorias',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -5998,6 +5998,8 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
             csvColumnType: '类型',
             csvColumnLimitType: '限额类型',
             csvColumnLimit: '限额',
+            noCardFeedsAvailable: '没有可用的卡片流水',
+            noCardFeedsAvailableDescription: '此工作区暂无可用的卡片流水。',
         },
         categories: {
             deleteCategories: '删除类别',

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -43,6 +43,7 @@ import type {
 import type {CardFeedErrors} from '@src/types/onyx/DerivedValues';
 import type {SelectedTimezone} from '@src/types/onyx/PersonalDetails';
 import type {Connections} from '@src/types/onyx/Policy';
+import type {ACHDataReimbursementAccount} from '@src/types/onyx/ReimbursementAccount';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type IconAsset from '@src/types/utils/IconAsset';
 
@@ -58,6 +59,7 @@ import {isBankAccountPartiallySetup} from './BankAccountUtils';
 import {CARD_FEED_COLORS, GENERIC_CARD_COLORS} from './CardArtworkColors';
 import DateUtils from './DateUtils';
 import {areAddressAndPersonalDetailsMissing, arePersonalDetailsMissing, temporaryGetDisplayNameOrDefault} from './PersonalDetailsUtils';
+import {hasInProgressUSDVBBA} from './ReimbursementAccountUtils';
 import StringUtils from './StringUtils';
 
 /**
@@ -590,6 +592,23 @@ function getEligibleBankAccountsForUkEuCard(bankAccountsList: OnyxEntry<BankAcco
             bankAccount?.bankCurrency === outputCurrency &&
             supportedCountries.includes(bankAccount?.bankCountry),
     );
+}
+
+function getExpensifyCardEnrollmentRoute(
+    policyID: string,
+    currencyCode: string | undefined,
+    isUkEuCurrencySupported: boolean,
+    bankAccountsList: OnyxEntry<BankAccountList>,
+    supportedCountriesByCurrency: OnyxEntry<Record<string, string[]>>,
+    achData: ACHDataReimbursementAccount | undefined,
+) {
+    const eligibleBankAccounts = isUkEuCurrencySupported
+        ? getEligibleBankAccountsForUkEuCard(bankAccountsList, supportedCountriesByCurrency, currencyCode)
+        : getEligibleBankAccountsForCard(bankAccountsList);
+    if (!eligibleBankAccounts.length || hasInProgressUSDVBBA(achData)) {
+        return ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({policyID, backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID)});
+    }
+    return ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policyID);
 }
 
 /**
@@ -2184,6 +2203,7 @@ export {
     getTranslationKeyForCardStatus,
     maskPin,
     getEligibleBankAccountsForCard,
+    getExpensifyCardEnrollmentRoute,
     sortCardsByCardholderName,
     isCurrencySupportedForECards,
     getCardFeedIcon,

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -594,14 +594,17 @@ function getEligibleBankAccountsForUkEuCard(bankAccountsList: OnyxEntry<BankAcco
     );
 }
 
-function getExpensifyCardEnrollmentRoute(
-    policyID: string,
-    currencyCode: string | undefined,
-    isUkEuCurrencySupported: boolean,
-    bankAccountsList: OnyxEntry<BankAccountList>,
-    supportedCountriesByCurrency: OnyxEntry<Record<string, string[]>>,
-    achData: ACHDataReimbursementAccount | undefined,
-) {
+type ExpensifyCardEnrollmentRouteParams = {
+    policyID: string;
+    currencyCode: string | undefined;
+    isUkEuCurrencySupported: boolean;
+    bankAccountsList: OnyxEntry<BankAccountList>;
+    supportedCountriesByCurrency: OnyxEntry<Record<string, string[]>>;
+    achData: ACHDataReimbursementAccount | undefined;
+};
+
+/** Returns the next enrollment route based on whether the workspace can use an existing bank account or must add one. */
+function getExpensifyCardEnrollmentRoute({policyID, currencyCode, isUkEuCurrencySupported, bankAccountsList, supportedCountriesByCurrency, achData}: ExpensifyCardEnrollmentRouteParams) {
     const eligibleBankAccounts = isUkEuCurrencySupported
         ? getEligibleBankAccountsForUkEuCard(bankAccountsList, supportedCountriesByCurrency, currencyCode)
         : getEligibleBankAccountsForCard(bankAccountsList);

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -320,6 +320,7 @@ type SettingsNavigatorParamList = {
     [SCREENS.SETTINGS.PROFILE.VACATION_DELEGATE]: undefined;
     [SCREENS.WORKSPACE.CURRENCY]: {
         isForcedToChangeCurrency?: boolean;
+        shouldStartExpensifyCardEnrollment?: boolean;
     };
     [SCREENS.WORKSPACE.DYNAMIC_WORKSPACE_OVERVIEW_ADDRESS]: {
         policyID: string;

--- a/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
@@ -9,12 +9,11 @@ import usePermissions from '@hooks/usePermissions';
 import useReviewWorkspaceSettingsTaskCompletion from '@hooks/useReviewWorkspaceSettingsTaskCompletion';
 import useShouldBlockCurrencyChange from '@hooks/useShouldBlockCurrencyChange';
 
-import {getEligibleBankAccountsForCard, getEligibleBankAccountsForUkEuCard, isCurrencySupportedForECards} from '@libs/CardUtils';
+import {getExpensifyCardEnrollmentRoute, isCurrencySupportedForECards} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import {goBackFromInvalidPolicy} from '@libs/PolicyUtils';
-import {hasInProgressUSDVBBA} from '@libs/ReimbursementAccountUtils';
 import {getEligibleExistingBusinessBankAccounts} from '@libs/WorkflowUtils';
 
 import {clearCorpayBankAccountFields} from '@userActions/BankAccounts';
@@ -64,19 +63,9 @@ function WorkspaceOverviewCurrencyPage({policy}: WorkspaceOverviewCurrencyPagePr
         const isUkEuCurrencySupported = isCurrencySupportedForECards(item.currencyCode) && isBetaEnabled(CONST.BETAS.EXPENSIFY_CARD_EU_UK);
         const canEnrollNewCardProgram = item.currencyCode === CONST.CURRENCY.USD || isUkEuCurrencySupported;
         if (shouldStartExpensifyCardEnrollment && canEnrollNewCardProgram) {
-            const eligibleBankAccounts = isUkEuCurrencySupported
-                ? getEligibleBankAccountsForUkEuCard(bankAccountList, supportedCountriesByCurrency, item.currencyCode)
-                : getEligibleBankAccountsForCard(bankAccountList);
-            if (!eligibleBankAccounts.length || hasInProgressUSDVBBA(reimbursementAccount?.achData)) {
-                Navigation.navigate(
-                    ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({
-                        policyID: policy.id,
-                        backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policy.id),
-                    }),
-                );
-                return;
-            }
-            Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policy.id));
+            Navigation.navigate(
+                getExpensifyCardEnrollmentRoute(policy.id, item.currencyCode, isUkEuCurrencySupported, bankAccountList, supportedCountriesByCurrency, reimbursementAccount?.achData),
+            );
             return;
         }
 

--- a/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
@@ -65,6 +65,7 @@ function WorkspaceOverviewCurrencyPage({policy}: WorkspaceOverviewCurrencyPagePr
         if (shouldStartExpensifyCardEnrollment && canEnrollNewCardProgram) {
             Navigation.navigate(
                 getExpensifyCardEnrollmentRoute(policy.id, item.currencyCode, isUkEuCurrencySupported, bankAccountList, supportedCountriesByCurrency, reimbursementAccount?.achData),
+                {forceReplace: true},
             );
             return;
         }

--- a/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
@@ -64,7 +64,14 @@ function WorkspaceOverviewCurrencyPage({policy}: WorkspaceOverviewCurrencyPagePr
         const canEnrollNewCardProgram = item.currencyCode === CONST.CURRENCY.USD || isUkEuCurrencySupported;
         if (shouldStartExpensifyCardEnrollment && canEnrollNewCardProgram) {
             Navigation.navigate(
-                getExpensifyCardEnrollmentRoute(policy.id, item.currencyCode, isUkEuCurrencySupported, bankAccountList, supportedCountriesByCurrency, reimbursementAccount?.achData),
+                getExpensifyCardEnrollmentRoute({
+                    policyID: policy.id,
+                    currencyCode: item.currencyCode,
+                    isUkEuCurrencySupported,
+                    bankAccountsList: bankAccountList,
+                    supportedCountriesByCurrency,
+                    achData: reimbursementAccount?.achData,
+                }),
                 {forceReplace: true},
             );
             return;

--- a/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewCurrencyPage.tsx
@@ -5,13 +5,16 @@ import ScreenWrapper from '@components/ScreenWrapper';
 
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
+import usePermissions from '@hooks/usePermissions';
 import useReviewWorkspaceSettingsTaskCompletion from '@hooks/useReviewWorkspaceSettingsTaskCompletion';
 import useShouldBlockCurrencyChange from '@hooks/useShouldBlockCurrencyChange';
 
+import {getEligibleBankAccountsForCard, getEligibleBankAccountsForUkEuCard, isCurrencySupportedForECards} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import {goBackFromInvalidPolicy} from '@libs/PolicyUtils';
+import {hasInProgressUSDVBBA} from '@libs/ReimbursementAccountUtils';
 import {getEligibleExistingBusinessBankAccounts} from '@libs/WorkflowUtils';
 
 import {clearCorpayBankAccountFields} from '@userActions/BankAccounts';
@@ -42,7 +45,11 @@ function WorkspaceOverviewCurrencyPage({policy}: WorkspaceOverviewCurrencyPagePr
     const route = useRoute<PlatformStackRouteProp<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.CURRENCY>>();
     const {translate} = useLocalize();
     const isForcedToChangeCurrency = !!route.params?.isForcedToChangeCurrency;
+    const shouldStartExpensifyCardEnrollment = !!route.params?.shouldStartExpensifyCardEnrollment;
     const [bankAccountList] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
+    const [supportedCountriesByCurrency] = useOnyx(ONYXKEYS.CARD_SUPPORTED_COUNTRIES);
+    const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
+    const {isBetaEnabled} = usePermissions();
     const shouldBlockCurrencyChange = useShouldBlockCurrencyChange(policy?.id);
     const getReviewWorkspaceSettingsTaskCompletion = useReviewWorkspaceSettingsTaskCompletion();
 
@@ -53,6 +60,25 @@ function WorkspaceOverviewCurrencyPage({policy}: WorkspaceOverviewCurrencyPagePr
         clearDraftValues(ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM);
         updateGeneralSettings(policy, policy?.name ?? '', item.currencyCode, getReviewWorkspaceSettingsTaskCompletion());
         clearCorpayBankAccountFields();
+
+        const isUkEuCurrencySupported = isCurrencySupportedForECards(item.currencyCode) && isBetaEnabled(CONST.BETAS.EXPENSIFY_CARD_EU_UK);
+        const canEnrollNewCardProgram = item.currencyCode === CONST.CURRENCY.USD || isUkEuCurrencySupported;
+        if (shouldStartExpensifyCardEnrollment && canEnrollNewCardProgram) {
+            const eligibleBankAccounts = isUkEuCurrencySupported
+                ? getEligibleBankAccountsForUkEuCard(bankAccountList, supportedCountriesByCurrency, item.currencyCode)
+                : getEligibleBankAccountsForCard(bankAccountList);
+            if (!eligibleBankAccounts.length || hasInProgressUSDVBBA(reimbursementAccount?.achData)) {
+                Navigation.navigate(
+                    ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({
+                        policyID: policy.id,
+                        backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policy.id),
+                    }),
+                );
+                return;
+            }
+            Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policy.id));
+            return;
+        }
 
         if (isForcedToChangeCurrency) {
             if (isCurrencySupportedForGlobalReimbursement(item.currencyCode as CurrencyType)) {
@@ -103,4 +129,6 @@ function WorkspaceOverviewCurrencyPage({policy}: WorkspaceOverviewCurrencyPagePr
     );
 }
 
+export {WorkspaceOverviewCurrencyPage};
+export type {WorkspaceOverviewCurrencyPageProps};
 export default withPolicyAndFullscreenLoading(WorkspaceOverviewCurrencyPage);

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardBankAccounts.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardBankAccounts.tsx
@@ -28,7 +28,7 @@ import type {SettingsNavigatorParamList} from '@navigation/types';
 
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 
-import {configureExpensifyCardsForPolicy, setIssueNewCardStepAndData} from '@userActions/Card';
+import {clearIssueNewCardFormData, configureExpensifyCardsForPolicy, setIssueNewCardStepAndData} from '@userActions/Card';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -129,6 +129,7 @@ function WorkspaceExpensifyCardBankAccounts({route}: WorkspaceExpensifyCardBankA
         if (!policyID) {
             return;
         }
+        clearIssueNewCardFormData();
         setIssueNewCardStepAndData({policyID, isChangeAssigneeDisabled: false});
         Navigation.dismissModal();
         Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_EXPENSIFY_CARD_ISSUE_NEW.path, ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID)));

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardFeedSelectorPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardFeedSelectorPage.tsx
@@ -246,40 +246,43 @@ function WorkspaceExpensifyCardFeedSelectorPage({route}: WorkspaceExpensifyCardF
         </View>
     ) : undefined;
 
-    let feedListContent = (
-        <BlockingView
-            icon={illustrations.Telescope}
-            iconWidth={variables.emptyListIconWidth}
-            iconHeight={variables.emptyListIconHeight}
-            title={translate('workspace.expensifyCard.noCardFeedsAvailable')}
-            subtitle={translate('workspace.expensifyCard.noCardFeedsAvailableDescription')}
-        />
-    );
-    if (issueNewCardAndOtherFeedsFooter) {
-        feedListContent = (
-            <ScrollView
+    const renderFeedListContent = () => {
+        if (primaryFeeds.length > 0) {
+            return (
+                <SelectionList
+                    ListItem={SingleSelectListItem}
+                    onSelectRow={selectFeed}
+                    data={primaryListData}
+                    alternateNumberOfSupportedLines={2}
+                    initiallyFocusedItemKey={lastSelectedExpensifyCardFeedID.toString()}
+                    addBottomSafeAreaPadding
+                    listFooterContent={issueNewCardAndOtherFeedsFooter}
+                    onDismissError={onDismissError}
+                />
+            );
+        }
+        if (issueNewCardAndOtherFeedsFooter) {
+            return (
+                <ScrollView
+                    addBottomSafeAreaPadding
+                    style={styles.flex1}
+                    keyboardShouldPersistTaps="handled"
+                >
+                    {issueNewCardAndOtherFeedsFooter}
+                </ScrollView>
+            );
+        }
+        return (
+            <BlockingView
                 addBottomSafeAreaPadding
-                style={styles.flex1}
-                keyboardShouldPersistTaps="handled"
-            >
-                {issueNewCardAndOtherFeedsFooter}
-            </ScrollView>
-        );
-    }
-    if (primaryFeeds.length > 0) {
-        feedListContent = (
-            <SelectionList
-                ListItem={SingleSelectListItem}
-                onSelectRow={selectFeed}
-                data={primaryListData}
-                alternateNumberOfSupportedLines={2}
-                initiallyFocusedItemKey={lastSelectedExpensifyCardFeedID.toString()}
-                addBottomSafeAreaPadding
-                listFooterContent={issueNewCardAndOtherFeedsFooter}
-                onDismissError={onDismissError}
+                icon={illustrations.Telescope}
+                iconWidth={variables.emptyListIconWidth}
+                iconHeight={variables.emptyListIconHeight}
+                title={translate('workspace.expensifyCard.noCardFeedsAvailable')}
+                subtitle={translate('workspace.expensifyCard.noCardFeedsAvailableDescription')}
             />
         );
-    }
+    };
 
     return (
         <AccessOrNotFoundWrapper
@@ -297,7 +300,7 @@ function WorkspaceExpensifyCardFeedSelectorPage({route}: WorkspaceExpensifyCardF
                     title={translate('workspace.companyCards.selectCards')}
                     onBackButtonPress={goBack}
                 />
-                {feedListContent}
+                {renderFeedListContent()}
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardFeedSelectorPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardFeedSelectorPage.tsx
@@ -1,3 +1,4 @@
+import BlockingView from '@components/BlockingViews/BlockingView';
 import {useDelegateNoAccessActions, useDelegateNoAccessState} from '@components/DelegateNoAccessModalProvider';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import Icon from '@components/Icon';
@@ -63,7 +64,7 @@ function WorkspaceExpensifyCardFeedSelectorPage({route}: WorkspaceExpensifyCardF
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
     const styles = useThemeStyles();
-    const illustrations = useMemoizedLazyIllustrations(['ExpensifyCardImage']);
+    const illustrations = useMemoizedLazyIllustrations(['ExpensifyCardImage', 'Telescope']);
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Plus']);
     const {isDelegateAccessRestricted} = useDelegateNoAccessState();
     const {showDelegateNoAccessModal} = useDelegateNoAccessActions();
@@ -207,8 +208,9 @@ function WorkspaceExpensifyCardFeedSelectorPage({route}: WorkspaceExpensifyCardF
     // Suppress the new-program branch on workspaces with unsupported currencies, and for members who cannot
     // reach the bank account setup page. These workspaces may only issue cards on existing feeds
     const shouldShowIssueCardButton = hasIssueCardFundID || (canEnrollNewCardProgram && canStartBankAccountSetup);
+    const shouldShowFooter = canWriteExpensifyCard && (shouldShowIssueCardButton || otherFeeds.length > 0);
 
-    const issueNewCardAndOtherFeedsFooter = canWriteExpensifyCard ? (
+    const issueNewCardAndOtherFeedsFooter = shouldShowFooter ? (
         <View style={[styles.w100, styles.flexColumn]}>
             {shouldShowIssueCardButton && (
                 <MenuItemAction
@@ -244,6 +246,41 @@ function WorkspaceExpensifyCardFeedSelectorPage({route}: WorkspaceExpensifyCardF
         </View>
     ) : undefined;
 
+    let feedListContent = (
+        <BlockingView
+            icon={illustrations.Telescope}
+            iconWidth={variables.emptyListIconWidth}
+            iconHeight={variables.emptyListIconHeight}
+            title={translate('workspace.expensifyCard.noCardFeedsAvailable')}
+            subtitle={translate('workspace.expensifyCard.noCardFeedsAvailableDescription')}
+        />
+    );
+    if (issueNewCardAndOtherFeedsFooter) {
+        feedListContent = (
+            <ScrollView
+                addBottomSafeAreaPadding
+                style={styles.flex1}
+                keyboardShouldPersistTaps="handled"
+            >
+                {issueNewCardAndOtherFeedsFooter}
+            </ScrollView>
+        );
+    }
+    if (primaryFeeds.length > 0) {
+        feedListContent = (
+            <SelectionList
+                ListItem={SingleSelectListItem}
+                onSelectRow={selectFeed}
+                data={primaryListData}
+                alternateNumberOfSupportedLines={2}
+                initiallyFocusedItemKey={lastSelectedExpensifyCardFeedID.toString()}
+                addBottomSafeAreaPadding
+                listFooterContent={issueNewCardAndOtherFeedsFooter}
+                onDismissError={onDismissError}
+            />
+        );
+    }
+
     return (
         <AccessOrNotFoundWrapper
             policyID={policyID}
@@ -260,26 +297,7 @@ function WorkspaceExpensifyCardFeedSelectorPage({route}: WorkspaceExpensifyCardF
                     title={translate('workspace.companyCards.selectCards')}
                     onBackButtonPress={goBack}
                 />
-                {primaryFeeds.length > 0 ? (
-                    <SelectionList
-                        ListItem={SingleSelectListItem}
-                        onSelectRow={selectFeed}
-                        data={primaryListData}
-                        alternateNumberOfSupportedLines={2}
-                        initiallyFocusedItemKey={lastSelectedExpensifyCardFeedID.toString()}
-                        addBottomSafeAreaPadding
-                        listFooterContent={issueNewCardAndOtherFeedsFooter}
-                        onDismissError={onDismissError}
-                    />
-                ) : (
-                    <ScrollView
-                        addBottomSafeAreaPadding
-                        style={styles.flex1}
-                        keyboardShouldPersistTaps="handled"
-                    >
-                        {issueNewCardAndOtherFeedsFooter}
-                    </ScrollView>
-                )}
+                {feedListContent}
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
@@ -21,7 +21,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 
 import {clearIssueNewCardFormData} from '@libs/actions/Card';
-import {getEligibleBankAccountsForCard, getEligibleBankAccountsForUkEuCard} from '@libs/CardUtils';
+import {getExpensifyCardEnrollmentRoute} from '@libs/CardUtils';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
@@ -86,34 +86,23 @@ function WorkspaceExpensifyCardPageEmptyState({route, policy}: WorkspaceExpensif
     const setupCtaTranslationKey = isSetupUnfinished ? 'workspace.expensifyCard.finishSetup' : 'workspace.expensifyCard.issueNewCard';
     const ctaTextTranslationKey = hasAccessibleFeeds ? 'workspace.moreFeatures.expensifyCard.feed.viewCards' : setupCtaTranslationKey;
 
-    const eligibleBankAccounts = isUkEuCurrencySupported
-        ? getEligibleBankAccountsForUkEuCard(bankAccountList, supportedCountriesByCurrency, policy?.outputCurrency)
-        : getEligibleBankAccountsForCard(bankAccountList);
-    const shouldStartBankAccountSetup = !eligibleBankAccounts.length || isSetupUnfinished;
     const canEditSettings = canEditWorkspaceSettings(policy, currentUserLogin);
     // Without an existing feed the only path forward is enrolling a new card program, and both the
     // bank account setup page and the currency page are admin only
     const shouldDisableCTA = !canWriteExpensifyCard || (!hasAccessibleFeeds && !canEditSettings);
 
     const startFlow = () => {
-        if (hasAccessibleFeeds && policy?.id) {
+        if (!policy?.id) {
+            return;
+        }
+        if (hasAccessibleFeeds) {
             clearIssueNewCardFormData();
             Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_EXPENSIFY_CARD_SELECT_FEED.path, ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policy.id)));
             return;
         }
-        if (shouldStartBankAccountSetup) {
-            Navigation.navigate(
-                ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({
-                    policyID: policy?.id,
-                    backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policy?.id),
-                }),
-            );
-            return;
-        }
-        if (policy?.id) {
-            clearIssueNewCardFormData();
-            Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_EXPENSIFY_CARD_SELECT_FEED.path, ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policy.id)));
-        }
+        Navigation.navigate(
+            getExpensifyCardEnrollmentRoute(policy.id, policy.outputCurrency, isUkEuCurrencySupported, bankAccountList, supportedCountriesByCurrency, reimbursementAccount?.achData),
+        );
     };
 
     const expensifyCardFeatures: FeatureListItem[] = [

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
@@ -147,7 +147,7 @@ function WorkspaceExpensifyCardPageEmptyState({route, policy}: WorkspaceExpensif
         if (shouldBlockCurrencyChange || result.action !== ModalActions.CONFIRM || !policy) {
             return;
         }
-        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW_CURRENCY.getRoute(policy.id));
+        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW_CURRENCY.getRoute(policy.id, {shouldStartExpensifyCardEnrollment: true}));
     };
 
     return (

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
@@ -101,7 +101,14 @@ function WorkspaceExpensifyCardPageEmptyState({route, policy}: WorkspaceExpensif
             return;
         }
         Navigation.navigate(
-            getExpensifyCardEnrollmentRoute(policy.id, policy.outputCurrency, isUkEuCurrencySupported, bankAccountList, supportedCountriesByCurrency, reimbursementAccount?.achData),
+            getExpensifyCardEnrollmentRoute({
+                policyID: policy.id,
+                currencyCode: policy.outputCurrency,
+                isUkEuCurrencySupported,
+                bankAccountsList: bankAccountList,
+                supportedCountriesByCurrency,
+                achData: reimbursementAccount?.achData,
+            }),
         );
     };
 

--- a/src/pages/workspace/invoices/WorkspaceInvoiceVBASection.tsx
+++ b/src/pages/workspace/invoices/WorkspaceInvoiceVBASection.tsx
@@ -84,7 +84,7 @@ function WorkspaceInvoiceVBASection({policyID, canWriteMoreFeatures, showReadOnl
             return;
         }
 
-        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW_CURRENCY.getRoute(policy.id, true));
+        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW_CURRENCY.getRoute(policy.id, {isForcedToChangeCurrency: true}));
     }, [policy]);
 
     /**

--- a/src/pages/workspace/workflows/tabs/WorkflowsPaymentsTab.tsx
+++ b/src/pages/workspace/workflows/tabs/WorkflowsPaymentsTab.tsx
@@ -116,7 +116,7 @@ function WorkflowsPaymentsTab({policyID}: WorkflowsPaymentsTabProps) {
         if (!policy) {
             return;
         }
-        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW_CURRENCY.getRoute(policy.id, true));
+        Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW_CURRENCY.getRoute(policy.id, {isForcedToChangeCurrency: true}));
     }, [policy]);
 
     const workflowsBackTo = ROUTES.WORKSPACE_WORKFLOWS.getRoute(policyID);

--- a/tests/ui/WorkspaceExpensifyCardFeedSelectorPageTest.tsx
+++ b/tests/ui/WorkspaceExpensifyCardFeedSelectorPageTest.tsx
@@ -1,0 +1,132 @@
+import {render, screen} from '@testing-library/react-native';
+
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+
+import WorkspaceExpensifyCardFeedSelectorPage from '@pages/workspace/expensifyCard/WorkspaceExpensifyCardFeedSelectorPage';
+
+import SCREENS from '@src/SCREENS';
+
+import type ReactNative from 'react-native';
+
+import React from 'react';
+
+import createMock from '../utils/createMock';
+
+const POLICY_ID = 'policy123';
+
+jest.mock('@components/BlockingViews/BlockingView', () => {
+    const {Text, View} = jest.requireActual<typeof ReactNative>('react-native');
+    return ({title, subtitle}: {title: string; subtitle: string}) => (
+        <View>
+            <Text>{title}</Text>
+            <Text>{subtitle}</Text>
+        </View>
+    );
+});
+jest.mock('@components/DelegateNoAccessModalProvider', () => ({
+    useDelegateNoAccessActions: () => ({}),
+    useDelegateNoAccessState: () => ({isDelegateAccessRestricted: false}),
+}));
+jest.mock('@components/HeaderWithBackButton', () => () => null);
+jest.mock('@components/LockedAccountModalProvider', () => ({
+    useLockedAccountActions: () => ({}),
+    useLockedAccountState: () => ({isAccountLocked: false}),
+}));
+jest.mock(
+    '@components/ScreenWrapper',
+    () =>
+        ({children}: {children: React.ReactNode}) =>
+            children,
+);
+jest.mock(
+    '@components/ScrollView',
+    () =>
+        ({children}: {children: React.ReactNode}) =>
+            children,
+);
+jest.mock('@hooks/useCanEnrollNewExpensifyCardProgram', () => ({
+    __esModule: true,
+    default: () => ({canEnrollNewCardProgram: false}),
+}));
+jest.mock('@hooks/useCurrentUserPersonalDetails', () => ({
+    __esModule: true,
+    default: () => ({login: 'member@example.com'}),
+}));
+jest.mock('@hooks/useDefaultFundID', () => ({
+    __esModule: true,
+    default: () => 1,
+}));
+jest.mock('@hooks/useExpensifyCardFeedsForFeedSelector', () => ({
+    __esModule: true,
+    default: () => ({primaryFeeds: [], otherFeeds: []}),
+}));
+jest.mock('@hooks/useLazyAsset', () => ({
+    useMemoizedLazyExpensifyIcons: () => ({Plus: 'Plus'}),
+    useMemoizedLazyIllustrations: () => ({
+        ExpensifyCardImage: 'ExpensifyCardImage',
+        Telescope: 'Telescope',
+    }),
+}));
+jest.mock('@hooks/useLocalize', () => ({
+    __esModule: true,
+    default: () => ({translate: (key: string) => key}),
+}));
+jest.mock('@hooks/useNetwork', () => ({
+    __esModule: true,
+    default: () => ({isOffline: false}),
+}));
+jest.mock('@hooks/useOnyx', () => ({
+    __esModule: true,
+    default: () => [undefined],
+}));
+jest.mock('@hooks/usePolicy', () => ({
+    __esModule: true,
+    default: () => ({id: POLICY_ID}),
+}));
+jest.mock('@hooks/usePrimaryContactMethod', () => ({
+    __esModule: true,
+    default: () => 'member@example.com',
+}));
+jest.mock('@hooks/useThemeStyles', () => ({
+    __esModule: true,
+    default: () => ({flex1: {flex: 1}}),
+}));
+jest.mock('@libs/PolicyUtils', () => ({
+    canEditWorkspaceSettings: () => false,
+    canMemberWrite: () => false,
+}));
+jest.mock('@navigation/Navigation', () => ({
+    __esModule: true,
+    default: {goBack: jest.fn(), navigate: jest.fn()},
+}));
+jest.mock('@pages/workspace/AccessOrNotFoundWrapper', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => children,
+}));
+jest.mock('@selectors/Account', () => ({isUserValidatedSelector: jest.fn()}));
+jest.mock('@userActions/CompanyCards', () => ({
+    linkCardFeedToPolicy: jest.fn(),
+}));
+
+type FeedSelectorScreenProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.DYNAMIC_WORKSPACE_EXPENSIFY_CARD_SELECT_FEED>;
+const route: FeedSelectorScreenProps['route'] = {
+    key: 'workspace-expensify-card-select-feed',
+    name: SCREENS.WORKSPACE.DYNAMIC_WORKSPACE_EXPENSIFY_CARD_SELECT_FEED,
+    params: {policyID: POLICY_ID},
+};
+const navigation = createMock<FeedSelectorScreenProps['navigation']>({});
+
+describe('WorkspaceExpensifyCardFeedSelectorPage', () => {
+    it('shows an empty state when no feeds or actions are available', () => {
+        render(
+            <WorkspaceExpensifyCardFeedSelectorPage
+                route={route}
+                navigation={navigation}
+            />,
+        );
+
+        expect(screen.getByText('workspace.expensifyCard.noCardFeedsAvailable')).toBeOnTheScreen();
+        expect(screen.getByText('workspace.expensifyCard.noCardFeedsAvailableDescription')).toBeOnTheScreen();
+    });
+});

--- a/tests/ui/WorkspaceOverviewCurrencyPageTest.tsx
+++ b/tests/ui/WorkspaceOverviewCurrencyPageTest.tsx
@@ -25,7 +25,7 @@ const mockPolicy = createMock<Policy>({
     name: 'Acme',
     outputCurrency: CONST.CURRENCY.AUD,
 });
-let mockEligibleBankAccounts: unknown[] = [];
+let mockEnrollmentRoute = '';
 let mockIsBetaEnabled = false;
 let mockIsUkEuCurrencySupported = false;
 const mockOnyxKeys = ONYXKEYS;
@@ -90,8 +90,7 @@ jest.mock('@hooks/useShouldBlockCurrencyChange', () => ({
     default: () => false,
 }));
 jest.mock('@libs/CardUtils', () => ({
-    getEligibleBankAccountsForCard: () => mockEligibleBankAccounts,
-    getEligibleBankAccountsForUkEuCard: () => mockEligibleBankAccounts,
+    getExpensifyCardEnrollmentRoute: () => mockEnrollmentRoute,
     isCurrencySupportedForECards: () => mockIsUkEuCurrencySupported,
 }));
 jest.mock('@libs/Navigation/Navigation', () => ({
@@ -141,7 +140,7 @@ function renderPage(shouldStartExpensifyCardEnrollment = true) {
 describe('WorkspaceOverviewCurrencyPage', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        mockEligibleBankAccounts = [];
+        mockEnrollmentRoute = ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({policyID: POLICY_ID, backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(POLICY_ID)});
         mockIsBetaEnabled = false;
         mockIsUkEuCurrencySupported = false;
     });
@@ -160,7 +159,7 @@ describe('WorkspaceOverviewCurrencyPage', () => {
     });
 
     it('opens the bank account selector after selecting a supported currency when an eligible account exists', () => {
-        mockEligibleBankAccounts = [{}];
+        mockEnrollmentRoute = ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(POLICY_ID);
         mockIsBetaEnabled = true;
         mockIsUkEuCurrencySupported = true;
         renderPage();

--- a/tests/ui/WorkspaceOverviewCurrencyPageTest.tsx
+++ b/tests/ui/WorkspaceOverviewCurrencyPageTest.tsx
@@ -1,0 +1,190 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
+
+import type {CurrencyListItem} from '@components/CurrencySelectionList/types';
+
+import Navigation from '@libs/Navigation/Navigation';
+
+import {WorkspaceOverviewCurrencyPage} from '@pages/workspace/WorkspaceOverviewCurrencyPage';
+import type {WorkspaceOverviewCurrencyPageProps} from '@pages/workspace/WorkspaceOverviewCurrencyPage';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import type {Policy} from '@src/types/onyx';
+
+import type ReactNative from 'react-native';
+
+import {useRoute} from '@react-navigation/native';
+import React from 'react';
+
+import createMock from '../utils/createMock';
+
+const POLICY_ID = 'policy123';
+const mockPolicy = createMock<Policy>({
+    id: POLICY_ID,
+    name: 'Acme',
+    outputCurrency: CONST.CURRENCY.AUD,
+});
+let mockEligibleBankAccounts: unknown[] = [];
+let mockIsBetaEnabled = false;
+let mockIsUkEuCurrencySupported = false;
+const mockOnyxKeys = ONYXKEYS;
+
+jest.mock('@components/CurrencySelectionList', () => {
+    const {Pressable, Text} = jest.requireActual<typeof ReactNative>('react-native');
+    return ({onSelect}: {onSelect: (item: CurrencyListItem) => void}) => (
+        <>
+            {['USD', 'GBP', 'EUR', 'AUD'].map((currencyCode) => (
+                <Pressable
+                    key={currencyCode}
+                    testID={`currency-${currencyCode}`}
+                    accessibilityRole="button"
+                    onPress={() =>
+                        onSelect({
+                            currencyCode,
+                            currencyName: currencyCode,
+                            keyForList: currencyCode,
+                            text: currencyCode,
+                        })
+                    }
+                >
+                    <Text>{currencyCode}</Text>
+                </Pressable>
+            ))}
+        </>
+    );
+});
+jest.mock('@components/HeaderWithBackButton', () => () => null);
+jest.mock(
+    '@components/ScreenWrapper',
+    () =>
+        ({children}: {children: React.ReactNode}) =>
+            children,
+);
+jest.mock('@hooks/useLocalize', () => ({
+    __esModule: true,
+    default: () => ({translate: (key: string) => key}),
+}));
+jest.mock('@hooks/useOnyx', () => ({
+    __esModule: true,
+    default: (key: string): unknown[] => {
+        if (key === mockOnyxKeys.BANK_ACCOUNT_LIST || key === mockOnyxKeys.CARD_SUPPORTED_COUNTRIES) {
+            return [{}];
+        }
+        if (key === mockOnyxKeys.REIMBURSEMENT_ACCOUNT) {
+            return [{achData: {}}];
+        }
+        return [undefined];
+    },
+}));
+jest.mock('@hooks/usePermissions', () => ({
+    __esModule: true,
+    default: () => ({isBetaEnabled: () => mockIsBetaEnabled}),
+}));
+jest.mock('@hooks/useReviewWorkspaceSettingsTaskCompletion', () => ({
+    __esModule: true,
+    default: () => jest.fn(),
+}));
+jest.mock('@hooks/useShouldBlockCurrencyChange', () => ({
+    __esModule: true,
+    default: () => false,
+}));
+jest.mock('@libs/CardUtils', () => ({
+    getEligibleBankAccountsForCard: () => mockEligibleBankAccounts,
+    getEligibleBankAccountsForUkEuCard: () => mockEligibleBankAccounts,
+    isCurrencySupportedForECards: () => mockIsUkEuCurrencySupported,
+}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    __esModule: true,
+    default: {
+        goBack: jest.fn(),
+        navigate: jest.fn(),
+        setNavigationActionToMicrotaskQueue: jest.fn(),
+    },
+}));
+jest.mock('@libs/PolicyUtils', () => ({goBackFromInvalidPolicy: jest.fn()}));
+jest.mock('@libs/ReimbursementAccountUtils', () => ({
+    hasInProgressUSDVBBA: () => false,
+}));
+jest.mock('@libs/WorkflowUtils', () => ({
+    getEligibleExistingBusinessBankAccounts: () => [],
+}));
+jest.mock('@pages/workspace/AccessOrNotFoundWrapper', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => children,
+}));
+jest.mock('@userActions/BankAccounts', () => ({
+    clearCorpayBankAccountFields: jest.fn(),
+}));
+jest.mock('@userActions/FormActions', () => ({clearDraftValues: jest.fn()}));
+jest.mock('@userActions/Policy/Policy', () => ({
+    isCurrencySupportedForGlobalReimbursement: () => false,
+    updateGeneralSettings: jest.fn(),
+}));
+jest.mock('@userActions/ReimbursementAccount', () => ({
+    navigateToBankAccountRoute: jest.fn(),
+}));
+jest.mock('@react-navigation/native', () => ({
+    createNavigationContainerRef: () => ({}),
+    useRoute: jest.fn(),
+}));
+
+const mockUseRoute = jest.mocked(useRoute);
+const mockNavigate = jest.mocked(Navigation.navigate);
+
+function renderPage(shouldStartExpensifyCardEnrollment = true) {
+    mockUseRoute.mockReturnValue(createMock<ReturnType<typeof useRoute>>({params: {shouldStartExpensifyCardEnrollment}}));
+    const props = createMock<WorkspaceOverviewCurrencyPageProps>({policy: mockPolicy});
+    render(<WorkspaceOverviewCurrencyPage {...props} />);
+}
+
+describe('WorkspaceOverviewCurrencyPage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockEligibleBankAccounts = [];
+        mockIsBetaEnabled = false;
+        mockIsUkEuCurrencySupported = false;
+    });
+
+    it('opens the add bank account flow after selecting USD when no eligible account exists', () => {
+        renderPage();
+
+        fireEvent.press(screen.getByTestId(`currency-${CONST.CURRENCY.USD}`));
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+            ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({
+                policyID: POLICY_ID,
+                backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(POLICY_ID),
+            }),
+        );
+    });
+
+    it('opens the bank account selector after selecting a supported currency when an eligible account exists', () => {
+        mockEligibleBankAccounts = [{}];
+        mockIsBetaEnabled = true;
+        mockIsUkEuCurrencySupported = true;
+        renderPage();
+
+        fireEvent.press(screen.getByTestId(`currency-${CONST.CURRENCY.GBP}`));
+
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(POLICY_ID));
+    });
+
+    it('does not start enrollment after selecting an unsupported currency', () => {
+        renderPage();
+
+        fireEvent.press(screen.getByTestId(`currency-${CONST.CURRENCY.AUD}`));
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(Navigation.setNavigationActionToMicrotaskQueue).toHaveBeenCalledWith(Navigation.goBack);
+    });
+
+    it('preserves the normal currency selection behavior outside Expensify Card enrollment', () => {
+        renderPage(false);
+
+        fireEvent.press(screen.getByTestId(`currency-${CONST.CURRENCY.USD}`));
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(Navigation.setNavigationActionToMicrotaskQueue).toHaveBeenCalledWith(Navigation.goBack);
+    });
+});

--- a/tests/ui/WorkspaceOverviewCurrencyPageTest.tsx
+++ b/tests/ui/WorkspaceOverviewCurrencyPageTest.tsx
@@ -155,6 +155,7 @@ describe('WorkspaceOverviewCurrencyPage', () => {
                 policyID: POLICY_ID,
                 backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(POLICY_ID),
             }),
+            {forceReplace: true},
         );
     });
 
@@ -166,7 +167,7 @@ describe('WorkspaceOverviewCurrencyPage', () => {
 
         fireEvent.press(screen.getByTestId(`currency-${CONST.CURRENCY.GBP}`));
 
-        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(POLICY_ID));
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(POLICY_ID), {forceReplace: true});
     });
 
     it('does not start enrollment after selecting an unsupported currency', () => {

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -47,6 +47,7 @@ import {
     getDomainByFundID,
     getEligibleBankAccountsForCard,
     getEligibleBankAccountsForUkEuCard,
+    getExpensifyCardEnrollmentRoute,
     getFeedNameForDisplay,
     getFeedType,
     getFilteredCardList,
@@ -83,6 +84,7 @@ import {
 } from '@src/libs/CardUtils';
 import DateUtils from '@src/libs/DateUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import type {
     BankAccountList,
     Card,
@@ -98,6 +100,7 @@ import type {
 } from '@src/types/onyx';
 import type {CardFeedWithNumber, CompanyFeeds} from '@src/types/onyx/CardFeeds';
 import type {Connections} from '@src/types/onyx/Policy';
+import type {ACHDataReimbursementAccount} from '@src/types/onyx/ReimbursementAccount';
 import type IconAsset from '@src/types/utils/IconAsset';
 
 import type {FC} from 'react';
@@ -4641,6 +4644,33 @@ describe('getEligibleBankAccountsForUkEuCard', () => {
         const result = getEligibleBankAccountsForUkEuCard(bankAccounts, undefined, 'GBP');
         expect(result).toHaveLength(1);
         expect(result.at(0)?.bankCountry).toBe('GB');
+    });
+});
+
+describe('getExpensifyCardEnrollmentRoute', () => {
+    const policyID = 'policy123';
+    const addBankAccountRoute = ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute({policyID, backTo: ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID)});
+    const eligibleBankAccounts: BankAccountList = {
+        '1': {
+            accountData: {type: CONST.BANK_ACCOUNT.TYPE.BUSINESS, allowDebit: true, state: CONST.BANK_ACCOUNT.STATE.OPEN},
+            bankCurrency: CONST.CURRENCY.USD,
+            bankCountry: 'US',
+        },
+    };
+
+    it('returns the add bank account route when no eligible account exists', () => {
+        expect(getExpensifyCardEnrollmentRoute(policyID, CONST.CURRENCY.USD, false, {}, undefined, undefined)).toBe(addBankAccountRoute);
+    });
+
+    it('returns the bank account selector route when an eligible account exists', () => {
+        expect(getExpensifyCardEnrollmentRoute(policyID, CONST.CURRENCY.USD, false, eligibleBankAccounts, undefined, undefined)).toBe(
+            ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policyID),
+        );
+    });
+
+    it('returns the add bank account route when setup is in progress', () => {
+        const achData = createMock<ACHDataReimbursementAccount>({bankAccountID: 1, state: CONST.BANK_ACCOUNT.STATE.SETUP});
+        expect(getExpensifyCardEnrollmentRoute(policyID, CONST.CURRENCY.USD, false, eligibleBankAccounts, undefined, achData)).toBe(addBankAccountRoute);
     });
 });
 

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -4659,18 +4659,43 @@ describe('getExpensifyCardEnrollmentRoute', () => {
     };
 
     it('returns the add bank account route when no eligible account exists', () => {
-        expect(getExpensifyCardEnrollmentRoute(policyID, CONST.CURRENCY.USD, false, {}, undefined, undefined)).toBe(addBankAccountRoute);
+        expect(
+            getExpensifyCardEnrollmentRoute({
+                policyID,
+                currencyCode: CONST.CURRENCY.USD,
+                isUkEuCurrencySupported: false,
+                bankAccountsList: {},
+                supportedCountriesByCurrency: undefined,
+                achData: undefined,
+            }),
+        ).toBe(addBankAccountRoute);
     });
 
     it('returns the bank account selector route when an eligible account exists', () => {
-        expect(getExpensifyCardEnrollmentRoute(policyID, CONST.CURRENCY.USD, false, eligibleBankAccounts, undefined, undefined)).toBe(
-            ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policyID),
-        );
+        expect(
+            getExpensifyCardEnrollmentRoute({
+                policyID,
+                currencyCode: CONST.CURRENCY.USD,
+                isUkEuCurrencySupported: false,
+                bankAccountsList: eligibleBankAccounts,
+                supportedCountriesByCurrency: undefined,
+                achData: undefined,
+            }),
+        ).toBe(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policyID));
     });
 
     it('returns the add bank account route when setup is in progress', () => {
         const achData = createMock<ACHDataReimbursementAccount>({bankAccountID: 1, state: CONST.BANK_ACCOUNT.STATE.SETUP});
-        expect(getExpensifyCardEnrollmentRoute(policyID, CONST.CURRENCY.USD, false, eligibleBankAccounts, undefined, achData)).toBe(addBankAccountRoute);
+        expect(
+            getExpensifyCardEnrollmentRoute({
+                policyID,
+                currencyCode: CONST.CURRENCY.USD,
+                isUkEuCurrencySupported: false,
+                bankAccountsList: eligibleBankAccounts,
+                supportedCountriesByCurrency: undefined,
+                achData,
+            }),
+        ).toBe(addBankAccountRoute);
     });
 });
 


### PR DESCRIPTION
### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues

If the user tries to enroll Expensify Card on a workspace with an unsupported currency, and they don't have access to link a feed from a different workspace, the current behavior is to prompt them to change their workspace currency. Then, when they do this, they must click the CTA again to launch the enrollment flow.

This PR adds a `shouldStartExpensifyCardEnrollment` parameter to the `workspaces/:policyID/overview/currency` route which will, when the user selects a supported Expensify card currency, automatically enter the bank account setup to being the enrollment flow.

This PR also adds an empty state to the feed list picker. If the user has access to an existing Expensify card workspace feed, but loses access to that feed while the picker is open, we now show an empty state rather than a blank panel.

$ https://github.com/Expensify/App/issues/99723#issuecomment-5455146382
PROPOSAL: 


### Tests
**Non-USD workspace, has no existing workspace feeds or eligible bank accounts**
1. Create a user who is an admin on a workspace whose currency is not USD, GBP or EUR. 
2. Enable the Expensify Card feature
3. Go to workspace > Expensify Card and press Issue new card
4. In the modal, press Update workspace currency
5. Select USD, GBP, or EUR from the currency picker
6. Confirm that, after a moment, you are taken to the "Add bank account" page


**Non-USD workspace, has no existing workspace feeds, does have eligible bank account**
1. Start with a user who has a verified business bank account already set up for some reason
2. Create a workspace whose currency is not USD, GBP or EUR
3. Enable the Expensify Card feature
4. Go to workspace > Expensify Card and press Issue new card
5. In the modal, press Update workspace currency
6. Select USD, GBP, or EUR from the currency picker
7. Confirm that you are taken to the "Choose bank account" page

**Non-USD workspace, has eligible feed, is removed as admin from existing feed**
1. Start with a user A who is an admin on a workspace A that already has Expensify Card configured on it
2. Create a workspace B whose currency is not USD, GBP or EUR
3. Enable the Expensify Card feature
4. Go to workspace > Expensify Card and press Issue new card
5. Confirm you are shown the other workspace in the RHP
6. As another admin on workspace A in a different browser, remove user A's admin permission on workspace A
7. Confirm that they see the empty illustration


- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Non-USD workspace, has no existing workspace feeds or eligible bank accounts</summary>

https://github.com/user-attachments/assets/c048d8d6-a519-4a77-abd4-6dba0a385946

</details>


<details>
<summary>Non-USD workspace, has no existing workspace feeds, does have eligible bank account</summary>

https://github.com/user-attachments/assets/85a01179-c8aa-4c84-bfd2-7c86d08f1038

</details>

<details>
<summary>Non-USD workspace, has eligible feed, is removed as admin from existing feed</summary>

https://github.com/user-attachments/assets/1b508c5d-ac5c-43df-8aa6-427a9654b894

</details>