### PR TITLE
Fix - Company cards - Broken card feed connection RHP spins forever with no error when the feed has a feed-level error

### DIFF
--- a/src/components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons.tsx
@@ -16,7 +16,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {getLinkedPolicyName} from '@libs/CardFeedUtils';
-import {getCompanyFeeds, getCustomOrFormattedFeedName, isCustomFeed} from '@libs/CardUtils';
+import {getCompanyFeeds, getCustomOrFormattedFeedName, isCustomFeed, isDirectFeed} from '@libs/CardUtils';
 
 import Navigation from '@navigation/Navigation';
 
@@ -73,6 +73,7 @@ function WorkspaceCompanyCardsTableHeaderButtons({policyID, feedName, isLoading,
     const hasOtherFeedWithRBR = Object.keys(companyFeeds ?? {}).some((feed) => feed !== feedName && shouldShowRbrForFeedNameWithDomainID[feed]);
     const shouldShowFeedSelectorRBR = hasOtherFeedWithRBR || !!feedErrors?.hasWorkspaceErrors;
     const shouldShowBrokenConnectionError = getShouldShowBrokenConnectionError(feedName, feedErrors);
+    const brokenConnectionMessage = isDirectFeed(feedName) ? translate('workspace.companyCards.brokenConnectionError') : `<rbr>${translate('common.genericErrorMessage')}</rbr>`;
 
     const openBankConnection = () => {
         if (!feedName) {
@@ -143,7 +144,7 @@ function WorkspaceCompanyCardsTableHeaderButtons({policyID, feedName, isLoading,
                     />
                     <View style={[styles.offlineFeedbackText, styles.pr5, styles.flexRow, styles.w100]}>
                         <RenderHTML
-                            html={translate('workspace.companyCards.brokenConnectionError')}
+                            html={brokenConnectionMessage}
                             onLinkPress={openBankConnection}
                         />
                     </View>

--- a/src/components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons.tsx
@@ -16,11 +16,11 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {getLinkedPolicyName} from '@libs/CardFeedUtils';
-import {getCompanyFeeds, getCustomOrFormattedFeedName, getPlaidCountry, getPlaidInstitutionId, isCustomFeed} from '@libs/CardUtils';
+import {getCompanyFeeds, getCustomOrFormattedFeedName, isCustomFeed} from '@libs/CardUtils';
 
 import Navigation from '@navigation/Navigation';
 
-import {setAddNewCompanyCardStepAndData, setAssignCardStepAndData} from '@userActions/CompanyCards';
+import {startCardFeedRefresh} from '@userActions/CompanyCards';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -79,24 +79,10 @@ function WorkspaceCompanyCardsTableHeaderButtons({policyID, feedName, isLoading,
             return;
         }
 
-        const institutionId = getPlaidInstitutionId(feedName);
-        const initialStep = institutionId ? CONST.COMPANY_CARD.STEP.PLAID_CONNECTION : CONST.COMPANY_CARD.STEP.BANK_CONNECTION;
-
-        // For Plaid feeds, seed selectedCountry so PlaidConnectionStep can start the login flow
-        if (institutionId) {
-            const country = getPlaidCountry(policy?.outputCurrency, currencyList, countryByIp);
-            setAddNewCompanyCardStepAndData({
-                data: {
-                    selectedCountry: country,
-                },
-            });
-        }
-
-        setAssignCardStepAndData({currentStep: initialStep});
-
-        Navigation.setNavigationActionToMicrotaskQueue(() => {
-            Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS_BROKEN_CARD_FEED_CONNECTION.getRoute(policyID ?? String(CONST.DEFAULT_NUMBER_ID), feedName));
-        });
+        // The refresh flow keeps the bank login open until the reconnect completes: expiration change for OAuth,
+        // import finishing for Plaid. The broken-connection page would treat a feed that only has feed-level errors
+        // as already reconnected and close at once.
+        startCardFeedRefresh(policyID, feedName, policy?.outputCurrency, currencyList, countryByIp);
     };
 
     const isCsvFeed = feedName?.includes(CONST.COMPANY_CARD.FEED_BANK_NAME.CSV);

--- a/src/libs/actions/CompanyCards.ts
+++ b/src/libs/actions/CompanyCards.ts
@@ -1383,6 +1383,8 @@ function startCardFeedRefresh(policyID: string, feed: CompanyCardFeedWithDomainI
         Onyx.merge(ONYXKEYS.ADD_NEW_COMPANY_CARD, {data: {selectedCountry}});
     }
 
+    // Start from a clean record.
+    clearAssignCardStepAndData();
     setAssignCardStepAndData({
         currentStep,
         isRefreshing: true,

--- a/src/libs/actions/CompanyCards.ts
+++ b/src/libs/actions/CompanyCards.ts
@@ -1383,7 +1383,7 @@ function startCardFeedRefresh(policyID: string, feed: CompanyCardFeedWithDomainI
         Onyx.merge(ONYXKEYS.ADD_NEW_COMPANY_CARD, {data: {selectedCountry}});
     }
 
-    // Start from a clean record.
+    // An abandoned assign flow can leave errors or cardToAssign behind, which BankConnection would read as a failed import or as a Plaid token.
     clearAssignCardStepAndData();
     setAssignCardStepAndData({
         currentStep,

--- a/src/libs/actions/Plaid.ts
+++ b/src/libs/actions/Plaid.ts
@@ -152,6 +152,7 @@ function importPlaidAccounts(
     plaidAccounts: string,
     plaidAccessToken: string | undefined,
     domainAccountID?: number,
+    isRepairingFeed = false,
 ) {
     const parameters: ImportPlaidAccountsParams = {
         publicToken,
@@ -179,7 +180,7 @@ function importPlaidAccounts(
             {
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: ONYXKEYS.ASSIGN_CARD,
-                value: {isRefreshing: null, errors: getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                value: {isRefreshing: null, ...(isRepairingFeed ? {errors: getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')} : {})},
             },
         ],
     };

--- a/src/libs/actions/Plaid.ts
+++ b/src/libs/actions/Plaid.ts
@@ -3,6 +3,7 @@ import type {AddPersonalPlaidCardParams, ImportPlaidAccountsParams, OpenPlaidBan
 import type OpenPlaidCompanyCardLoginParams from '@libs/API/parameters/OpenPlaidCompanyCardLoginParams';
 import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import {getCardFeedWithoutDomainID} from '@libs/CardUtils';
+import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
 import getPlaidLinkTokenParameters from '@libs/getPlaidLinkTokenParameters';
 
 import CONST from '@src/CONST';
@@ -178,7 +179,7 @@ function importPlaidAccounts(
             {
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: ONYXKEYS.ASSIGN_CARD,
-                value: {isRefreshing: null},
+                value: {isRefreshing: null, errors: getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
             },
         ],
     };

--- a/src/pages/workspace/companyCards/BankConnection/index.native.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.native.tsx
@@ -14,7 +14,6 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useUpdateFeedBrokenConnection from '@hooks/useUpdateFeedBrokenConnection';
 
 import {updateSelectedFeed} from '@libs/actions/Card';
-import {setAssignCardStepAndData} from '@libs/actions/CompanyCards';
 import {checkIfNewFeedConnected, getBankName, getCompanyCardFeed, isSelectedFeedExpired} from '@libs/CardUtils';
 import getUAForWebView from '@libs/getUAForWebView';
 import Navigation from '@libs/Navigation/Navigation';
@@ -115,10 +114,9 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                 // When refreshing the feed, a healthy connection must not short-circuit into the assignee step.
                 // RefreshCardFeedConnectionPage can't render it and the modal would spin forever.
                 if (!assignCard?.isRefreshing) {
-                    setAssignCardStepAndData({
-                        currentStep: assignCard?.cardToAssign?.dateOption ? CONST.COMPANY_CARD.STEP.CONFIRMATION : CONST.COMPANY_CARD.STEP.ASSIGNEE,
-                        isEditing: false,
-                    });
+                    // The host pages only render the connection steps, so an assign flow that detoured here is not
+                    // resumed: the panel closes and the admin assigns the card again on the reconnected feed.
+                    Navigation.goBack(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID));
                     return;
                 }
             }
@@ -155,7 +153,6 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
         url,
         feed,
         isFeedExpired,
-        assignCard?.cardToAssign?.dateOption,
         assignCard?.isRefreshing,
         isPlaid,
         onImportPlaidAccounts,

--- a/src/pages/workspace/companyCards/BankConnection/index.native.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.native.tsx
@@ -1,5 +1,6 @@
 import ActivityIndicator from '@components/ActivityIndicator';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
+import ConfirmationPage from '@components/ConfirmationPage';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 
@@ -7,6 +8,7 @@ import useCardFeeds from '@hooks/useCardFeeds';
 import useDuplicateFeedDetection from '@hooks/useDuplicateFeedDetection';
 import useImportPlaidAccounts from '@hooks/useImportPlaidAccounts';
 import useIsBlockedToAddFeed from '@hooks/useIsBlockedToAddFeed';
+import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePrevious from '@hooks/usePrevious';
@@ -27,6 +29,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {CompanyCardFeedWithDomainID} from '@src/types/onyx';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 import type {WebViewNavigation} from 'react-native-webview';
 
@@ -70,6 +73,9 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
     const onImportPlaidAccounts = useImportPlaidAccounts(policyID);
     const {updateBrokenConnection, isFeedConnectionBroken} = useUpdateFeedBrokenConnection({policyID, feed});
     const isNewFeedHasError = !!(newFeed && cardFeeds?.[newFeed]?.errors);
+    // Set by importPlaidAccounts failureData while repairing an existing feed
+    const hasImportError = !!feed && !isEmptyObject(assignCard?.errors);
+    const illustrations = useMemoizedLazyIllustrations(['BrokenCompanyCardBankConnection']);
     const {isBlockedToAddNewFeeds, isAllFeedsResultLoading} = useIsBlockedToAddFeed(policyID);
     const {checkForDuplicateFeed} = useDuplicateFeedDetection({policyID, isPlaid});
 
@@ -100,6 +106,11 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
 
     useEffect(() => {
         if ((!url && !isPlaid) || isNewFeedHasError) {
+            return;
+        }
+
+        // A failed import is rendered instead; clearing isRefreshing must not fall through to the healthy-feed close below.
+        if (hasImportError) {
             return;
         }
 
@@ -159,6 +170,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
         isFeedConnectionBroken,
         updateBrokenConnection,
         isNewFeedHasError,
+        hasImportError,
         checkForDuplicateFeed,
     ]);
 
@@ -197,10 +209,22 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                         renderLoading={renderLoading}
                     />
                 )}
-                {(isAllFeedsResultLoading || (isBlockedToAddNewFeeds && !feed) || isConnectionCompleted || isPlaid) && !isNewFeedHasError && (
+                {(isAllFeedsResultLoading || (isBlockedToAddNewFeeds && !feed) || isConnectionCompleted || isPlaid) && !isNewFeedHasError && !hasImportError && (
                     <ActivityIndicator
                         size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE}
                         style={styles.flex1}
+                    />
+                )}
+                {hasImportError && (
+                    <ConfirmationPage
+                        heading={translate('workspace.companyCards.error.feedCouldNotBeLoadedTitle')}
+                        description={translate('common.genericErrorMessage')}
+                        illustration={illustrations.BrokenCompanyCardBankConnection}
+                        illustrationStyle={styles.errorStateCardIllustration}
+                        containerStyle={styles.h100}
+                        shouldShowButton
+                        buttonText={translate('common.buttonConfirm')}
+                        onButtonPress={handleBackButtonPress}
                     />
                 )}
                 {isNewFeedHasError && (

--- a/src/pages/workspace/companyCards/BankConnection/index.native.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.native.tsx
@@ -224,7 +224,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                         containerStyle={styles.h100}
                         shouldShowButton
                         buttonText={translate('common.buttonConfirm')}
-                        onButtonPress={handleBackButtonPress}
+                        onButtonPress={() => Navigation.goBack(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID))}
                     />
                 )}
                 {isNewFeedHasError && (

--- a/src/pages/workspace/companyCards/BankConnection/index.native.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.native.tsx
@@ -73,7 +73,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
     const onImportPlaidAccounts = useImportPlaidAccounts(policyID);
     const {updateBrokenConnection, isFeedConnectionBroken} = useUpdateFeedBrokenConnection({policyID, feed});
     const isNewFeedHasError = !!(newFeed && cardFeeds?.[newFeed]?.errors);
-    // Set by importPlaidAccounts failureData while repairing an existing feed
+    // importPlaidAccounts only writes these errors while repairing an existing feed, so the add-card flow ignores them
     const hasImportError = !!feed && !isEmptyObject(assignCard?.errors);
     const illustrations = useMemoizedLazyIllustrations(['BrokenCompanyCardBankConnection']);
     const {isBlockedToAddNewFeeds, isAllFeedsResultLoading} = useIsBlockedToAddFeed(policyID);
@@ -109,7 +109,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
             return;
         }
 
-        // A failed import is rendered instead; clearing isRefreshing must not fall through to the healthy-feed close below.
+        // A failed import is rendered instead. Clearing isRefreshing must not fall through to the healthy feed close below.
         if (hasImportError) {
             return;
         }
@@ -122,11 +122,10 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                     Navigation.goBack(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID));
                     return;
                 }
-                // When refreshing the feed, a healthy connection must not short-circuit into the assignee step.
-                // RefreshCardFeedConnectionPage can't render it and the modal would spin forever.
+                // The host pages only render the connection steps, so an assign flow that detoured here is not resumed.
+                // The panel closes and the admin assigns the card again on the reconnected feed. During a refresh the
+                // panel stays open because RefreshCardFeedConnectionPage closes it once the reconnect completes.
                 if (!assignCard?.isRefreshing) {
-                    // The host pages only render the connection steps, so an assign flow that detoured here is not
-                    // resumed: the panel closes and the admin assigns the card again on the reconnected feed.
                     Navigation.goBack(ROUTES.WORKSPACE_COMPANY_CARDS.getRoute(policyID));
                     return;
                 }

--- a/src/pages/workspace/companyCards/BankConnection/index.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.tsx
@@ -18,7 +18,6 @@ import usePrevious from '@hooks/usePrevious';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useUpdateFeedBrokenConnection from '@hooks/useUpdateFeedBrokenConnection';
 
-import {setAssignCardStepAndData} from '@libs/actions/CompanyCards';
 import {checkIfNewFeedConnected, getBankName, getCompanyCardFeed, isSelectedFeedExpired} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
 
@@ -130,10 +129,9 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                 // When refreshing the feed, a healthy connection must not short-circuit into the assignee step.
                 // RefreshCardFeedConnectionPage can't render it and the modal would spin forever.
                 if (!assignCard?.isRefreshing) {
-                    setAssignCardStepAndData({
-                        currentStep: assignCard?.cardToAssign?.dateOption ? CONST.COMPANY_CARD.STEP.CONFIRMATION : CONST.COMPANY_CARD.STEP.ASSIGNEE,
-                        isEditing: false,
-                    });
+                    // The host pages only render the connection steps, so an assign flow that detoured here is not
+                    // resumed: the panel closes and the admin assigns the card again on the reconnected feed.
+                    Navigation.closeRHPFlow();
                     return;
                 }
             }
@@ -183,7 +181,6 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
         feed,
         isFeedExpired,
         isOffline,
-        assignCard?.cardToAssign?.dateOption,
         assignCard?.isRefreshing,
         isPlaid,
         onImportPlaidAccounts,

--- a/src/pages/workspace/companyCards/BankConnection/index.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.tsx
@@ -1,6 +1,7 @@
 import ActivityIndicator from '@components/ActivityIndicator';
 import BlockingView from '@components/BlockingViews/BlockingView';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
+import ConfirmationPage from '@components/ConfirmationPage';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
@@ -31,6 +32,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {CompanyCardFeedWithDomainID} from '@src/types/onyx';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
@@ -55,7 +57,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
     const [assignCard] = useOnyx(ONYXKEYS.ASSIGN_CARD);
     const [cardFeeds] = useCardFeeds(policyID);
     const prevFeedsData = usePrevious(cardFeeds);
-    const illustrations = useMemoizedLazyIllustrations(['PendingBank']);
+    const illustrations = useMemoizedLazyIllustrations(['PendingBank', 'BrokenCompanyCardBankConnection']);
     const [shouldBlockWindowOpen, setShouldBlockWindowOpen] = useState(false);
     const selectedBank = addNewCard?.data?.selectedBank;
     const bankName = feed ? getBankName(getCompanyCardFeed(feed)) : (addNewCard?.data?.plaidConnectedFeed ?? selectedBank);
@@ -73,6 +75,8 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
     const headerTitleAddCards = translate('workspace.companyCards.addCards');
     const headerTitle = feed ? translate('workspace.companyCards.assignCard') : headerTitleAddCards;
     const isNewFeedHasError = !!(newFeed && cardFeeds?.[newFeed]?.errors);
+    // Set by importPlaidAccounts failureData while repairing an existing feed
+    const hasImportError = !!feed && !isEmptyObject(assignCard?.errors);
     const onImportPlaidAccounts = useImportPlaidAccounts(policyID);
     const {isBlockedToAddNewFeeds, isAllFeedsResultLoading} = useIsBlockedToAddFeed(policyID);
     const {checkForDuplicateFeed} = useDuplicateFeedDetection({policyID, isPlaid});
@@ -114,6 +118,12 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
 
     useEffect(() => {
         if ((!url && !isPlaid) || isOffline || isNewFeedHasError || isAllFeedsResultLoading || (isBlockedToAddNewFeeds && !feed)) {
+            return;
+        }
+
+        // A failed import is rendered instead; clearing isRefreshing must not fall through to the healthy-feed close below.
+        if (hasImportError) {
+            customWindow?.close();
             return;
         }
 
@@ -187,10 +197,25 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
         isFeedConnectionBroken,
         updateBrokenConnection,
         isNewFeedHasError,
+        hasImportError,
         checkForDuplicateFeed,
     ]);
 
     const getContent = () => {
+        if (hasImportError) {
+            return (
+                <ConfirmationPage
+                    heading={translate('workspace.companyCards.error.feedCouldNotBeLoadedTitle')}
+                    description={translate('common.genericErrorMessage')}
+                    illustration={illustrations.BrokenCompanyCardBankConnection}
+                    illustrationStyle={styles.errorStateCardIllustration}
+                    containerStyle={styles.h100}
+                    shouldShowButton
+                    buttonText={translate('common.buttonConfirm')}
+                    onButtonPress={handleBackButtonPress}
+                />
+            );
+        }
         if (isNewFeedHasError) {
             return (
                 <WorkspaceCompanyCardsErrorConfirmation

--- a/src/pages/workspace/companyCards/BankConnection/index.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.tsx
@@ -212,7 +212,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                     containerStyle={styles.h100}
                     shouldShowButton
                     buttonText={translate('common.buttonConfirm')}
-                    onButtonPress={handleBackButtonPress}
+                    onButtonPress={() => Navigation.closeRHPFlow()}
                 />
             );
         }

--- a/src/pages/workspace/companyCards/BankConnection/index.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.tsx
@@ -75,7 +75,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
     const headerTitleAddCards = translate('workspace.companyCards.addCards');
     const headerTitle = feed ? translate('workspace.companyCards.assignCard') : headerTitleAddCards;
     const isNewFeedHasError = !!(newFeed && cardFeeds?.[newFeed]?.errors);
-    // Set by importPlaidAccounts failureData while repairing an existing feed
+    // importPlaidAccounts only writes these errors while repairing an existing feed, so the add-card flow ignores them
     const hasImportError = !!feed && !isEmptyObject(assignCard?.errors);
     const onImportPlaidAccounts = useImportPlaidAccounts(policyID);
     const {isBlockedToAddNewFeeds, isAllFeedsResultLoading} = useIsBlockedToAddFeed(policyID);
@@ -121,7 +121,7 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
             return;
         }
 
-        // A failed import is rendered instead; clearing isRefreshing must not fall through to the healthy-feed close below.
+        // A failed import is rendered instead. Clearing isRefreshing must not fall through to the healthy feed close below.
         if (hasImportError) {
             customWindow?.close();
             return;
@@ -136,11 +136,10 @@ function BankConnection({policyID, feed, title}: BankConnectionProps) {
                     Navigation.closeRHPFlow();
                     return;
                 }
-                // When refreshing the feed, a healthy connection must not short-circuit into the assignee step.
-                // RefreshCardFeedConnectionPage can't render it and the modal would spin forever.
+                // The host pages only render the connection steps, so an assign flow that detoured here is not resumed.
+                // The panel closes and the admin assigns the card again on the reconnected feed. During a refresh the
+                // panel stays open because RefreshCardFeedConnectionPage closes it once the reconnect completes.
                 if (!assignCard?.isRefreshing) {
-                    // The host pages only render the connection steps, so an assign flow that detoured here is not
-                    // resumed: the panel closes and the admin assigns the card again on the reconnected feed.
                     Navigation.closeRHPFlow();
                     return;
                 }

--- a/src/pages/workspace/companyCards/BrokenCardFeedConnectionPage.tsx
+++ b/src/pages/workspace/companyCards/BrokenCardFeedConnectionPage.tsx
@@ -1,11 +1,12 @@
-import useLocalize from '@hooks/useLocalize';
+import useCardFeeds from '@hooks/useCardFeeds';
 import useOnyx from '@hooks/useOnyx';
 
+import {isDirectFeed} from '@libs/CardUtils';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 
 import type {SettingsNavigatorParamList} from '@navigation/types';
 
-import LoadingPage from '@pages/LoadingPage';
+import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import type {WithPolicyAndFullscreenLoadingProps} from '@pages/workspace/withPolicyAndFullscreenLoading';
 import withPolicyAndFullscreenLoading from '@pages/workspace/withPolicyAndFullscreenLoading';
@@ -28,16 +29,20 @@ function BrokenCardFeedConnectionPage({route, policy}: BrokenCardFeedConnectionP
     const feed = route.params?.feed;
     const policyID = policy?.id;
 
-    const {translate} = useLocalize();
-
     const [assignCard] = useOnyx(ONYXKEYS.ASSIGN_CARD);
     const currentStep = assignCard?.currentStep;
+
+    const [cardFeeds] = useCardFeeds(policyID);
 
     useEffect(() => {
         return () => {
             clearAssignCardStepAndData();
         };
     }, []);
+
+    if (!isDirectFeed(feed) || !cardFeeds?.[feed] || !currentStep) {
+        return <NotFoundPage />;
+    }
 
     let content: React.ReactNode;
     switch (currentStep) {
@@ -58,7 +63,7 @@ function BrokenCardFeedConnectionPage({route, policy}: BrokenCardFeedConnectionP
             );
             break;
         default:
-            content = <LoadingPage title={translate('workspace.companyCards.assignCard')} />;
+            content = <NotFoundPage />;
     }
 
     return (

--- a/src/pages/workspace/companyCards/RefreshCardFeedConnectionPage.tsx
+++ b/src/pages/workspace/companyCards/RefreshCardFeedConnectionPage.tsx
@@ -20,6 +20,7 @@ import {clearAssignCardStepAndData} from '@userActions/CompanyCards';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 import React, {useEffect} from 'react';
 
@@ -51,13 +52,14 @@ function RefreshCardFeedConnectionPage({route, policy}: RefreshCardFeedConnectio
         };
     }, []);
 
-    // Plaid feeds: isRefreshing is cleared by importPlaidAccounts successData
+    // Plaid feeds: isRefreshing is cleared by importPlaidAccounts on both success and failure; a failure also sets
+    // errors, which BankConnection renders instead of closing the panel.
     useEffect(() => {
-        if (prevIsRefreshing !== true || isRefreshing) {
+        if (prevIsRefreshing !== true || isRefreshing || !isEmptyObject(assignCard?.errors)) {
             return;
         }
         Navigation.closeRHPFlow();
-    }, [prevIsRefreshing, isRefreshing]);
+    }, [prevIsRefreshing, isRefreshing, assignCard?.errors]);
 
     // OAuth feeds: expiration updates after bank re-authentication completes. A feed whose OAuth details were never
     // cached has no expiration yet, so the first populated value counts as completion too.

--- a/src/pages/workspace/companyCards/RefreshCardFeedConnectionPage.tsx
+++ b/src/pages/workspace/companyCards/RefreshCardFeedConnectionPage.tsx
@@ -59,9 +59,10 @@ function RefreshCardFeedConnectionPage({route, policy}: RefreshCardFeedConnectio
         Navigation.closeRHPFlow();
     }, [prevIsRefreshing, isRefreshing]);
 
-    // OAuth feeds: expiration updates after bank re-authentication completes
+    // OAuth feeds: expiration updates after bank re-authentication completes. A feed whose OAuth details were never
+    // cached has no expiration yet, so the first populated value counts as completion too.
     useEffect(() => {
-        if (prevFeedExpiration === undefined || prevFeedExpiration === feedExpiration || !isRefreshing) {
+        if (prevFeedExpiration === feedExpiration || !isRefreshing) {
             return;
         }
         Navigation.closeRHPFlow();

--- a/src/pages/workspace/companyCards/RefreshCardFeedConnectionPage.tsx
+++ b/src/pages/workspace/companyCards/RefreshCardFeedConnectionPage.tsx
@@ -52,8 +52,8 @@ function RefreshCardFeedConnectionPage({route, policy}: RefreshCardFeedConnectio
         };
     }, []);
 
-    // Plaid feeds: isRefreshing is cleared by importPlaidAccounts on both success and failure; a failure also sets
-    // errors, which BankConnection renders instead of closing the panel.
+    // Plaid feeds: importPlaidAccounts clears isRefreshing on both success and failure. A failure also sets errors,
+    // which BankConnection renders, so the panel has to stay open for them.
     useEffect(() => {
         if (prevIsRefreshing !== true || isRefreshing || !isEmptyObject(assignCard?.errors)) {
             return;

--- a/src/pages/workspace/companyCards/addNew/PlaidConnectionStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/PlaidConnectionStep.tsx
@@ -148,6 +148,7 @@ function PlaidConnectionStep({feed, policyID, onExit, title}: PlaidConnectionSte
                                     JSON.stringify(metadata.accounts),
                                     '',
                                     splitCardFeedWithDomainID(feed)?.domainID,
+                                    true,
                                 );
                             }
                             setAssignCardStepAndData({

--- a/src/pages/workspace/companyCards/assignCard/ConfirmationStep.tsx
+++ b/src/pages/workspace/companyCards/assignCard/ConfirmationStep.tsx
@@ -109,7 +109,10 @@ function ConfirmationStep({route}: ConfirmationStepProps) {
                 });
             }
 
-            Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS_BROKEN_CARD_FEED_CONNECTION.getRoute(policyID, feed));
+            setAssignCardStepAndData({currentStep: institutionId ? CONST.COMPANY_CARD.STEP.PLAID_CONNECTION : CONST.COMPANY_CARD.STEP.BANK_CONNECTION});
+            Navigation.setNavigationActionToMicrotaskQueue(() => {
+                Navigation.navigate(ROUTES.WORKSPACE_COMPANY_CARDS_BROKEN_CARD_FEED_CONNECTION.getRoute(policyID, feed));
+            });
             return;
         }
 

--- a/tests/unit/BrokenCardFeedConnectionPageTest.tsx
+++ b/tests/unit/BrokenCardFeedConnectionPageTest.tsx
@@ -1,0 +1,183 @@
+import {act, cleanup, render, screen} from '@testing-library/react-native';
+
+import useCardFeeds from '@hooks/useCardFeeds';
+
+import {clearAssignCardStepAndData} from '@libs/actions/CompanyCards';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+// Bypass the HOC and render the inner component directly
+jest.mock('@pages/workspace/withPolicyAndFullscreenLoading', () => (Component: React.ComponentType) => Component);
+
+jest.mock('@pages/workspace/AccessOrNotFoundWrapper', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => children,
+}));
+
+jest.mock('@hooks/useCardFeeds', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+jest.mock('@pages/workspace/companyCards/BankConnection', () => ({
+    __esModule: true,
+
+    default: () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const {View} = require('react-native');
+        return <View testID="BankConnection" />;
+    },
+}));
+
+jest.mock('@pages/workspace/companyCards/addNew/PlaidConnectionStep', () => ({
+    __esModule: true,
+
+    default: () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const {View} = require('react-native');
+        return <View testID="PlaidConnectionStep" />;
+    },
+}));
+
+jest.mock('@pages/ErrorPage/NotFoundPage', () => ({
+    __esModule: true,
+
+    default: () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const {View} = require('react-native');
+        return <View testID="NotFoundPage" />;
+    },
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    closeRHPFlow: jest.fn(),
+    getActiveRouteWithoutParams: jest.fn(() => ''),
+    isNavigationReady: jest.fn(() => Promise.resolve()),
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setNavigationActionToMicrotaskQueue: jest.fn(),
+    getTopmostReportId: jest.fn(),
+}));
+
+jest.mock('@libs/actions/CompanyCards', () => ({
+    clearAssignCardStepAndData: jest.fn(),
+}));
+
+jest.mock('@hooks/useLocalize', () => ({
+    __esModule: true,
+    default: () => ({translate: (key: string) => key}),
+}));
+
+const mockUseCardFeeds = jest.mocked(useCardFeeds);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+const BrokenCardFeedConnectionPage = require('@pages/workspace/companyCards/BrokenCardFeedConnectionPage').default;
+
+const DIRECT_FEED = `${CONST.COMPANY_CARD.FEED_BANK_NAME.CHASE}#99999` as const;
+const COMMERCIAL_FEED = `${CONST.COMPANY_CARD.FEED_BANK_NAME.VISA}#99999` as const;
+const MOCK_POLICY = {id: 'policy1'};
+
+function mockFeeds(feedKey: string) {
+    mockUseCardFeeds.mockReturnValue([
+        {[feedKey]: {feed: CONST.COMPANY_CARD.FEED_BANK_NAME.CHASE, accountList: [], credentials: '', expiration: 20240101}},
+        {status: 'loaded'},
+        undefined,
+        {},
+        0,
+    ]);
+}
+
+function renderPage(feed: string = DIRECT_FEED) {
+    return render(
+        <BrokenCardFeedConnectionPage
+            policy={MOCK_POLICY}
+            route={{params: {feed}}}
+        />,
+    );
+}
+
+describe('BrokenCardFeedConnectionPage', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    afterEach(async () => {
+        cleanup();
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+        jest.clearAllMocks();
+    });
+
+    beforeEach(() => {
+        mockFeeds(DIRECT_FEED);
+    });
+
+    describe('renders the connection steps it supports', () => {
+        it.each([
+            [CONST.COMPANY_CARD.STEP.BANK_CONNECTION, 'BankConnection'],
+            [CONST.COMPANY_CARD.STEP.PLAID_CONNECTION, 'PlaidConnectionStep'],
+        ])('renders %s as %s', async (currentStep, testID) => {
+            await Onyx.merge(ONYXKEYS.ASSIGN_CARD, {currentStep});
+
+            renderPage();
+            await act(async () => {
+                await waitForBatchedUpdates();
+            });
+
+            expect(screen.getByTestId(testID)).toBeTruthy();
+            expect(screen.queryByTestId('NotFoundPage')).toBeNull();
+        });
+    });
+
+    describe('never falls through to an indefinite spinner', () => {
+        it.each([
+            ['currentStep is not set', undefined, DIRECT_FEED],
+            // The reported bug: BankConnection wrote a step this page cannot render and it became a forever spinner.
+            ['currentStep is a step this page cannot render', CONST.COMPANY_CARD.STEP.ASSIGNEE, DIRECT_FEED],
+            ['the feed is not a direct feed', CONST.COMPANY_CARD.STEP.BANK_CONNECTION, COMMERCIAL_FEED],
+        ])('renders NotFoundPage when %s', async (_case, currentStep, feed) => {
+            if (currentStep) {
+                await Onyx.merge(ONYXKEYS.ASSIGN_CARD, {currentStep});
+            }
+            mockFeeds(feed);
+
+            renderPage(feed);
+            await act(async () => {
+                await waitForBatchedUpdates();
+            });
+
+            expect(screen.getByTestId('NotFoundPage')).toBeTruthy();
+            expect(screen.queryByTestId('BankConnection')).toBeNull();
+        });
+
+        it('renders NotFoundPage when the feed is missing from the card feeds', async () => {
+            await Onyx.merge(ONYXKEYS.ASSIGN_CARD, {currentStep: CONST.COMPANY_CARD.STEP.BANK_CONNECTION});
+            mockUseCardFeeds.mockReturnValue([{}, {status: 'loaded'}, undefined, {}, 0]);
+
+            renderPage();
+            await act(async () => {
+                await waitForBatchedUpdates();
+            });
+
+            expect(screen.getByTestId('NotFoundPage')).toBeTruthy();
+        });
+    });
+
+    it('calls clearAssignCardStepAndData on unmount', async () => {
+        await Onyx.merge(ONYXKEYS.ASSIGN_CARD, {currentStep: CONST.COMPANY_CARD.STEP.BANK_CONNECTION});
+
+        const {unmount} = renderPage();
+        await act(async () => {
+            await waitForBatchedUpdates();
+        });
+
+        unmount();
+
+        expect(clearAssignCardStepAndData).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/BrokenCardFeedConnectionPageTest.tsx
+++ b/tests/unit/BrokenCardFeedConnectionPageTest.tsx
@@ -12,7 +12,7 @@ import Onyx from 'react-native-onyx';
 
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
-// Bypass the HOC and render the inner component directly
+// The policy loading HOC would need a full policy in Onyx before rendering anything, which these tests do not care about
 jest.mock('@pages/workspace/withPolicyAndFullscreenLoading', () => (Component: React.ComponentType) => Component);
 
 jest.mock('@pages/workspace/AccessOrNotFoundWrapper', () => ({
@@ -29,6 +29,7 @@ jest.mock('@pages/workspace/companyCards/BankConnection', () => ({
     __esModule: true,
 
     default: () => {
+        // jest.mock factories are hoisted above imports, so the module has to be required inside
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const {View} = require('react-native');
         return <View testID="BankConnection" />;
@@ -39,6 +40,7 @@ jest.mock('@pages/workspace/companyCards/addNew/PlaidConnectionStep', () => ({
     __esModule: true,
 
     default: () => {
+        // jest.mock factories are hoisted above imports, so the module has to be required inside
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const {View} = require('react-native');
         return <View testID="PlaidConnectionStep" />;
@@ -49,6 +51,7 @@ jest.mock('@pages/ErrorPage/NotFoundPage', () => ({
     __esModule: true,
 
     default: () => {
+        // jest.mock factories are hoisted above imports, so the module has to be required inside
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const {View} = require('react-native');
         return <View testID="NotFoundPage" />;
@@ -75,6 +78,7 @@ jest.mock('@hooks/useLocalize', () => ({
 }));
 
 const mockUseCardFeeds = jest.mocked(useCardFeeds);
+// Required after the mocks above are registered so the page picks up the mocked HOC and children
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 const BrokenCardFeedConnectionPage = require('@pages/workspace/companyCards/BrokenCardFeedConnectionPage').default;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

- Route the "log into your bank" CTA through the existing card feed refresh flow.
- Stop BankConnection from writing an assign-card step that the broken/refresh connection pages can't render, so the reconnect no longer spins forever
- The broken-connection page also now falls back to NotFoundPage for any unrenderable state.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/100465

PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

--->
#### For dev tests - how to get local feed into desired state

```
const DOMAIN_ID = 'your_domain_id';
const FEED      = 'your_feed_id;
const POLICY_ID = 'your_policy_id;
const KEY       = `sharedNVP_private_domain_member_${DOMAIN_ID}`;
const feedPatch = (patch) => Onyx.merge(KEY, {settings: {oAuthAccountDetails: {[FEED]: patch}}});

globalThis.expire      = () => feedPatch({expiration: Math.floor(Date.now() / 1000) - 60});
globalThis.reconnect   = () => feedPatch({expiration: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30});
globalThis.seedError   = () => feedPatch({errors: {[String(Date.now() * 1000)]: 'Could not generate Plaid accessToken'}});
globalThis.clearErrors = () => feedPatch({errors: null});
globalThis.state       = async () => console.log({
    feedErrors: (await Onyx.get('cardFeedErrors'))?.cardFeedErrors?.[`${FEED}#${DOMAIN_ID}`],
    assignCard: await Onyx.get('assignCard'),
});

// mimics importPlaidAccounts failureData
globalThis.failImport = () => Onyx.merge('assignCard', {isRefreshing: null, errors: {[String(Date.now() * 1000)]: 'Could not generate Plaid accessToken'}});

globalThis.addUnassigned = async () => {
    const list = (await Onyx.get(KEY))?.settings?.oAuthAccountDetails?.[FEED]?.accountList ?? [];
    return feedPatch({accountList: [...list, `MOCK - ${Date.now() % 10000}`]});
};


// One unassigned row to click (XXXX5555) and one assigned card.
await feedPatch({accountList: ['XXXX2004', 'XXXX5555']});
await Onyx.merge(`cards_${DOMAIN_ID}_${FEED}`, {
    999900001: {cardID: 999900001, bank: FEED, fundID: DOMAIN_ID, state: 3, cardName: 'XXXX2004', lastFourPAN: '2004'},
});
await Onyx.merge(`lastSelectedFeed_${POLICY_ID}`, `${FEED}#${DOMAIN_ID}`);

```
```
// Scenario 1:
await reconnect(); await seedError();
```
```
// Scenario 2 
await clearErrors(); await reconnect(); await addUnassigned(); await expire();
```

```
// Scenario 3
await failImport());
```


#### Scenario 1 - Feed lvl error
1. Open app, go to a workspace with a direct (Plaid or OAuth) company card feed that shows the "Card feed connection is broken" banner and has no cards with a broken scrape result.
2. Navigate to Workspace -> Company Cards, click "log into your bank", complete the bank/Plaid login.
3. Verify that the RHP stays open during login and closes once the reconnect completes, with no indefinite spinner.

#### Scenario 2 - Expired feed
1. Open app, go to a workspace with an expired direct company card feed, start assigning a card, reach the Confirmation step, click Assign.
2. Verify that the bank/Plaid connection step renders (no "Not found" page or spinner), and after login the RHP closes.

#### Scenario 3 - Failed import
1. Open app, Company Cards on the feed with error banner
2. Click "log into your bank"
3. Verify that RHP "Assign new cards" opens.
4. Somehow force a failed import (Can be simulated with Scenario 3 snippet)
5. Verify that the RHP stays open and shows "Couldn't load this feed" with the broken-bank illustration
6. Verify that Confirm returns to Company Cards.





### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/f1107598-d435-4807-aa6b-8f63bb18fa09

https://github.com/user-attachments/assets/bbb5cde8-1cca-43c3-b200-db3f1d578702



</details>
