### PR TITLE
fix(charts): keep the skia canvas usable when React re-runs Canvas effects on web

### DIFF
--- a/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch
+++ b/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js b/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
+index ec3b49e..a7ddd2b 100644
+--- a/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
++++ b/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
+@@ -100,8 +100,19 @@ class WebGLRenderer {
+   }
+   dispose() {
+     if (this.surface) {
+-      var _this$canvas;
+-      (_this$canvas = this.canvas) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getContext("webgl2")) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getExtension("WEBGL_lose_context")) === null || _this$canvas === void 0 || _this$canvas.loseContext();
++      // A lost context is permanent for the element and effect cleanup is not unmount: an
++      // <Activity> hide (or a StrictMode DEV re-run) disposes the renderer but keeps the
++      // <canvas>, and the reveal re-creates a renderer on that same element, which can never get
++      // a usable context again once it was lost. Defer the release one microtask and only lose
++      // the context once React has really detached the element - at cleanup time it is still
++      // connected even during a real unmount (upstream issue #3976, PR #4027). A kept element
++      // also keeps its last frame while the hidden screen stays visible as a static backdrop.
++      const canvas = this.canvas;
++      queueMicrotask(() => {
++        if (canvas && !canvas.isConnected) {
++          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
++        }
++      });
+       this.surface.ref.delete();
+       this.surface = null;
+     }
+diff --git a/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js b/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
+index e1cd87b..4ea9833 100644
+--- a/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
++++ b/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
+@@ -93,8 +93,19 @@ class WebGLRenderer {
+   }
+   dispose() {
+     if (this.surface) {
+-      var _this$canvas;
+-      (_this$canvas = this.canvas) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getContext("webgl2")) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getExtension("WEBGL_lose_context")) === null || _this$canvas === void 0 || _this$canvas.loseContext();
++      // A lost context is permanent for the element and effect cleanup is not unmount: an
++      // <Activity> hide (or a StrictMode DEV re-run) disposes the renderer but keeps the
++      // <canvas>, and the reveal re-creates a renderer on that same element, which can never get
++      // a usable context again once it was lost. Defer the release one microtask and only lose
++      // the context once React has really detached the element - at cleanup time it is still
++      // connected even during a real unmount (upstream issue #3976, PR #4027). A kept element
++      // also keeps its last frame while the hidden screen stays visible as a static backdrop.
++      const canvas = this.canvas;
++      queueMicrotask(() => {
++        if (canvas && !canvas.isConnected) {
++          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
++        }
++      });
+       this.surface.ref.delete();
+       this.surface = null;
+     }

--- a/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch
+++ b/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch
@@ -2,22 +2,18 @@ diff --git a/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPict
 index ec3b49e..a7ddd2b 100644
 --- a/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
 +++ b/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
