### PR TITLE
Fix back button loop on Profile after copiloting into an agent

### DIFF
--- a/src/libs/Navigation/AppNavigator/withAgentAccessDenied.tsx
+++ b/src/libs/Navigation/AppNavigator/withAgentAccessDenied.tsx
@@ -36,7 +36,12 @@ function withAgentAccessDenied(getComponent: () => React.ComponentType): () => R
                         // forceReplace REPLACEs the stale guarded central-pane route instead of PUSHing Profile on
                         // top of it, so back from Profile pops to the unguarded Account sidebar rather than the
                         // guarded route that would re-fire this redirect.
-                        const redirectToProfile = () => Navigation.navigate(ROUTES.SETTINGS_PROFILE.getRoute(), {forceReplace: true});
+                        const redirectToProfile = () => {
+                            Navigation.popRootToTop();
+                            Navigation.navigate(ROUTES.SETTINGS_PROFILE.getRoute(), {
+                                forceReplace: true,
+                            });
+                        };
 
                         // The guarded screen can be open inside a modal/RHP (e.g. the agent-edit page the owner was
                         // on when they tapped "Copilot into account"), or an unguarded RHP (e.g. the agent DM) can be

--- a/tests/navigation/AgentCopilotRedirectTests.tsx
+++ b/tests/navigation/AgentCopilotRedirectTests.tsx
@@ -1,0 +1,272 @@
+import {act, render, waitFor} from '@testing-library/react-native';
+
+import useIsAgentAccount from '@hooks/useIsAgentAccount';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+
+import getIsNarrowLayout from '@libs/getIsNarrowLayout';
+import createRootStackNavigator from '@libs/Navigation/AppNavigator/createRootStackNavigator';
+import createSplitNavigator from '@libs/Navigation/AppNavigator/createSplitNavigator';
+import withAgentAccessDenied from '@libs/Navigation/AppNavigator/withAgentAccessDenied';
+import Navigation from '@libs/Navigation/Navigation';
+import navigationRef from '@libs/Navigation/navigationRef';
+import type {AuthScreensParamList, ReportsSplitNavigatorParamList, RightModalNavigatorParamList, SettingsSplitNavigatorParamList, TabNavigatorParamList} from '@libs/Navigation/types';
+
+import CONST from '@src/CONST';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+
+import type {InitialState, NavigatorScreenParams} from '@react-navigation/native';
+
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import {NavigationContainer} from '@react-navigation/native';
+import React from 'react';
+
+jest.mock('@hooks/useIsAgentAccount', () => jest.fn());
+jest.mock('@hooks/useResponsiveLayout', () => jest.fn());
+jest.mock('@libs/getIsNarrowLayout', () => jest.fn());
+
+const mockedUseIsAgentAccount = jest.mocked(useIsAgentAccount);
+const mockedUseResponsiveLayout = jest.mocked(useResponsiveLayout);
+const mockedGetIsNarrowLayout = jest.mocked(getIsNarrowLayout);
+
+type TestRootParamList = AuthScreensParamList & {
+    [NAVIGATORS.REPORTS_SPLIT_NAVIGATOR]: NavigatorScreenParams<ReportsSplitNavigatorParamList>;
+    [NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR]: NavigatorScreenParams<SettingsSplitNavigatorParamList>;
+};
+
+const RootStack = createRootStackNavigator<TestRootParamList>();
+const TabNav = createBottomTabNavigator<TabNavigatorParamList>();
+const ReportsSplit = createSplitNavigator<ReportsSplitNavigatorParamList>();
+const SettingsSplit = createSplitNavigator<SettingsSplitNavigatorParamList>();
+const RightModalStack = createSplitNavigator<RightModalNavigatorParamList>();
+
+const getEmptyComponent = () => jest.fn();
+
+function AgentsPageStub() {
+    return null;
+}
+
+function TestReportsSplitNavigator() {
+    return (
+        <ReportsSplit.Navigator
+            sidebarScreen={SCREENS.INBOX}
+            defaultCentralScreen={SCREENS.REPORT}
+            parentRoute={CONST.NAVIGATION_TESTS.DEFAULT_PARENT_ROUTE}
+        >
+            <ReportsSplit.Screen
+                name={SCREENS.INBOX}
+                getComponent={getEmptyComponent}
+            />
+            <ReportsSplit.Screen
+                name={SCREENS.REPORT}
+                getComponent={getEmptyComponent}
+            />
+        </ReportsSplit.Navigator>
+    );
+}
+
+function TestSettingsSplitNavigator() {
+    return (
+        <SettingsSplit.Navigator
+            sidebarScreen={SCREENS.SETTINGS.ROOT}
+            defaultCentralScreen={SCREENS.SETTINGS.PROFILE.ROOT}
+            parentRoute={CONST.NAVIGATION_TESTS.DEFAULT_PARENT_ROUTE}
+        >
+            <SettingsSplit.Screen
+                name={SCREENS.SETTINGS.ROOT}
+                getComponent={getEmptyComponent}
+            />
+            <SettingsSplit.Screen
+                name={SCREENS.SETTINGS.PROFILE.ROOT}
+                getComponent={getEmptyComponent}
+            />
+            <SettingsSplit.Screen
+                name={SCREENS.SETTINGS.AGENTS.ROOT}
+                getComponent={withAgentAccessDenied(() => AgentsPageStub)}
+            />
+        </SettingsSplit.Navigator>
+    );
+}
+
+function TestRightModalNavigator() {
+    return (
+        <RightModalStack.Navigator
+            defaultCentralScreen={SCREENS.RIGHT_MODAL.SETTINGS}
+            parentRoute={CONST.NAVIGATION_TESTS.DEFAULT_PARENT_ROUTE}
+        >
+            <RightModalStack.Screen
+                name={SCREENS.RIGHT_MODAL.SETTINGS}
+                getComponent={getEmptyComponent()}
+            />
+            <RightModalStack.Screen
+                name={SCREENS.RIGHT_MODAL.PROFILE}
+                getComponent={getEmptyComponent()}
+            />
+        </RightModalStack.Navigator>
+    );
+}
+
+function TestTabNavigator() {
+    return (
+        <TabNav.Navigator screenOptions={{headerShown: false}}>
+            <TabNav.Screen
+                name={SCREENS.HOME}
+                component={getEmptyComponent()}
+            />
+            <TabNav.Screen
+                name={NAVIGATORS.REPORTS_SPLIT_NAVIGATOR}
+                component={TestReportsSplitNavigator}
+            />
+            <TabNav.Screen
+                name={NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR}
+                component={TestSettingsSplitNavigator}
+            />
+        </TabNav.Navigator>
+    );
+}
+
+function TestContainer({initialState}: {initialState: InitialState}) {
+    return (
+        <NavigationContainer
+            ref={navigationRef}
+            initialState={initialState}
+            onReady={Navigation.setIsNavigationReady}
+        >
+            <RootStack.Navigator>
+                <RootStack.Screen
+                    name={NAVIGATORS.TAB_NAVIGATOR}
+                    component={TestTabNavigator}
+                />
+                <RootStack.Screen
+                    name={NAVIGATORS.RIGHT_MODAL_NAVIGATOR}
+                    component={TestRightModalNavigator}
+                />
+            </RootStack.Navigator>
+        </NavigationContainer>
+    );
+}
+
+const settingsTabWithAgents = {
+    name: NAVIGATORS.TAB_NAVIGATOR,
+    state: {
+        index: 2,
+        routes: [
+            {name: SCREENS.HOME},
+            {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
+            {
+                name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR,
+                state: {
+                    index: 1,
+                    routes: [{name: SCREENS.SETTINGS.ROOT}, {name: SCREENS.SETTINGS.AGENTS.ROOT}],
+                },
+            },
+        ],
+    },
+};
+
+const agentEditModal = {
+    name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+    state: {
+        index: 0,
+        routes: [{name: SCREENS.RIGHT_MODAL.SETTINGS}],
+    },
+};
+
+const agentChatTab = {
+    name: NAVIGATORS.TAB_NAVIGATOR,
+    state: {
+        index: 1,
+        routes: [
+            {name: SCREENS.HOME},
+            {
+                name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR,
+                state: {
+                    index: 1,
+                    routes: [{name: SCREENS.INBOX}, {name: SCREENS.REPORT, params: {reportID: '1'}}],
+                },
+            },
+        ],
+    },
+};
+
+const profileModal = {
+    name: NAVIGATORS.RIGHT_MODAL_NAVIGATOR,
+    state: {
+        index: 0,
+        routes: [{name: SCREENS.RIGHT_MODAL.PROFILE}],
+    },
+};
+
+function getRootState() {
+    return navigationRef.current?.getRootState();
+}
+
+function getSettingsSplitState() {
+    const tabState = getRootState()?.routes.at(0)?.state;
+    return tabState?.routes.find((route) => route.name === NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR)?.state;
+}
+
+async function expectAgentLandedOnProfileWithAccountUnderneath() {
+    // Then every root entry created during the owner's session is gone, so no guarded route is left to re-fire the redirect
+    await waitFor(
+        () => {
+            expect(getRootState()?.routes.length).toBe(1);
+        },
+        {timeout: CONST.MAX_TRANSITION_START_WAIT_MS * 3},
+    );
+
+    // Then the guarded agents route is replaced by Profile instead of Profile being pushed on top of it
+    await waitFor(
+        () => {
+            expect(getSettingsSplitState()?.routes.map((route) => route.name)).toEqual([SCREENS.SETTINGS.ROOT, SCREENS.SETTINGS.PROFILE.ROOT]);
+        },
+        {timeout: CONST.MAX_TRANSITION_START_WAIT_MS * 3},
+    );
+
+    // Then going back from Profile lands on the Account page rather than looping back into Profile
+    act(() => {
+        Navigation.goBack();
+    });
+    expect(getSettingsSplitState()?.routes.at(-1)?.name).toBe(SCREENS.SETTINGS.ROOT);
+}
+
+describe('Agent copilot redirect', () => {
+    beforeEach(() => {
+        mockedGetIsNarrowLayout.mockReturnValue(true);
+        mockedUseResponsiveLayout.mockReturnValue({
+            ...CONST.NAVIGATION_TESTS.DEFAULT_USE_RESPONSIVE_LAYOUT_VALUE,
+            shouldUseNarrowLayout: true,
+        });
+        mockedUseIsAgentAccount.mockReturnValue(true);
+    });
+
+    it('lands the agent on Profile with the Account page underneath when copiloting from the agent chat profile', async () => {
+        // Given the stack built by Agents > agent > chat with agent > chat header, at the moment "Copilot into account" is tapped
+        render(
+            <TestContainer
+                initialState={{
+                    index: 3,
+                    routes: [settingsTabWithAgents, agentEditModal, agentChatTab, profileModal],
+                }}
+            />,
+        );
+
+        // When the session flips to an agent and the guard redirects
+        await expectAgentLandedOnProfileWithAccountUnderneath();
+    });
+
+    it('lands the agent on Profile with the Account page underneath when copiloting straight from the agent page', async () => {
+        // Given the shorter stack built by Agents > agent, at the moment "Copilot into account" is tapped
+        render(
+            <TestContainer
+                initialState={{
+                    index: 1,
+                    routes: [settingsTabWithAgents, agentEditModal],
+                }}
+            />,
+        );
+
+        // When the session flips to an agent and the guard redirects
+        await expectAgentLandedOnProfileWithAccountUnderneath();
+    });
+});

--- a/tests/unit/withAgentAccessDenied.test.tsx
+++ b/tests/unit/withAgentAccessDenied.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     getActiveRoute: jest.fn(() => ''),
     isActiveRoute: jest.fn(() => false),
     isTopmostRouteModalScreen: jest.fn(() => false),
+    popRootToTop: jest.fn(),
     isNavigationReady: jest.fn(() => Promise.resolve()),
 }));
 
