### PR TITLE
[Hold Web-E#55999] Show attempt-limit errors when revealing card details

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2623,6 +2623,7 @@ const CONST = {
         EXP_ERROR: 666,
         UNABLE_TO_RETRY: 'unableToRetry',
         UPDATE_REQUIRED: 426,
+        TOO_MANY_REQUESTS: 429,
         INCORRECT_VALIDATE_CODE: 451,
         ADMIN_REQUIRED: 460,
         POLICY_DIFF_WARNING: 305,

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -3221,6 +3221,7 @@ ${amount} für ${merchant} – ${date}`,
         timeExpiredAnnouncement: 'Die Zeit ist abgelaufen',
         error: {
             pleaseFillSecurityCode: 'Bitte geben Sie Ihren Sicherheitscode ein',
+            tooManyAttempts: 'Zu viele Versuche. Bitte versuche es später erneut.',
             incorrectSecurityCode: 'Falscher oder ungültiger Sicherheitscode. Bitte versuchen Sie es erneut oder fordern Sie einen neuen Code an.',
             pleaseFillTwoFactorAuth: 'Bitte gib deinen Zwei-Faktor-Authentifizierungscode ein',
         },

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -3221,7 +3221,7 @@ ${amount} für ${merchant} – ${date}`,
         timeExpiredAnnouncement: 'Die Zeit ist abgelaufen',
         error: {
             pleaseFillSecurityCode: 'Bitte geben Sie Ihren Sicherheitscode ein',
-            tooManyAttempts: 'Zu viele Versuche. Bitte versuche es später erneut.',
+            tooManyAttempts: 'Zu viele Versuche. Bitte versuchen Sie es später erneut.',
             incorrectSecurityCode: 'Falscher oder ungültiger Sicherheitscode. Bitte versuchen Sie es erneut oder fordern Sie einen neuen Code an.',
             pleaseFillTwoFactorAuth: 'Bitte gib deinen Zwei-Faktor-Authentifizierungscode ein',
         },

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -3274,6 +3274,7 @@ ${amount} για ${merchant} - ${date}`,
         error: {
             pleaseFillTwoFactorAuth: 'Εισαγάγετε τον κωδικό ελέγχου ταυτότητας δύο παραγόντων σας',
             pleaseFillSecurityCode: 'Παρακαλούμε εισαγάγετε τον κωδικό ασφαλείας σας',
+            tooManyAttempts: 'Πάρα πολλές προσπάθειες. Δοκιμάστε ξανά αργότερα.',
             incorrectSecurityCode: 'Εσφαλμένος ή μη έγκυρος κωδικός ασφαλείας. Δοκιμάστε ξανά ή ζητήστε έναν νέο κωδικό.',
         },
         securityCodeNotReceived: 'Δεν λάβατε κωδικό ασφαλείας;',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3319,6 +3319,7 @@ const translations = {
         timeExpiredAnnouncement: 'The time has expired',
         error: {
             pleaseFillSecurityCode: 'Please enter your security code',
+            tooManyAttempts: 'Too many attempts. Please try again later.',
             incorrectSecurityCode: 'Incorrect or invalid security code. Please try again or request a new code.',
             pleaseFillTwoFactorAuth: 'Please enter your two-factor authentication code',
         },

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3129,6 +3129,7 @@ ${amount} para ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'El tiempo ha expirado',
         error: {
             pleaseFillSecurityCode: 'Por favor, introduce tu código de seguridad',
+            tooManyAttempts: 'Demasiados intentos. Inténtalo de nuevo más tarde.',
             incorrectSecurityCode: 'Código de seguridad incorrecto o no válido. Inténtalo de nuevo o solicita un código nuevo.',
             pleaseFillTwoFactorAuth: 'Por favor, introduce tu código de autenticación de dos factores.',
         },

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3129,7 +3129,7 @@ ${amount} para ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'El tiempo ha expirado',
         error: {
             pleaseFillSecurityCode: 'Por favor, introduce tu código de seguridad',
-            tooManyAttempts: 'Demasiados intentos. Inténtalo de nuevo más tarde.',
+            tooManyAttempts: 'Demasiados intentos. Por favor, inténtalo de nuevo más tarde.',
             incorrectSecurityCode: 'Código de seguridad incorrecto o no válido. Inténtalo de nuevo o solicita un código nuevo.',
             pleaseFillTwoFactorAuth: 'Por favor, introduce tu código de autenticación de dos factores.',
         },

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -3228,6 +3228,7 @@ ${amount} pour ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'Le temps est écoulé',
         error: {
             pleaseFillSecurityCode: 'Veuillez saisir votre code de sécurité',
+            tooManyAttempts: 'Trop de tentatives. Veuillez réessayer plus tard.',
             incorrectSecurityCode: 'Code de sécurité incorrect ou non valide. Veuillez réessayer ou demander un nouveau code.',
             pleaseFillTwoFactorAuth: 'Veuillez saisir votre code d’authentification à deux facteurs',
         },

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -3212,6 +3212,7 @@ ${amount} per ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'Il tempo è scaduto',
         error: {
             pleaseFillSecurityCode: 'Inserisci il tuo codice di sicurezza',
+            tooManyAttempts: 'Troppi tentativi. Riprova più tardi.',
             incorrectSecurityCode: 'Codice di sicurezza errato o non valido. Riprova oppure richiedi un nuovo codice.',
             pleaseFillTwoFactorAuth: 'Inserisci il tuo codice di autenticazione a due fattori',
         },

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -3179,6 +3179,7 @@ ${date} の ${merchant} への ${amount}`,
         timeExpiredAnnouncement: '時間切れです',
         error: {
             pleaseFillSecurityCode: 'セキュリティコードを入力してください',
+            tooManyAttempts: '試行回数が多すぎます。しばらくしてからもう一度お試しください。',
             incorrectSecurityCode: 'セキュリティコードが正しくないか無効です。もう一度お試しいただくか、新しいコードをリクエストしてください。',
             pleaseFillTwoFactorAuth: '2 要素認証コードを入力してください',
         },

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -3212,6 +3212,7 @@ ${amount} voor ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'De tijd is verstreken',
         error: {
             pleaseFillSecurityCode: 'Voer je beveiligingscode in',
+            tooManyAttempts: 'Te veel pogingen. Probeer het later opnieuw.',
             incorrectSecurityCode: 'Onjuiste of ongeldige beveiligingscode. Probeer het opnieuw of vraag een nieuwe code aan.',
             pleaseFillTwoFactorAuth: 'Voer je twee-factor-authenticatiecode in',
         },

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -3243,7 +3243,7 @@ ${amount} dla ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'Czas minął',
         error: {
             pleaseFillSecurityCode: 'Wpisz swój kod bezpieczeństwa',
-            tooManyAttempts: 'Zbyt wiele prób. Spróbuj ponownie później.',
+            tooManyAttempts: 'Za dużo prób. Spróbuj ponownie później.',
             incorrectSecurityCode: 'Nieprawidłowy lub nieważny kod zabezpieczający. Spróbuj ponownie albo poproś o nowy kod.',
             pleaseFillTwoFactorAuth: 'Wprowadź swój kod uwierzytelniania dwuskładnikowego',
         },

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -3243,6 +3243,7 @@ ${amount} dla ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'Czas minął',
         error: {
             pleaseFillSecurityCode: 'Wpisz swój kod bezpieczeństwa',
+            tooManyAttempts: 'Zbyt wiele prób. Spróbuj ponownie później.',
             incorrectSecurityCode: 'Nieprawidłowy lub nieważny kod zabezpieczający. Spróbuj ponownie albo poproś o nowy kod.',
             pleaseFillTwoFactorAuth: 'Wprowadź swój kod uwierzytelniania dwuskładnikowego',
         },

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -3202,6 +3202,7 @@ ${amount} para ${merchant} - ${date}`,
         timeExpiredAnnouncement: 'O tempo expirou',
         error: {
             pleaseFillSecurityCode: 'Insira seu código de segurança',
+            tooManyAttempts: 'Muitas tentativas. Tente novamente mais tarde.',
             incorrectSecurityCode: 'Código de segurança incorreto ou inválido. Tente novamente ou solicite um novo código.',
             pleaseFillTwoFactorAuth: 'Insira seu código de autenticação de dois fatores',
         },

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -3101,7 +3101,7 @@ ${amount}，商户：${merchant} - 日期：${date}`,
         timeExpiredAnnouncement: '时间已到期',
         error: {
             pleaseFillSecurityCode: '请输入您的安全码',
-            tooManyAttempts: '尝试次数过多。请稍后重试。',
+            tooManyAttempts: '尝试次数过多。请稍后再试。',
             incorrectSecurityCode: '安全码不正确或无效。请重试或请求新代码。',
             pleaseFillTwoFactorAuth: '请输入您的双重身份验证代码',
         },

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -3099,7 +3099,12 @@ ${amount}，商户：${merchant} - 日期：${date}`,
             other: `剩余时间：${count} 秒`,
         }),
         timeExpiredAnnouncement: '时间已到期',
-        error: {pleaseFillSecurityCode: '请输入您的安全码', incorrectSecurityCode: '安全码不正确或无效。请重试或请求新代码。', pleaseFillTwoFactorAuth: '请输入您的双重身份验证代码'},
+        error: {
+            pleaseFillSecurityCode: '请输入您的安全码',
+            tooManyAttempts: '尝试次数过多。请稍后重试。',
+            incorrectSecurityCode: '安全码不正确或无效。请重试或请求新代码。',
+            pleaseFillTwoFactorAuth: '请输入您的双重身份验证代码',
+        },
     },
     passwordForm: {
         pleaseFillOutAllFields: '请填写所有字段',

--- a/src/libs/actions/PersonalDetails.ts
+++ b/src/libs/actions/PersonalDetails.ts
@@ -673,6 +673,11 @@ function setPersonalDetailsAndRevealExpensifyCard(
         })
             .then((response) => {
                 if (response?.jsonCode !== CONST.JSON_CODE.SUCCESS) {
+                    if (response?.jsonCode === CONST.JSON_CODE.TOO_MANY_REQUESTS) {
+                        // eslint-disable-next-line prefer-promise-reject-errors
+                        reject('validateCodeForm.error.tooManyAttempts');
+                        return;
+                    }
                     if (response?.jsonCode === CONST.JSON_CODE.INCORRECT_VALIDATE_CODE) {
                         // eslint-disable-next-line prefer-promise-reject-errors
                         reject('validateCodeForm.error.incorrectSecurityCode');

--- a/tests/actions/PersonalDetailsTest.ts
+++ b/tests/actions/PersonalDetailsTest.ts
@@ -47,6 +47,54 @@ describe('actions/PersonalDetails', () => {
         jest.restoreAllMocks();
     });
 
+    describe('setPersonalDetailsAndRevealExpensifyCard', () => {
+        const personalDetails = {
+            legalFirstName: 'Test',
+            legalLastName: 'User',
+            phoneNumber: '+15005550006',
+            addressCity: 'San Francisco',
+            addressStreet: '123 Main St',
+            addressStreet2: '',
+            addressZip: '94105',
+            addressCountry: 'US',
+            dob: '1990-01-01',
+            addressState: 'CA',
+            addressProvince: '',
+        };
+
+        it.each([
+            [CONST.JSON_CODE.TOO_MANY_REQUESTS, 'validateCodeForm.error.tooManyAttempts'],
+            [CONST.JSON_CODE.INCORRECT_VALIDATE_CODE, 'validateCodeForm.error.incorrectSecurityCode'],
+            [CONST.HTTP_STATUS.INTERNAL_SERVER_ERROR, 'cardPage.unexpectedError'],
+            [CONST.HTTP_STATUS.UNAUTHORIZED, 'cardPage.cardDetailsLoadingFailure'],
+        ])('maps response %s to %s', async (jsonCode, translationKey) => {
+            mockAPI.makeRequestWithSideEffects.mockResolvedValue({jsonCode});
+
+            await expect(PersonalDetailsActions.setPersonalDetailsAndRevealExpensifyCard(personalDetails, 123, '123456')).rejects.toBe(translationKey);
+            expect(mockAPI.makeRequestWithSideEffects).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns card details after a successful reveal', async () => {
+            const cardDetails = {
+                pan: '4111111111111111',
+                expiration: '12/30',
+                cvv: '123',
+            };
+            mockAPI.makeRequestWithSideEffects.mockResolvedValue({
+                jsonCode: CONST.JSON_CODE.SUCCESS,
+                ...cardDetails,
+            });
+
+            await expect(PersonalDetailsActions.setPersonalDetailsAndRevealExpensifyCard(personalDetails, 123, '123456')).resolves.toEqual(cardDetails);
+        });
+
+        it('preserves the connection error for failed requests', async () => {
+            mockAPI.makeRequestWithSideEffects.mockRejectedValue(new Error('Network error'));
+
+            await expect(PersonalDetailsActions.setPersonalDetailsAndRevealExpensifyCard(personalDetails, 123, '123456')).rejects.toBe('cardPage.cardDetailsLoadingFailure');
+        });
+    });
+
     describe('updateAddress', () => {
         it('should call API.write with correct parameters and optimistic data for US addresses and navigate back', async () => {
             const addresses: Address[] = [


### PR DESCRIPTION
Held on:

 - https://github.com/Expensify/Web-Expensify/pull/55999

### Explanation of Change

When Auth blocks further security-code attempts while revealing an Expensify Card, the App currently shows a connection error and asks the user to retry. This PR handles the API's distinct `jsonCode: 429` response with the localised message “_Too many attempts. Please try again later._” 


### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/679767

PROPOSAL: N/A

### Tests

Covered by added automated tests

- [x] Verify that no errors appear in the JS console.

### Offline tests

N/A

### QA Steps

1. Deploy the companion API change.
2. Open a US Expensify Card's reveal-details verification screen.
3. Submit incorrect security codes until the API responds with `jsonCode: 429`.
4. Verify “_Too many attempts. Please try again later._” appears instead of the connection error.

- [x] Verify that no errors appear in the JS console.

### PR Author Checklist

- [x] Link the issue and companion API PR.
- [x] Add regression tests for the new error and existing response paths.
- [x] Run changed-file lint and spelling checks.
- [ ] Complete manual web, mobile, and offline QA.
- [x] Complete copy and translation review.
- [x] Verify the full typecheck with synchronized dependencies.

### Screenshots/Videos

Not captured; this changes the message in the existing validation screen without changing its layout.