-@@ -100,8 +100,19 @@ class WebGLRenderer {
+@@ -100,8 +100,15 @@ class WebGLRenderer {
    }
    dispose() {
      if (this.surface) {
 -      var _this$canvas;
 -      (_this$canvas = this.canvas) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getContext("webgl2")) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getExtension("WEBGL_lose_context")) === null || _this$canvas === void 0 || _this$canvas.loseContext();
-+      // A lost context is permanent for the element and effect cleanup is not unmount: an
-+      // <Activity> hide (or a StrictMode DEV re-run) disposes the renderer but keeps the
-+      // <canvas>, and the reveal re-creates a renderer on that same element, which can never get
-+      // a usable context again once it was lost. Defer the release one microtask and only lose
-+      // the context once React has really detached the element - at cleanup time it is still
-+      // connected even during a real unmount (upstream issue #3976, PR #4027). A kept element
-+      // also keeps its last frame while the hidden screen stays visible as a static backdrop.
++      // A lost context is permanent for the element and effect cleanup is not unmount (an
++      // <Activity> hide or a StrictMode re-run keeps the <canvas>), so only lose it once React
++      // has really detached the element (upstream Shopify/react-native-skia#4002).
 +      const canvas = this.canvas;
 +      queueMicrotask(() => {
-+        if (canvas && !canvas.isConnected) {
++        if (!canvas.isConnected) {
 +          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
 +        }
 +      });
@@ -28,22 +24,18 @@ diff --git a/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictur
 index e1cd87b..4ea9833 100644
 --- a/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
 +++ b/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
-@@ -93,8 +93,19 @@ class WebGLRenderer {
+@@ -93,8 +93,15 @@ class WebGLRenderer {
    }
    dispose() {
      if (this.surface) {
 -      var _this$canvas;
 -      (_this$canvas = this.canvas) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getContext("webgl2")) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getExtension("WEBGL_lose_context")) === null || _this$canvas === void 0 || _this$canvas.loseContext();
-+      // A lost context is permanent for the element and effect cleanup is not unmount: an
-+      // <Activity> hide (or a StrictMode DEV re-run) disposes the renderer but keeps the
-+      // <canvas>, and the reveal re-creates a renderer on that same element, which can never get
-+      // a usable context again once it was lost. Defer the release one microtask and only lose
-+      // the context once React has really detached the element - at cleanup time it is still
-+      // connected even during a real unmount (upstream issue #3976, PR #4027). A kept element
-+      // also keeps its last frame while the hidden screen stays visible as a static backdrop.
++      // A lost context is permanent for the element and effect cleanup is not unmount (an
++      // <Activity> hide or a StrictMode re-run keeps the <canvas>), so only lose it once React
++      // has really detached the element (upstream Shopify/react-native-skia#4002).
 +      const canvas = this.canvas;
 +      queueMicrotask(() => {
-+        if (canvas && !canvas.isConnected) {
++        if (!canvas.isConnected) {
 +          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
 +        }
 +      });

--- a/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch
+++ b/patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPict
 index ec3b49e..a7ddd2b 100644
 --- a/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
 +++ b/node_modules/@shopify/react-native-skia/lib/commonjs/views/SkiaPictureView.web.js
-@@ -100,8 +100,15 @@ class WebGLRenderer {
+@@ -100,8 +100,12 @@ class WebGLRenderer {
    }
    dispose() {
      if (this.surface) {
@@ -10,13 +10,10 @@ index ec3b49e..a7ddd2b 100644
 -      (_this$canvas = this.canvas) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getContext("webgl2")) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getExtension("WEBGL_lose_context")) === null || _this$canvas === void 0 || _this$canvas.loseContext();
 +      // A lost context is permanent for the element and effect cleanup is not unmount (an
 +      // <Activity> hide or a StrictMode re-run keeps the <canvas>), so only lose it once React
-+      // has really detached the element (upstream Shopify/react-native-skia#4002).
-+      const canvas = this.canvas;
-+      queueMicrotask(() => {
-+        if (!canvas.isConnected) {
-+          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
-+        }
-+      });
++      // has detached the element (upstream Shopify/react-native-skia#4002).
++      if (!this.canvas.isConnected) {
++        this.canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
++      }
        this.surface.ref.delete();
        this.surface = null;
      }
@@ -24,7 +21,7 @@ diff --git a/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictur
 index e1cd87b..4ea9833 100644
 --- a/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
 +++ b/node_modules/@shopify/react-native-skia/lib/module/views/SkiaPictureView.web.js
-@@ -93,8 +93,15 @@ class WebGLRenderer {
+@@ -93,8 +93,12 @@ class WebGLRenderer {
    }
    dispose() {
      if (this.surface) {
@@ -32,13 +29,10 @@ index e1cd87b..4ea9833 100644
 -      (_this$canvas = this.canvas) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getContext("webgl2")) === null || _this$canvas === void 0 || (_this$canvas = _this$canvas.getExtension("WEBGL_lose_context")) === null || _this$canvas === void 0 || _this$canvas.loseContext();
 +      // A lost context is permanent for the element and effect cleanup is not unmount (an
 +      // <Activity> hide or a StrictMode re-run keeps the <canvas>), so only lose it once React
-+      // has really detached the element (upstream Shopify/react-native-skia#4002).
-+      const canvas = this.canvas;
-+      queueMicrotask(() => {
-+        if (!canvas.isConnected) {
-+          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
-+        }
-+      });
++      // has detached the element (upstream Shopify/react-native-skia#4002).
++      if (!this.canvas.isConnected) {
++        this.canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext();
++      }
        this.surface.ref.delete();
        this.surface = null;
      }

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -130,11 +130,15 @@
 
     One case gets worse than before: a screen unmounted while hidden. Its
     cleanup already ran at hide time, when the canvas was still connected, so
-    React runs none at unmount and the context is only reclaimed by the
-    browser's LRU force-loss once the cap is hit. Before the patch every
-    unmount, background screen or not, released its context synchronously.
-    Mounted screens are unchanged, each held a live context before Activity
-    too. Upstream #4002 has the same gap.
+    React runs none at unmount and the context, with its full-size drawing
+    buffer, is only reclaimed by the browser's LRU force-loss once the cap is
+    hit. Before the patch every unmount, background screen or not, released
+    its context synchronously. Mounted screens are unchanged, each held a live
+    context before Activity too. Upstream #4002 skips the same release, but it
+    is less exposed: its dispose() frees the surface, the GrContext, the
+    CanvasKit context handle and the drawing buffer at every hide, so only the
+    context slot survives there. Freeing the buffer is the canvas size reset
+    that would blank the backdrop, which is why this patch does not copy it.
     ```
 
 - Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976, fixed by https://github.com/Shopify/react-native-skia/pull/4002 (merged 2026-09-02, not in any release as of 2026-09-09; the latest is 2.11.2). Its dispose() applies the same isConnected guard (deferred by a microtask, since its caller is a layout effect) and adds context-restore handling, but it also zeroes the canvas size on cleanup, so a hidden Activity screen would show a blank chart in the backdrop. When the Skia dependency is bumped past that merge, either accept the blank backdrop and drop this patch or replace it with a patch that only removes the size reset.

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -115,15 +115,18 @@
     throws "Cannot read properties of null (reading 'rangeMin')", which patch
     002 turns into the "unable to display chart" fallback.
 
-    dispose() now defers the release by one microtask and only loses the
-    context when the canvas has left the document. React runs cleanup before
-    detaching the host node, so isConnected is false one microtask later only
-    for a real unmount, which keeps releasing the context deterministically
-    (browsers cap a page at ~16 live contexts). An Activity hide keeps the
-    element connected, so the context and the last presented frame survive
-    and the reveal builds its surface on the live context like the resize path
-    already does. The kept frame matters because ScreenActivityWrapper keeps
-    the hidden screen painted as a static backdrop (AlwaysPaintedView).
+    dispose() now only loses the context when the canvas has left the
+    document. In 2.4.18 it runs from a passive useEffect cleanup, which React
+    flushes after removing the host node, so isConnected is already false at
+    cleanup time on a real unmount, which keeps releasing the context
+    deterministically (browsers cap a page at ~16 live contexts). An Activity
+    hide keeps the element connected, so the context and the last presented
+    frame survive and the reveal builds its surface on the live context like
+    the resize path already does. The kept frame matters because
+    ScreenActivityWrapper keeps the hidden screen painted as a static backdrop
+    (AlwaysPaintedView). Upstream defers the same check by a microtask because
+    its dispose() runs from a layout effect cleanup, before the node is
+    detached; a passive caller needs no deferral.
 
     One case gets worse than before: a screen unmounted while hidden. Its
     cleanup already ran at hide time, when the canvas was still connected, so
@@ -134,6 +137,6 @@
     too. Upstream #4002 has the same gap.
     ```
 
-- Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976, fixed by https://github.com/Shopify/react-native-skia/pull/4002 (merged 2026-09-02, not in any release as of 2026-09-09; the latest is 2.11.2). Its dispose() defers the loss the same way and adds context-restore handling, but it also zeroes the canvas size on cleanup, so a hidden Activity screen would show a blank chart in the backdrop. When the Skia dependency is bumped past that merge, either accept the blank backdrop and drop this patch or replace it with a patch that only removes the size reset.
+- Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976, fixed by https://github.com/Shopify/react-native-skia/pull/4002 (merged 2026-09-02, not in any release as of 2026-09-09; the latest is 2.11.2). Its dispose() applies the same isConnected guard (deferred by a microtask, since its caller is a layout effect) and adds context-restore handling, but it also zeroes the canvas size on cleanup, so a hidden Activity screen would show a blank chart in the backdrop. When the Skia dependency is bumped past that merge, either accept the blank backdrop and drop this patch or replace it with a patch that only removes the size reset.
 - E/App issue: https://github.com/Expensify/App/issues/98254
 - PR introducing patch: https://github.com/Expensify/App/pull/100714

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -97,3 +97,48 @@
 - Upstream PR/issue: https://github.com/Shopify/react-native-skia/pull/3855 — the same fix, merged upstream on 2026-05-26. Drop this patch once the Skia dependency is bumped to >= 2.6.9.
 - E/App issue: https://github.com/Expensify/App/issues/98331, https://github.com/Expensify/App/issues/95905
 - PR introducing patch: https://github.com/Expensify/App/pull/98437
+
+### [@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch](@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch)
+
+- Reason:
+
+    ```
+    Fixes charts staying permanently blank on web whenever React re-runs the
+    layout effects of a mounted <Canvas> on the same DOM node - most importantly
+    a screen wrapped in React <Activity> being hidden and revealed (the
+    ScreenActivityWrapper rollout), and StrictMode's DEV double-invoke.
+
+    Hiding an Activity subtree runs effect cleanups: SkiaPictureView's cleanup
+    calls WebGLRenderer.dispose(), which called WEBGL_lose_context.loseContext()
+    on the <canvas>. Per the WEBGL_lose_context spec that loss is permanent for
+    the element - a later getContext("webgl2") hands back the same lost context
+    and only restoreContext() can revive it. Revealing re-runs the effects and
+    creates a new renderer on the same canvas element, so
+    CanvasKit.MakeWebGLCanvasSurface can never succeed on it again - it throws
+    "Cannot read properties of null (reading 'rangeMin')" (which patch 002 turns
+    into the "unable to display chart" fallback). Losing the context also blanks
+    the canvas while the hidden screen can still be on screen: the app keeps a
+    hidden <Activity> screen visible as a static backdrop (display: contents).
+
+    Fix (mirrors upstream PR #4027): dispose() no longer loses the context
+    synchronously. It defers the release by one microtask and only calls
+    loseContext() when the canvas actually left the document - React runs effect
+    cleanup before detaching the host node, so the element is still connected at
+    cleanup time even during a real unmount, but one microtask later
+    isConnected is false only for a real unmount. An Activity hide keeps the
+    element connected, so the context - and the last presented frame the
+    backdrop shows - survives, and the reveal creates its new surface on the
+    live context exactly like the already-working resize path. A real unmount
+    still releases the context deterministically, which matters because
+    browsers cap a page at ~16 live WebGL contexts.
+
+    A screen unmounted while hidden runs no cleanup at all, so its context is
+    reclaimed only by the browser's LRU force-loss once the cap is hit; a
+    leaked context is never used again, so it is the first eviction victim.
+    Context pressure from hidden screens matches the pre-Activity baseline,
+    where every mounted background screen held a live context anyway.
+    ```
+
+- Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976 - the same root cause reported against upstream `main`, with two open fixes: https://github.com/Shopify/react-native-skia/pull/4027 (deferred `isConnected`-guarded release, which this patch mirrors) and https://github.com/Shopify/react-native-skia/pull/4002 (drops `loseContext()` entirely; safe upstream only because `deleteContext()` exists there, which 2.4.18 lacks). Revisit when either merges and the Skia dependency is bumped.
+- E/App issue: https://github.com/Expensify/App/issues/98254
+- PR introducing patch: https://github.com/Expensify/App/pull/100714

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -125,10 +125,13 @@
     already does. The kept frame matters because ScreenActivityWrapper keeps
     the hidden screen painted as a static backdrop (AlwaysPaintedView).
 
-    A screen unmounted while hidden runs no cleanup, so its context is only
-    reclaimed by the browser's LRU force-loss once the cap is hit. That matches
-    the pre-Activity baseline, where every mounted background screen held a
-    live context anyway.
+    One case gets worse than before: a screen unmounted while hidden. Its
+    cleanup already ran at hide time, when the canvas was still connected, so
+    React runs none at unmount and the context is only reclaimed by the
+    browser's LRU force-loss once the cap is hit. Before the patch every
+    unmount, background screen or not, released its context synchronously.
+    Mounted screens are unchanged, each held a live context before Activity
+    too. Upstream #4002 has the same gap.
     ```
 
 - Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976, fixed by https://github.com/Shopify/react-native-skia/pull/4002 (merged 2026-09-02, not in any release as of 2026-09-09; the latest is 2.11.2). Its dispose() defers the loss the same way and adds context-restore handling, but it also zeroes the canvas size on cleanup, so a hidden Activity screen would show a blank chart in the backdrop. When the Skia dependency is bumped past that merge, either accept the blank backdrop and drop this patch or replace it with a patch that only removes the size reset.

--- a/patches/@shopify/react-native-skia/details.md
+++ b/patches/@shopify/react-native-skia/details.md
@@ -104,41 +104,33 @@
 
     ```
     Fixes charts staying permanently blank on web whenever React re-runs the
-    layout effects of a mounted <Canvas> on the same DOM node - most importantly
-    a screen wrapped in React <Activity> being hidden and revealed (the
-    ScreenActivityWrapper rollout), and StrictMode's DEV double-invoke.
+    layout effects of a mounted <Canvas> on the same DOM node: a screen wrapped
+    in React <Activity> being hidden and revealed (the ScreenActivityWrapper
+    rollout) and StrictMode's DEV double-invoke.
 
-    Hiding an Activity subtree runs effect cleanups: SkiaPictureView's cleanup
-    calls WebGLRenderer.dispose(), which called WEBGL_lose_context.loseContext()
-    on the <canvas>. Per the WEBGL_lose_context spec that loss is permanent for
-    the element - a later getContext("webgl2") hands back the same lost context
-    and only restoreContext() can revive it. Revealing re-runs the effects and
-    creates a new renderer on the same canvas element, so
-    CanvasKit.MakeWebGLCanvasSurface can never succeed on it again - it throws
-    "Cannot read properties of null (reading 'rangeMin')" (which patch 002 turns
-    into the "unable to display chart" fallback). Losing the context also blanks
-    the canvas while the hidden screen can still be on screen: the app keeps a
-    hidden <Activity> screen visible as a static backdrop (display: contents).
+    The effect cleanup calls WebGLRenderer.dispose(), which lost the WebGL
+    context of the <canvas>. Per the WEBGL_lose_context spec that loss is
+    permanent for the element, so the renderer the re-run creates on the same
+    element can never get a surface again: CanvasKit.MakeWebGLCanvasSurface
+    throws "Cannot read properties of null (reading 'rangeMin')", which patch
+    002 turns into the "unable to display chart" fallback.
 
-    Fix (mirrors upstream PR #4027): dispose() no longer loses the context
-    synchronously. It defers the release by one microtask and only calls
-    loseContext() when the canvas actually left the document - React runs effect
-    cleanup before detaching the host node, so the element is still connected at
-    cleanup time even during a real unmount, but one microtask later
-    isConnected is false only for a real unmount. An Activity hide keeps the
-    element connected, so the context - and the last presented frame the
-    backdrop shows - survives, and the reveal creates its new surface on the
-    live context exactly like the already-working resize path. A real unmount
-    still releases the context deterministically, which matters because
-    browsers cap a page at ~16 live WebGL contexts.
+    dispose() now defers the release by one microtask and only loses the
+    context when the canvas has left the document. React runs cleanup before
+    detaching the host node, so isConnected is false one microtask later only
+    for a real unmount, which keeps releasing the context deterministically
+    (browsers cap a page at ~16 live contexts). An Activity hide keeps the
+    element connected, so the context and the last presented frame survive
+    and the reveal builds its surface on the live context like the resize path
+    already does. The kept frame matters because ScreenActivityWrapper keeps
+    the hidden screen painted as a static backdrop (AlwaysPaintedView).
 
-    A screen unmounted while hidden runs no cleanup at all, so its context is
-    reclaimed only by the browser's LRU force-loss once the cap is hit; a
-    leaked context is never used again, so it is the first eviction victim.
-    Context pressure from hidden screens matches the pre-Activity baseline,
-    where every mounted background screen held a live context anyway.
+    A screen unmounted while hidden runs no cleanup, so its context is only
+    reclaimed by the browser's LRU force-loss once the cap is hit. That matches
+    the pre-Activity baseline, where every mounted background screen held a
+    live context anyway.
     ```
 
-- Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976 - the same root cause reported against upstream `main`, with two open fixes: https://github.com/Shopify/react-native-skia/pull/4027 (deferred `isConnected`-guarded release, which this patch mirrors) and https://github.com/Shopify/react-native-skia/pull/4002 (drops `loseContext()` entirely; safe upstream only because `deleteContext()` exists there, which 2.4.18 lacks). Revisit when either merges and the Skia dependency is bumped.
+- Upstream PR/issue: https://github.com/Shopify/react-native-skia/issues/3976, fixed by https://github.com/Shopify/react-native-skia/pull/4002 (merged 2026-09-02, not in any release as of 2026-09-09; the latest is 2.11.2). Its dispose() defers the loss the same way and adds context-restore handling, but it also zeroes the canvas size on cleanup, so a hidden Activity screen would show a blank chart in the backdrop. When the Skia dependency is bumped past that merge, either accept the blank backdrop and drop this patch or replace it with a patch that only removes the size reset.
 - E/App issue: https://github.com/Expensify/App/issues/98254
 - PR introducing patch: https://github.com/Expensify/App/pull/100714


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Adds patch 004 to `@shopify/react-native-skia` so a `<Canvas>` on web survives React re-running its layout effects on the same DOM node. Today `WebGLRenderer.dispose()` loses the canvas's WebGL context on every effect cleanup, and a lost context is permanent for that element, so the re-run can never create a surface again and the chart stays blank. This is a prerequisite for hiding chart screens with React `<Activity>` (the `ScreenActivityWrapper` rollout, https://github.com/Expensify/App/issues/98254) and it also fixes the same failure under StrictMode's dev double-invoke.

**In the app**
- Nothing changes in production today: no screen opts into `nonTopScreenBehavior: 'activity'` yet, and StrictMode is a dev-only tool.
- With `USE_REACT_STRICT_MODE_IN_DEV` on, Reports charts (bar, line, pie) render instead of falling back to "Unable to display chart".
- Once a screen with charts opts into Activity, hiding and revealing it keeps the chart and its last presented frame instead of showing a white block.

**In the code**
- New `patches/@shopify/react-native-skia/@shopify+react-native-skia+2.4.18+004+defer-webgl-context-loss-to-unmount.patch`: `dispose()` now loses the context only when the canvas has already left the document, which is the real-unmount case. In 2.4.18 it runs from a passive effect cleanup, which React flushes after detaching the host node, so a plain `isConnected` check is enough and a real unmount still releases its context deterministically (browsers cap a page at ~16 live contexts). An Activity hide or a StrictMode re-run keeps the element connected, so the new renderer reuses the live context like the resize path already does.
- Same guard as the upstream Shopify/react-native-skia#4002 (merged 2026-09-02, not in any release yet), minus its microtask deferral, which that fix needs only because its `dispose()` runs from a layout effect cleanup, before the node is detached. Upstream also zeroes the canvas size on cleanup, which would blank a hidden Activity screen's backdrop, so a Skia bump does not fully replace this patch. `details.md` records that.

**Known regression**
- A screen unmounted while it is hidden no longer releases its WebGL context eagerly. Its cleanup already ran at hide time, when the canvas was still connected, so React runs none at unmount and the context, with its full-size drawing buffer, is reclaimed only by the browser's own eviction of the oldest context once the per-page cap is hit (16 in Chrome). Before the patch every unmount released the context synchronously. Mounted screens are unchanged, each held a live context before Activity too.
- Upstream Shopify/react-native-skia#4002 skips the same release in that case, but it is less exposed: its `dispose()` frees the surface, the `GrContext`, the CanvasKit context handle and the drawing buffer at every hide, so only the context slot survives there. Freeing the buffer is the canvas size reset that would blank a hidden screen's backdrop, which is why this patch does not copy it.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/98254
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
Web (Chrome) only, the patch touches `SkiaPictureView.web.js`.

1. In `src/CONFIG.ts` set `USE_REACT_STRICT_MODE_IN_DEV` to `true` and start the web app (`npm run web`).
2. Open Reports, group expenses (for example by category) and switch the view to the bar chart. Verify that the chart renders (without the patch it shows "Unable to display chart").
3. Switch to the line and pie views. Verify that each chart renders and that no `rangeMin` or WebGL error appears in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - the patch changes how a web `<canvas>` releases its WebGL context, no network or Onyx code is touched.

### QA Steps
Web (Chrome and Safari) and mWeb, the patch only touches the web renderer.

1. Open Reports, group expenses (for example by category) and switch the view to the bar chart. Verify that the chart renders.
2. Switch to the line view and then the pie view. Verify that each chart renders with its labels and that no "Unable to display chart" message appears.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Web QA Steps</summary>

https://github.com/user-attachments/assets/5fe31824-c217-4de7-87aa-6515a7e5d33c


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Before fix behavior with Activity</summary>

https://github.com/user-attachments/assets/fdf263f9-9aee-4117-8fb1-eacf0b32c73b



</details>


<details>
<summary>After fix behavior with Activity</summary>


https://github.com/user-attachments/assets/94522b11-74d4-4ccb-9b3d-794942d5a0ba


</details>





