### PR TITLE
Fix back navigation from debug DateTime picker landing on Not Found

### DIFF
--- a/src/pages/Debug/DateTimeSelector.tsx
+++ b/src/pages/Debug/DateTimeSelector.tsx
@@ -59,7 +59,7 @@ function DateTimeSelector({errorText = '', name, value, onInputChange, ref}: Dat
             brickRoadIndicator={errorText ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
             errorText={errorText}
             onPress={() => {
-                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.DETAILS_DATE_TIME_PICKER.getRoute(name, value)));
+                Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.DETAILS_DATE_TIME_PICKER.getRoute(name, value ? encodeURIComponent(value) : value)));
             }}
             shouldShowRightIcon
         />

--- a/src/pages/Debug/DynamicDebugDetailsDateTimePickerPage.tsx
+++ b/src/pages/Debug/DynamicDebugDetailsDateTimePickerPage.tsx
@@ -36,7 +36,7 @@ function DynamicDebugDetailsDateTimePickerPage({
 
     const handleSubmit = (time: string) => {
         const formattedDateTime = format(new Date(`${date} ${time}`), 'yyyy-MM-dd HH:mm:ss.SSS');
-        Navigation.goBack(appendParam(backPath, fieldName ?? '', formattedDateTime), {compareParams: false});
+        Navigation.goBack(appendParam(backPath, fieldName ?? '', encodeURIComponent(formattedDateTime)), {compareParams: false});
     };
 
     return (
@@ -45,7 +45,7 @@ function DynamicDebugDetailsDateTimePickerPage({
                 title={fieldName}
                 shouldShowBackButton
                 onBackButtonPress={() => {
-                    Navigation.goBack(fieldValue ? appendParam(backPath, fieldName, fieldValue) : backPath, {compareParams: false});
+                    Navigation.goBack(fieldValue ? appendParam(backPath, fieldName, encodeURIComponent(fieldValue)) : backPath, {compareParams: false});
                 }}
             />
             <ScrollView contentContainerStyle={styles.gap8}>


### PR DESCRIPTION
### Details
$ #100725

### Root cause
DateTime values formatted as yyyy-MM-dd HH:mm:ss.SSS were interpolated raw into route URLs in three places across DateTimeSelector and DynamicDebugDetailsDateTimePickerPage. Spaces and colons in the URL break web route matching, so tapping Back from the picker resolves to the Not Found page instead of the Debug Report RHP. Sibling pickers (constant, country) only pass spaceless codes, which is why only DateTime fields are affected.

### Fix
encodeURIComponent the datetime value at all three call sites. Query params are decoded on read (findAllMatchingDynamicSuffixes decodeURIComponent plus URLSearchParams entries), so values round-trip unchanged.

### Tests
- [ ] Verify back from a DateTime field returns to the Debug Report RHP on web
- [ ] Verify the picked datetime still populates the form

Note: I could not run the app locally (no test account), requesting QA on the repro steps in #100725.