@@ -52,7 +53,9 @@ jest.mock('@react-navigation/native', () => {
     };
 });
 
-jest.mock('@hooks/useResponsiveLayout', () => () => ({shouldUseNarrowLayout: false}));
+jest.mock('@hooks/useResponsiveLayout', () => () => ({
+    shouldUseNarrowLayout: false,
+}));
 
 function ProtectedContent() {
     return <Text testID="protected-content">Protected Content</Text>;


### PR DESCRIPTION
### Explanation of Change

Copiloting into an agent from the agent chat header leaves 4 root stack entries, two of which hold owner-only screens guarded by `withAgentAccessDenied`. The redirect to Profile only dismissed the topmost modal, and because it started from the Reports tab `linkTo`'s cross-tab rule turned the REPLACE back into a PUSH, discarding `forceReplace`. So the stale guarded routes survived underneath, and pressing back re-focused one, which fired `redirectAgentAway` and pushed Profile again — the loop.

Calling `Navigation.popRootToTop()` before the redirect drops every root entry created during the owner's session, so nothing guarded is left to re-fire and `forceReplace` can finally replace the guarded pane: root entries go 4 → 1, the split under Profile becomes `[Settings_Root, Settings_Profile]`, and back lands on the Account page instead of `Home`. `dismissModal` is kept so the RHP still animates away, and `linkTo` is untouched. Added `tests/navigation/AgentCopilotRedirectTests.tsx`, which fails on `main` with `Expected: 1, Received: 4`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/99074
PROPOSAL: https://github.com/Expensify/App/issues/99074#issuecomment-5507537521

### Tests

Precondition: an account with an agent created under **Account > Agents**.

1. Go to **Account > Agents** and tap the agent.
2. Tap **Chat with agent**.
3. Tap the chat header.
4. Tap **Copilot into account**.
5. Verify you land on the Profile page.
6. Tap the back button.
7. Verify the **Account** page opens and Profile does **not** reopen.
8. Repeat pressing back and verify you are never redirected to Profile again.
9. Regression (short path, #94088): **Account > Agents** → tap the agent → **Copilot into account** → back → verify the **Account** page opens.
10. Regression (normal copilot): copilot into a regular member account and verify the current page is not reset and back behaves as before.

- [x] Verify that no errors appear in the JS console

### Offline tests

Copiloting is blocked while offline (`useSwitchToDelegator` short-circuits when the network is offline), so this flow cannot be started offline and the change has no offline-specific behavior.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Before fix:


https://github.com/user-attachments/assets/6bab9c4a-9f61-42df-b466-5e62352f9895

After fix Native:


https://github.com/user-attachments/assets/0e236d1f-3b37-402a-a8eb-02358d83228b




</details>

<details>
<summary>Android: mWeb Chrome</summary>



https://github.com/user-attachments/assets/7473e390-ebef-4af7-b902-e6db5d33a40e



</details>

<details>
<summary>iOS: Native</summary>

After fix:


https://github.com/user-attachments/assets/cb398704-ed13-486c-b642-6a54db56ad55






</details>

<details>
<summary>iOS: mWeb Safari</summary>

After fix:





https://github.com/user-attachments/assets/2a40b771-1a4c-444b-a285-e17ff3d78d47





</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>


