### PR TITLE
fix: show the correct error for folder attachments

### DIFF
--- a/src/libs/fileDownload/FileUtils.ts
+++ b/src/libs/fileDownload/FileUtils.ts
@@ -790,11 +790,6 @@ const getFileValidationErrorText = (
                     title: translate('attachmentPicker.someFilesCantBeUploaded'),
                     reason: translate('attachmentPicker.sizeLimitExceeded', maxSize / 1024 / 1024),
                 };
-            case CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED:
-                return {
-                    title: translate('attachmentPicker.attachmentError'),
-                    reason: translate('attachmentPicker.folderNotAllowedMessage'),
-                };
             case CONST.FILE_VALIDATION_ERRORS.MAX_FILE_LIMIT_EXCEEDED:
                 return {
                     title: translate('attachmentPicker.someFilesCantBeUploaded'),
@@ -806,6 +801,11 @@ const getFileValidationErrorText = (
     }
 
     switch (validationError.error) {
+        case CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED:
+            return {
+                title: translate('attachmentPicker.attachmentError'),
+                reason: translate('attachmentPicker.folderNotAllowedMessage'),
+            };
         case CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE:
             return {
                 title: translate('attachmentPicker.wrongFileType'),

--- a/src/libs/fileDownload/FileUtils.ts
+++ b/src/libs/fileDownload/FileUtils.ts
@@ -791,6 +791,7 @@ const getFileValidationErrorText = (
                     reason: translate('attachmentPicker.sizeLimitExceeded', maxSize / 1024 / 1024),
                 };
             case CONST.FILE_VALIDATION_ERRORS.MAX_FILE_LIMIT_EXCEEDED:
+                // This error can only occur for a multi-file selection, so it intentionally has no single-file case below.
                 return {
                     title: translate('attachmentPicker.someFilesCantBeUploaded'),
                     reason: translate('attachmentPicker.maxFileLimitExceeded'),
@@ -803,7 +804,7 @@ const getFileValidationErrorText = (
     switch (validationError.error) {
         case CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED:
             return {
-                title: translate('attachmentPicker.attachmentError'),
+                title: translate(validationError.isValidatingMultipleFiles ? 'attachmentPicker.someFilesCantBeUploaded' : 'attachmentPicker.attachmentError'),
                 reason: translate('attachmentPicker.folderNotAllowedMessage'),
             };
         case CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE:

--- a/src/libs/validateAttachmentFile.ts
+++ b/src/libs/validateAttachmentFile.ts
@@ -23,6 +23,11 @@ async function validateAttachmentFile(file: FileObject, item?: DataTransferItem,
         return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FILE_INVALID};
     }
 
+    // Detect folders before receipt-specific extension and size checks so they retain the folder error.
+    if (isDataTransferItemDirectory(item)) {
+        return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED};
+    }
+
     if (isValidatingReceipts && !isValidReceiptExtension(file)) {
         return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE};
     }
@@ -48,10 +53,6 @@ async function validateAttachmentFile(file: FileObject, item?: DataTransferItem,
 
     if (!fileObject) {
         return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FILE_INVALID};
-    }
-
-    if (isDataTransferItemDirectory(item)) {
-        return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED};
     }
 
     const normalizedFile = await normalizeFileObject(fileObject);

--- a/tests/unit/FileUtilsTest.ts
+++ b/tests/unit/FileUtilsTest.ts
@@ -526,6 +526,23 @@ describe('FileUtils', () => {
             expect(result.reason).toBe('attachmentPicker.imageDimensionsTooLarge');
         });
 
+        it('should return the folder-specific error text for a single folder', () => {
+            const result = getFileValidationErrorText(mockTranslate, {error: CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED});
+
+            expect(result.title).toBe('attachmentPicker.attachmentError');
+            expect(result.reason).toBe('attachmentPicker.folderNotAllowedMessage');
+        });
+
+        it('should return the folder-specific error text when multiple items are selected', () => {
+            const result = getFileValidationErrorText(mockTranslate, {
+                error: CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED,
+                isValidatingMultipleFiles: true,
+            });
+
+            expect(result.title).toBe('attachmentPicker.attachmentError');
+            expect(result.reason).toBe('attachmentPicker.folderNotAllowedMessage');
+        });
+
         it('should return empty strings for null validation error', () => {
             const result = getFileValidationErrorText(mockTranslate, null);
 

--- a/tests/unit/FileUtilsTest.ts
+++ b/tests/unit/FileUtilsTest.ts
@@ -539,7 +539,7 @@ describe('FileUtils', () => {
                 isValidatingMultipleFiles: true,
             });
 
-            expect(result.title).toBe('attachmentPicker.attachmentError');
+            expect(result.title).toBe('attachmentPicker.someFilesCantBeUploaded');
             expect(result.reason).toBe('attachmentPicker.folderNotAllowedMessage');
         });
 

--- a/tests/unit/ValidateAttachmentFileTest.ts
+++ b/tests/unit/ValidateAttachmentFileTest.ts
@@ -207,6 +207,22 @@ describe('validateAttachmentFile', () => {
             expect(error.error).toEqual(CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED);
         });
 
+        it.each(['folder', 'receipts.pdf'])('returns FOLDER_NOT_ALLOWED for a receipt directory named %s', async (name) => {
+            const mockItem = createMock<DataTransferItem>({
+                kind: 'file' as const,
+                webkitGetAsEntry: jest.fn(() => createMock<FileSystemEntry>({isDirectory: true})),
+            });
+
+            const file = createMockFile(name, 0);
+            const error = await validateAttachmentFile(file, mockItem, true);
+
+            if (error.isValid) {
+                throw new Error('validateAttachmentFile should return an invalid result');
+            }
+
+            expect(error.error).toEqual(CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED);
+        });
+
         it('returns valid result when DataTransferItem is not a directory', async () => {
             const mockItem = createMock<DataTransferItem>({
                 kind: 'file' as const,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

Folder drops can surface misleading errors depending on where and how the user drops them. A single folder in the attachment zone falls back to corrupted-file copy, the receipt zone reports an unsupported file type, and mixed selections use a title that implies every file failed. This PR makes folder classification and error titles consistent across those paths.

### Reproduction

1. Open a report on desktop web and drag a single folder onto the attachment drop zone.
2. Notice that the modal shows the generic corrupted-file message instead of the folder-specific message.
3. Drag a single folder onto the receipt drop zone.
4. Notice that the modal reports an unsupported file type instead of rejecting the folder as a folder.
5. Drag a folder and a valid file onto the attachment drop zone together.
6. Notice that the modal uses the singular attachment-error title even though the valid file can continue.

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This originated while re-evaluating the unfinished attachment-validation work in [#85751](https://github.com/Expensify/App/pull/85751). Most of that work was later covered by [#86189](https://github.com/Expensify/App/pull/86189), which corrected receipt attachment validation, [#93234](https://github.com/Expensify/App/pull/93234), which made multi-file validation sequential and cleaned up object URLs, and [#92236](https://github.com/Expensify/App/pull/92236), which expanded `useFilesValidation` coverage. Related fixes in [#96024](https://github.com/Expensify/App/pull/96024) and [#96940](https://github.com/Expensify/App/pull/96940) also addressed HEIC conversion failures and file snapshot reliability.

Comparing those changes with the current implementation exposed three remaining gaps. `getFileValidationErrorText()` fell back to the corrupted-file copy for a single folder, receipt validation checked the extension and size before checking whether the item was a directory, and a folder in a mixed selection used the singular attachment-error title.

Folder detection now runs before receipt-specific extension and size validation. The error mapper returns the folder-specific reason for any folder and uses **Some files can't be uploaded** for a mixed selection. The multi-file limit case also documents why it intentionally has no single-file counterpart. Unit tests cover single and mixed folder errors plus receipt folders with and without a valid-looking extension.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/100707
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Sign in on desktop web and open any report.
2. Drag a single folder onto the attachment drop zone.
3. Verify an **Attachment error** modal appears with **Uploading a folder is not allowed. Please try a different file.**
4. Verify the generic corrupted-file message does not appear.
5. Drag a single folder onto the receipt drop zone.
6. Verify the same folder-specific title and message appear instead of an unsupported-file-type or file-too-small error.
7. Drag a folder and a valid file onto the attachment drop zone together.
8. Verify the modal title is **Some files can't be uploaded**, the reason is the folder-specific message, and the valid file continues.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go offline.
2. Repeat steps 1 through 8 from **Tests**.
3. Verify the same folder-specific errors appear and the valid file in the mixed selection continues.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as **Tests**.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Screenshots are provided by C+ review already
