### PR TITLE
[No QA] Revert accidental .github changes from #93317

### DIFF
--- a/.github/actions/javascript/isDeployChecklistLocked/index.js
+++ b/.github/actions/javascript/isDeployChecklistLocked/index.js
@@ -3431,7 +3431,9 @@ var require_CONST = __commonJS({
         REGISTER_AUTHENTICATION_KEY: "register_authentication_key",
         REPLACE_CARD: "replace_card",
         SHIP_CARD: "ship_card",
-        REPORT_CARD_FRAUD: "report_card_fraud"
+        REPORT_CARD_FRAUD: "report_card_fraud",
+        ISSUE_CARD: "issue_card",
+        UPDATE_CARD: "update_card"
       },
       EXPENSIFY_CARD: {
         FEED_NAME: "Expensify Card",
@@ -23108,9 +23110,22 @@ var require_ExpensiMark = __commonJS({
     var Logger_1 = __importDefault(require_Logger());
     var Utils = __importStar(require_utils());
     var EXTRAS_DEFAULT = {};
+    var ASCII_DIGIT_START = "0".charCodeAt(0);
+    var ASCII_DIGIT_END = "9".charCodeAt(0);
+    var ASCII_UPPERCASE_START = "A".charCodeAt(0);
+    var ASCII_UPPERCASE_END = "Z".charCodeAt(0);
+    var ASCII_LOWERCASE_START = "a".charCodeAt(0);
+    var ASCII_LOWERCASE_END = "z".charCodeAt(0);
+    var ASCII_WHITESPACE_END = " ".charCodeAt(0);
+    var NON_BREAKING_SPACE_CODE = 160;
+    var URL_PROTOCOLS = ["https://", "http://", "ftps://", "ftp://"];
+    var URL_CANDIDATE_PREFIX_CHARACTERS = "@_*~";
+    var PROTECTED_TAG_NAMES = /* @__PURE__ */ new Set(["a", "code", "pre", "video"]);
     var MARKDOWN_LINK_REGEX = new RegExp(`\\[((?:[^\\[\\]\\r\\n]*(?:\\[[^\\[\\]\\r\\n]*][^\\[\\]\\r\\n]*)*))]\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, "gi");
     var MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, "gi");
     var MARKDOWN_VIDEO_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(((${UrlPatterns.MARKDOWN_URL_REGEX})\\.(?:${Constants.CONST.VIDEO_EXTENSIONS.join("|")}))\\)(?![^<]*(<\\/pre>|<\\/code>))`, "gi");
+    var BOLD_MARKDOWN_REGEX = /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g;
+    var STRIKETHROUGH_MARKDOWN_REGEX = /(?<!<[^>]*)\B~((?![\s~])[\s\S]*?[^\s~](?<!\s))~\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g;
     var SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
     var VICTORY_CHART_REGEX = /<VictoryChart\b[^>]*\/>|<VictoryChart\b[^>]*>[\s\S]*?<\/VictoryChart>/gi;
     var VICTORY_CHART_PLACEHOLDER_DELIMITER = String.fromCharCode(0);
@@ -23149,6 +23164,218 @@ var require_ExpensiMark = __commonJS({
         return text.replace(regexp, (...args) => replacement(extras, ...args));
       }
       return text.replace(regexp, replacement);
+    }
+    function isAsciiAlphaNumeric(character) {
+      if (!character) {
+        return false;
+      }
+      const code = character.charCodeAt(0);
+      return code >= ASCII_DIGIT_START && code <= ASCII_DIGIT_END || code >= ASCII_UPPERCASE_START && code <= ASCII_UPPERCASE_END || code >= ASCII_LOWERCASE_START && code <= ASCII_LOWERCASE_END;
+    }
+    function isWordCharacter(character) {
+      return character === "_" || isAsciiAlphaNumeric(character);
+    }
+    function canOpenBoldMarkdown(text, position, isProtected) {
+      if (isProtected) {
+        return false;
+      }
+      const nextCharacter = text[position + 1];
+      if (!nextCharacter || /\s|\*/.test(nextCharacter) || text.startsWith("</em", position + 1)) {
+        return false;
+      }
+      const previousCharacter = text[position - 1];
+      if (!isWordCharacter(previousCharacter)) {
+        return true;
+      }
+      return previousCharacter === "_" && !isWordCharacter(text[position - 2]);
+    }
+    function canOpenStrikethroughMarkdown(text, position) {
+      if (isWordCharacter(text[position - 1])) {
+        return false;
+      }
+      const nextCharacter = text[position + 1];
+      return !!nextCharacter && !/\s|~/.test(nextCharacter);
+    }
+    function canCloseMarkdown(text, position, marker) {
+      const previousCharacter = text[position - 1];
+      return !!previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]);
+    }
+    function updateProtectedTagStack(text, tagStart, protectedTags) {
+      var _a, _b;
+      const tagEnd = text.indexOf(">", tagStart + 1);
+      if (tagEnd === -1) {
+        return void 0;
+      }
+      const tag = text.slice(tagStart + 1, tagEnd).trim();
+      const isClosingTag = tag.startsWith("/");
+      const tagName = (_b = (_a = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)) === null || _a === void 0 ? void 0 : _a[1]) === null || _b === void 0 ? void 0 : _b.toLowerCase();
+      if (tagName && PROTECTED_TAG_NAMES.has(tagName)) {
+        if (isClosingTag) {
+          const matchingTagIndex = protectedTags.lastIndexOf(tagName);
+          if (matchingTagIndex !== -1) {
+            protectedTags.splice(matchingTagIndex, 1);
+          }
+        } else if (!tag.endsWith("/")) {
+          protectedTags.push(tagName);
+        }
+      }
+      return tagEnd + 1;
+    }
+    function isHostnameCharacter(character) {
+      return !!character && (isAsciiAlphaNumeric(character) || character === "-" || character === ".");
+    }
+    function isUrlBoundarySpace(character) {
+      const code = character.charCodeAt(0);
+      return code <= ASCII_WHITESPACE_END || code === NON_BREAKING_SPACE_CODE;
+    }
+    function getProtocolAt(text, position) {
+      var _a;
+      const firstCharacter = (_a = text[position]) === null || _a === void 0 ? void 0 : _a.toLowerCase();
+      if (firstCharacter !== "h" && firstCharacter !== "f") {
+        return void 0;
+      }
+      return URL_PROTOCOLS.find((protocol) => text.slice(position, position + protocol.length).toLowerCase() === protocol);
+    }
+    function findHostnameEnd(text, hostnameStart, dotPosition) {
+      let hostnameEnd = dotPosition + 1;
+      while (hostnameEnd < text.length && (isAsciiAlphaNumeric(text[hostnameEnd]) || text[hostnameEnd] === "-")) {
+        hostnameEnd++;
+      }
+      if (hostnameStart === dotPosition || hostnameEnd === dotPosition + 1) {
+        return void 0;
+      }
+      return hostnameEnd;
+    }
+    function extendUrlCandidateBoundaries(text, start, end) {
+      let candidateStart = start;
+      while (candidateStart > 0 && URL_CANDIDATE_PREFIX_CHARACTERS.includes(text[candidateStart - 1])) {
+        candidateStart--;
+      }
+      let candidateEnd = end;
+      while (candidateEnd < text.length && !isUrlBoundarySpace(text[candidateEnd]) && text[candidateEnd] !== "<") {
+        candidateEnd++;
+      }
+      return { start: candidateStart, end: candidateEnd };
+    }
+    function findUrlCandidates(text) {
+      const candidates = [];
+      const protectedTags = [];
+      let index = 0;
+      let hostnameRunStart = 0;
+      while (index < text.length) {
+        if (text[index] === "<") {
+          const nextIndex = updateProtectedTagStack(text, index, protectedTags);
+          if (nextIndex === void 0) {
+            break;
+          }
+          index = nextIndex;
+          hostnameRunStart = index;
+          continue;
+        }
+        if (protectedTags.length > 0) {
+          index++;
+          hostnameRunStart = index;
+          continue;
+        }
+        const matchedProtocol = getProtocolAt(text, index);
+        if (matchedProtocol) {
+          const candidate2 = extendUrlCandidateBoundaries(text, index, index + matchedProtocol.length);
+          candidates.push(candidate2);
+          index = candidate2.end;
+          hostnameRunStart = candidate2.end;
+          continue;
+        }
+        if (!isHostnameCharacter(text[index])) {
+          hostnameRunStart = index + 1;
+          index++;
+          continue;
+        }
+        if (text[index] !== ".") {
+          index++;
+          continue;
+        }
+        const hostnameEnd = findHostnameEnd(text, hostnameRunStart, index);
+        if (hostnameEnd === void 0) {
+          index++;
+          continue;
+        }
+        const candidate = extendUrlCandidateBoundaries(text, hostnameRunStart, hostnameEnd);
+        candidates.push(candidate);
+        index = candidate.end;
+        hostnameRunStart = candidate.end;
+      }
+      return candidates;
+    }
+    function replaceMarkdownCandidates(text, regexp, replacement, marker, canOpen) {
+      if (!text.includes(marker)) {
+        return text;
+      }
+      const markers = [];
+      const protectedTags = [];
+      let index = 0;
+      while (index < text.length) {
+        if (text[index] === "<") {
+          const nextIndex = updateProtectedTagStack(text, index, protectedTags);
+          if (nextIndex === void 0) {
+            break;
+          }
+          index = nextIndex;
+          continue;
+        }
+        if (text[index] === marker) {
+          markers.push({ position: index, isProtected: protectedTags.length > 0 });
+        }
+        index++;
+      }
+      if (markers.length < 2) {
+        return text;
+      }
+      const output = [];
+      const candidateRegex = regexp;
+      let outputStart = 0;
+      let openingMarker;
+      for (const currentMarker of markers) {
+        const markerPosition = currentMarker.position;
+        if (openingMarker === void 0) {
+          openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : void 0;
+          continue;
+        }
+        if (currentMarker.isProtected || !canCloseMarkdown(text, markerPosition, marker)) {
+          continue;
+        }
+        if (openingMarker.isProtected) {
+          openingMarker = void 0;
+          continue;
+        }
+        const openingPosition = openingMarker.position;
+        const prefixLength = openingPosition > 0 ? 1 : 0;
+        const suffixLength = markerPosition + 1 < text.length ? 1 : 0;
+        const candidateStart = openingPosition - prefixLength;
+        const candidateEnd = markerPosition + 1 + suffixLength;
+        const candidate = text.slice(candidateStart, candidateEnd);
+        candidateRegex.lastIndex = 0;
+        const candidateMatch = candidateRegex.exec(candidate);
+        if (!candidateMatch) {
+          openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : void 0;
+          continue;
+        }
+        candidateRegex.lastIndex = 0;
+        const replacedCandidate = replaceTextWithExtras(candidate, candidateRegex, EXTRAS_DEFAULT, replacement);
+        if (replacedCandidate !== candidate) {
+          const replacedCoreEnd = suffixLength ? replacedCandidate.length - suffixLength : replacedCandidate.length;
+          output.push(text.slice(outputStart, openingPosition));
+          output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
+          outputStart = markerPosition + 1;
+          openingMarker = void 0;
+          continue;
+        }
+        openingMarker = void 0;
+      }
+      if (output.length === 0) {
+        return text;
+      }
+      output.push(text.slice(outputStart));
+      return output.join("");
     }
     function replaceBlockElementWithNewLine(htmlString) {
       let splitText = htmlString.replaceAll(/<blockquote>> (<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>)/gi, "<blockquote>> ").split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>|<blockquote>|<\/blockquote>/);
@@ -23570,7 +23797,7 @@ var require_ExpensiMark = __commonJS({
             name: "autolink",
             process: (textToProcess, replacement) => {
               const regex2 = new RegExp(`(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${UrlPatterns.MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, "gi");
-              return this.modifyTextForUrlLinks(regex2, textToProcess, replacement);
+              return this.modifyTextForUrlLinks(regex2, textToProcess, replacement, true);
             },
             replacement: (_extras, _match, g1, g2) => {
               const href = str_1.default.sanitizeURL(g2);
@@ -23675,7 +23902,7 @@ ${"<blockquote>".repeat(i)}`, "\n");
             // \B will match everything that \b doesn't, so it works
             // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
             name: "bold",
-            regex: /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+            process: (textToProcess, replacement) => replaceMarkdownCandidates(textToProcess, BOLD_MARKDOWN_REGEX, replacement, "*", canOpenBoldMarkdown),
             replacement: (_extras, match, g1, g2) => {
               if (g1.includes("_")) {
                 return `${g1}<strong>${g2}</strong>`;
@@ -23685,7 +23912,7 @@ ${"<blockquote>".repeat(i)}`, "\n");
           },
           {
             name: "strikethrough",
-            regex: /(?<!<[^>]*)\B~((?![\s~])[\s\S]*?[^\s~](?<!\s))~\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+            process: (textToProcess, replacement) => replaceMarkdownCandidates(textToProcess, STRIKETHROUGH_MARKDOWN_REGEX, replacement, "~", canOpenStrikethroughMarkdown),
             replacement: (_extras, match, g1) => g1.includes("</pre>") || containsNonPairTag(g1) ? match : `<del>${g1}</del>`
           },
           {
@@ -24075,7 +24302,25 @@ ${g2}
       /**
        * Checks matched URLs for validity and replace valid links with html elements
        */
-      modifyTextForUrlLinks(regex2, textToCheck, replacement) {
+      modifyTextForUrlLinks(regex2, textToCheck, replacement, shouldScanForUrls = false) {
+        if (shouldScanForUrls) {
+          const candidates = findUrlCandidates(textToCheck);
+          if (candidates.length === 0) {
+            return textToCheck;
+          }
+          const output = [];
+          const candidateRegex = regex2;
+          let outputStart = 0;
+          for (const { start, end } of candidates) {
+            const candidate = textToCheck.slice(start, end);
+            candidateRegex.lastIndex = 0;
+            output.push(textToCheck.slice(outputStart, start));
+            output.push(this.modifyTextForUrlLinks(candidateRegex, candidate, replacement));
+            outputStart = end;
+          }
+          output.push(textToCheck.slice(outputStart));
+          return output.join("");
+        }
         let match = regex2.exec(textToCheck);
         let replacedText = "";
         let startIndex = 0;

--- a/.github/actions/javascript/proposalPoliceComment/index.js
+++ b/.github/actions/javascript/proposalPoliceComment/index.js
@@ -24245,7 +24245,9 @@ var require_CONST = __commonJS({
         REGISTER_AUTHENTICATION_KEY: "register_authentication_key",
         REPLACE_CARD: "replace_card",
         SHIP_CARD: "ship_card",
-        REPORT_CARD_FRAUD: "report_card_fraud"
+        REPORT_CARD_FRAUD: "report_card_fraud",
+        ISSUE_CARD: "issue_card",
+        UPDATE_CARD: "update_card"
       },
       EXPENSIFY_CARD: {
         FEED_NAME: "Expensify Card",
@@ -43922,9 +43924,22 @@ var require_ExpensiMark = __commonJS({
     var Logger_1 = __importDefault(require_Logger());
     var Utils = __importStar(require_utils2());
     var EXTRAS_DEFAULT = {};
+    var ASCII_DIGIT_START = "0".charCodeAt(0);
+    var ASCII_DIGIT_END = "9".charCodeAt(0);
+    var ASCII_UPPERCASE_START = "A".charCodeAt(0);
+    var ASCII_UPPERCASE_END = "Z".charCodeAt(0);
+    var ASCII_LOWERCASE_START = "a".charCodeAt(0);
+    var ASCII_LOWERCASE_END = "z".charCodeAt(0);
+    var ASCII_WHITESPACE_END = " ".charCodeAt(0);
+    var NON_BREAKING_SPACE_CODE = 160;
+    var URL_PROTOCOLS = ["https://", "http://", "ftps://", "ftp://"];
+    var URL_CANDIDATE_PREFIX_CHARACTERS = "@_*~";
+    var PROTECTED_TAG_NAMES = /* @__PURE__ */ new Set(["a", "code", "pre", "video"]);
     var MARKDOWN_LINK_REGEX = new RegExp(`\\[((?:[^\\[\\]\\r\\n]*(?:\\[[^\\[\\]\\r\\n]*][^\\[\\]\\r\\n]*)*))]\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, "gi");
     var MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, "gi");
     var MARKDOWN_VIDEO_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(((${UrlPatterns.MARKDOWN_URL_REGEX})\\.(?:${Constants.CONST.VIDEO_EXTENSIONS.join("|")}))\\)(?![^<]*(<\\/pre>|<\\/code>))`, "gi");
+    var BOLD_MARKDOWN_REGEX = /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g;
+    var STRIKETHROUGH_MARKDOWN_REGEX = /(?<!<[^>]*)\B~((?![\s~])[\s\S]*?[^\s~](?<!\s))~\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g;
     var SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
     var VICTORY_CHART_REGEX = /<VictoryChart\b[^>]*\/>|<VictoryChart\b[^>]*>[\s\S]*?<\/VictoryChart>/gi;
     var VICTORY_CHART_PLACEHOLDER_DELIMITER = String.fromCharCode(0);
@@ -43963,6 +43978,218 @@ var require_ExpensiMark = __commonJS({
         return text.replace(regexp, (...args) => replacement(extras, ...args));
       }
       return text.replace(regexp, replacement);
+    }
+    function isAsciiAlphaNumeric(character) {
+      if (!character) {
+        return false;
+      }
+      const code = character.charCodeAt(0);
+      return code >= ASCII_DIGIT_START && code <= ASCII_DIGIT_END || code >= ASCII_UPPERCASE_START && code <= ASCII_UPPERCASE_END || code >= ASCII_LOWERCASE_START && code <= ASCII_LOWERCASE_END;
+    }
+    function isWordCharacter(character) {
+      return character === "_" || isAsciiAlphaNumeric(character);
+    }
+    function canOpenBoldMarkdown(text, position, isProtected) {
+      if (isProtected) {
+        return false;
+      }
+      const nextCharacter = text[position + 1];
+      if (!nextCharacter || /\s|\*/.test(nextCharacter) || text.startsWith("</em", position + 1)) {
+        return false;
+      }
+      const previousCharacter = text[position - 1];
+      if (!isWordCharacter(previousCharacter)) {
+        return true;
+      }
+      return previousCharacter === "_" && !isWordCharacter(text[position - 2]);
+    }
+    function canOpenStrikethroughMarkdown(text, position) {
+      if (isWordCharacter(text[position - 1])) {
+        return false;
+      }
+      const nextCharacter = text[position + 1];
+      return !!nextCharacter && !/\s|~/.test(nextCharacter);
+    }
+    function canCloseMarkdown(text, position, marker) {
+      const previousCharacter = text[position - 1];
+      return !!previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]);
+    }
+    function updateProtectedTagStack(text, tagStart, protectedTags) {
+      var _a3, _b;
+      const tagEnd = text.indexOf(">", tagStart + 1);
+      if (tagEnd === -1) {
+        return void 0;
+      }
+      const tag = text.slice(tagStart + 1, tagEnd).trim();
+      const isClosingTag = tag.startsWith("/");
+      const tagName = (_b = (_a3 = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)) === null || _a3 === void 0 ? void 0 : _a3[1]) === null || _b === void 0 ? void 0 : _b.toLowerCase();
+      if (tagName && PROTECTED_TAG_NAMES.has(tagName)) {
+        if (isClosingTag) {
+          const matchingTagIndex = protectedTags.lastIndexOf(tagName);
+          if (matchingTagIndex !== -1) {
+            protectedTags.splice(matchingTagIndex, 1);
+          }
+        } else if (!tag.endsWith("/")) {
+          protectedTags.push(tagName);
+        }
+      }
+      return tagEnd + 1;
+    }
+    function isHostnameCharacter(character) {
+      return !!character && (isAsciiAlphaNumeric(character) || character === "-" || character === ".");
+    }
+    function isUrlBoundarySpace(character) {
+      const code = character.charCodeAt(0);
+      return code <= ASCII_WHITESPACE_END || code === NON_BREAKING_SPACE_CODE;
+    }
+    function getProtocolAt(text, position) {
+      var _a3;
+      const firstCharacter = (_a3 = text[position]) === null || _a3 === void 0 ? void 0 : _a3.toLowerCase();
+      if (firstCharacter !== "h" && firstCharacter !== "f") {
+        return void 0;
+      }
+      return URL_PROTOCOLS.find((protocol) => text.slice(position, position + protocol.length).toLowerCase() === protocol);
+    }
+    function findHostnameEnd(text, hostnameStart, dotPosition) {
+      let hostnameEnd = dotPosition + 1;
+      while (hostnameEnd < text.length && (isAsciiAlphaNumeric(text[hostnameEnd]) || text[hostnameEnd] === "-")) {
+        hostnameEnd++;
+      }
+      if (hostnameStart === dotPosition || hostnameEnd === dotPosition + 1) {
+        return void 0;
+      }
+      return hostnameEnd;
+    }
+    function extendUrlCandidateBoundaries(text, start, end) {
+      let candidateStart = start;
+      while (candidateStart > 0 && URL_CANDIDATE_PREFIX_CHARACTERS.includes(text[candidateStart - 1])) {
+        candidateStart--;
+      }
+      let candidateEnd = end;
+      while (candidateEnd < text.length && !isUrlBoundarySpace(text[candidateEnd]) && text[candidateEnd] !== "<") {
+        candidateEnd++;
+      }
+      return { start: candidateStart, end: candidateEnd };
+    }
+    function findUrlCandidates(text) {
+      const candidates = [];
+      const protectedTags = [];
+      let index = 0;
+      let hostnameRunStart = 0;
+      while (index < text.length) {
+        if (text[index] === "<") {
+          const nextIndex = updateProtectedTagStack(text, index, protectedTags);
+          if (nextIndex === void 0) {
+            break;
+          }
+          index = nextIndex;
+          hostnameRunStart = index;
+          continue;
+        }
+        if (protectedTags.length > 0) {
+          index++;
+          hostnameRunStart = index;
+          continue;
+        }
+        const matchedProtocol = getProtocolAt(text, index);
+        if (matchedProtocol) {
+          const candidate2 = extendUrlCandidateBoundaries(text, index, index + matchedProtocol.length);
+          candidates.push(candidate2);
+          index = candidate2.end;
+          hostnameRunStart = candidate2.end;
+          continue;
+        }
+        if (!isHostnameCharacter(text[index])) {
+          hostnameRunStart = index + 1;
+          index++;
+          continue;
+        }
+        if (text[index] !== ".") {
+          index++;
+          continue;
+        }
+        const hostnameEnd = findHostnameEnd(text, hostnameRunStart, index);
+        if (hostnameEnd === void 0) {
+          index++;
+          continue;
+        }
+        const candidate = extendUrlCandidateBoundaries(text, hostnameRunStart, hostnameEnd);
+        candidates.push(candidate);
+        index = candidate.end;
+        hostnameRunStart = candidate.end;
+      }
+      return candidates;
+    }
+    function replaceMarkdownCandidates(text, regexp, replacement, marker, canOpen) {
+      if (!text.includes(marker)) {
+        return text;
+      }
+      const markers = [];
+      const protectedTags = [];
+      let index = 0;
+      while (index < text.length) {
+        if (text[index] === "<") {
+          const nextIndex = updateProtectedTagStack(text, index, protectedTags);
+          if (nextIndex === void 0) {
+            break;
+          }
+          index = nextIndex;
+          continue;
+        }
+        if (text[index] === marker) {
+          markers.push({ position: index, isProtected: protectedTags.length > 0 });
+        }
+        index++;
+      }
+      if (markers.length < 2) {
+        return text;
+      }
+      const output = [];
+      const candidateRegex = regexp;
+      let outputStart = 0;
+      let openingMarker;
+      for (const currentMarker of markers) {
+        const markerPosition = currentMarker.position;
+        if (openingMarker === void 0) {
+          openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : void 0;
+          continue;
+        }
+        if (currentMarker.isProtected || !canCloseMarkdown(text, markerPosition, marker)) {
+          continue;
+        }
+        if (openingMarker.isProtected) {
+          openingMarker = void 0;
+          continue;
+        }
+        const openingPosition = openingMarker.position;
+        const prefixLength = openingPosition > 0 ? 1 : 0;
+        const suffixLength = markerPosition + 1 < text.length ? 1 : 0;
+        const candidateStart = openingPosition - prefixLength;
+        const candidateEnd = markerPosition + 1 + suffixLength;
+        const candidate = text.slice(candidateStart, candidateEnd);
+        candidateRegex.lastIndex = 0;
+        const candidateMatch = candidateRegex.exec(candidate);
+        if (!candidateMatch) {
+          openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : void 0;
+          continue;
+        }
+        candidateRegex.lastIndex = 0;
+        const replacedCandidate = replaceTextWithExtras(candidate, candidateRegex, EXTRAS_DEFAULT, replacement);
+        if (replacedCandidate !== candidate) {
+          const replacedCoreEnd = suffixLength ? replacedCandidate.length - suffixLength : replacedCandidate.length;
+          output.push(text.slice(outputStart, openingPosition));
+          output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
+          outputStart = markerPosition + 1;
+          openingMarker = void 0;
+          continue;
+        }
+        openingMarker = void 0;
+      }
+      if (output.length === 0) {
+        return text;
+      }
+      output.push(text.slice(outputStart));
+      return output.join("");
     }
     function replaceBlockElementWithNewLine(htmlString) {
       let splitText = htmlString.replaceAll(/<blockquote>> (<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>)/gi, "<blockquote>> ").split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>|<blockquote>|<\/blockquote>/);
@@ -44384,7 +44611,7 @@ var require_ExpensiMark = __commonJS({
             name: "autolink",
             process: (textToProcess, replacement) => {
               const regex2 = new RegExp(`(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${UrlPatterns.MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, "gi");
-              return this.modifyTextForUrlLinks(regex2, textToProcess, replacement);
+              return this.modifyTextForUrlLinks(regex2, textToProcess, replacement, true);
             },
             replacement: (_extras, _match, g1, g2) => {
               const href = str_1.default.sanitizeURL(g2);
@@ -44489,7 +44716,7 @@ ${"<blockquote>".repeat(i)}`, "\n");
             // \B will match everything that \b doesn't, so it works
             // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
             name: "bold",
-            regex: /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+            process: (textToProcess, replacement) => replaceMarkdownCandidates(textToProcess, BOLD_MARKDOWN_REGEX, replacement, "*", canOpenBoldMarkdown),
             replacement: (_extras, match2, g1, g2) => {
               if (g1.includes("_")) {
                 return `${g1}<strong>${g2}</strong>`;
@@ -44499,7 +44726,7 @@ ${"<blockquote>".repeat(i)}`, "\n");
           },
           {
             name: "strikethrough",
-            regex: /(?<!<[^>]*)\B~((?![\s~])[\s\S]*?[^\s~](?<!\s))~\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+            process: (textToProcess, replacement) => replaceMarkdownCandidates(textToProcess, STRIKETHROUGH_MARKDOWN_REGEX, replacement, "~", canOpenStrikethroughMarkdown),
             replacement: (_extras, match2, g1) => g1.includes("</pre>") || containsNonPairTag(g1) ? match2 : `<del>${g1}</del>`
           },
           {
@@ -44889,7 +45116,25 @@ ${g2}
       /**
        * Checks matched URLs for validity and replace valid links with html elements
        */
-      modifyTextForUrlLinks(regex2, textToCheck, replacement) {
+      modifyTextForUrlLinks(regex2, textToCheck, replacement, shouldScanForUrls = false) {
+        if (shouldScanForUrls) {
+          const candidates = findUrlCandidates(textToCheck);
+          if (candidates.length === 0) {
+            return textToCheck;
+          }
+          const output = [];
+          const candidateRegex = regex2;
+          let outputStart = 0;
+          for (const { start, end } of candidates) {
+            const candidate = textToCheck.slice(start, end);
+            candidateRegex.lastIndex = 0;
+            output.push(textToCheck.slice(outputStart, start));
+            output.push(this.modifyTextForUrlLinks(candidateRegex, candidate, replacement));
+            outputStart = end;
+          }
+          output.push(textToCheck.slice(outputStart));
+          return output.join("");
+        }
         let match2 = regex2.exec(textToCheck);
         let replacedText = "";
         let startIndex = 0;


### PR DESCRIPTION
### Details
Reverts inadvertent changes to `.github/actions/javascript/isDeployChecklistLocked/index.js` and `.github/actions/javascript/proposalPoliceComment/index.js` introduced in https://github.com/Expensify/App/pull/93317.

### Fixed Issues
$

### Tests
1. Verify GitHub actions workflow checks run and pass.
2. Verify `.github/actions/javascript/isDeployChecklistLocked/index.js` and `.github/actions/javascript/proposalPoliceComment/index.js` match their state prior to PR #93317.

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>
