### PR TITLE
[CFI] Show export account column on workspace card tables

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -5137,6 +5137,15 @@ const CONST = {
         },
         CARD_LIST_THRESHOLD: 8,
         DEFAULT_EXPORT_TYPE: 'default',
+
+        /**
+         * How a card's export account is resolved. Most integrations point a card's NVP at one entry in a flat account
+         * list, while Rillet and DualEntry resolve it through a program account that each card feed can override.
+         */
+        EXPORT_RESOLVER: {
+            SINGLE_ACCOUNT: 'singleAccount',
+            PROGRAM_ACCOUNT: 'programAccount',
+        },
         EXPORT_CARD_TYPES: {
             /**
              * Name of Card NVP for QBO custom export accounts
@@ -8750,6 +8759,9 @@ const CONST = {
 
             /** How narrow a free-text column may be squeezed before the table scrolls instead, matching the ~180px default text column width table libraries use. */
             MIN_FREE_TEXT_COLUMN_WIDTH: 180,
+
+            /** Export account names are unbounded, so this column truncates rather than widening the table past its container. */
+            MAX_EXPORT_ACCOUNT_COLUMN_WIDTH: 240,
         },
     },
 

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8759,9 +8759,6 @@ const CONST = {
 
             /** How narrow a free-text column may be squeezed before the table scrolls instead, matching the ~180px default text column width table libraries use. */
             MIN_FREE_TEXT_COLUMN_WIDTH: 180,
-
-            /** Export account names are unbounded, so this column truncates rather than widening the table past its container. */
-            MAX_EXPORT_ACCOUNT_COLUMN_WIDTH: 240,
         },
     },
 

--- a/src/components/Table/useDynamicColumnWidths.ts
+++ b/src/components/Table/useDynamicColumnWidths.ts
@@ -85,9 +85,16 @@ function measureColumnContentWidth<DataType extends TableData, ColumnKey extends
         }
     }
 
+    // A column with no measured text and no extraWidth genuinely never shows anything, so it needs 0px. A column with
+    // extraWidth still has non-text content to fit (e.g. an icon with no accompanying text on some rows), so its width
+    // is not skipped just because no row's text happened to measure wider than the others.
+    if (widestContentWidth === 0 && !dynamicSizing.extraWidth) {
+        return 0;
+    }
+
     // Rounded up because the widths end up as whole px grid tracks. Rounding a fraction down would leave a column
     // narrower than the text it was sized to hold, and the browser would put an ellipsis on text that fits.
-    return widestContentWidth === 0 ? 0 : Math.ceil(widestContentWidth + (dynamicSizing.extraWidth ?? 0));
+    return Math.ceil(widestContentWidth + (dynamicSizing.extraWidth ?? 0));
 }
 
 /**

--- a/src/components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableRow.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableRow.tsx
@@ -31,6 +31,7 @@ type WorkspaceCompanyCardTableRowData = TableData &
         isCardDeleted: boolean;
         isAssigned: boolean;
         assignedCard?: Card;
+        exportAccountTitle?: string;
         onDismissError?: () => void;
     };
 
@@ -44,6 +45,9 @@ type WorkspaceCompanyCardTableRowProps = {
 
     /** Whether the current member can edit company cards */
     canWriteCompanyCards: boolean;
+
+    /** Whether the Export account column is shown, so the row must keep its cell in step with the column */
+    shouldShowExportAccountColumn: boolean;
 
     shouldUseNarrowTableLayout: boolean;
     rowIndex: number;
@@ -61,6 +65,7 @@ function WorkspaceCompanyCardTableRow({
     feedName,
     CardFeedIcon,
     shouldUseNarrowTableLayout,
+    shouldShowExportAccountColumn,
     rowIndex,
     isAssigningCardDisabled,
     canWriteCompanyCards,
@@ -111,7 +116,7 @@ function WorkspaceCompanyCardTableRow({
         return Navigation.navigate(createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_COMPANY_CARD_DETAILS.getRoute(feedName, cardID.toString())));
     };
 
-    const accessibilityLabel = [memberColumnTitle, formattedCardDetails, formattedCustomCardName].filter(Boolean).join(', ');
+    const accessibilityLabel = [memberColumnTitle, formattedCardDetails, formattedCustomCardName, item.exportAccountTitle].filter(Boolean).join(', ');
 
     return (
         <Table.Row
@@ -181,6 +186,20 @@ function WorkspaceCompanyCardTableRow({
                                 shouldShowTooltip
                                 numberOfLines={1}
                                 text={customCardName ?? ''}
+                                style={[styles.lh16, styles.optionDisplayName, styles.pre]}
+                            />
+                        </View>
+                    )}
+
+                    {!shouldUseNarrowTableLayout && shouldShowExportAccountColumn && (
+                        <View
+                            style={[styles.flex1, styles.justifyContentCenter]}
+                            {...getCellAccessibilityProps(isTableSemanticsEnabled)}
+                        >
+                            <TextWithTooltip
+                                shouldShowTooltip
+                                numberOfLines={1}
+                                text={item.exportAccountTitle ?? ''}
                                 style={[styles.lh16, styles.optionDisplayName, styles.pre]}
                             />
                         </View>

--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -192,6 +192,10 @@ function WorkspaceCompanyCardsTable({
     const shouldShowGBDisclaimer = isGB && (isNoFeed || hasNoAssignedCard);
     const shouldUseNarrowTableLayout = shouldUseNarrowLayout || isMediumScreenWidth;
 
+    // Whether any row currently renders the Assign button, so the actions column's dynamic sizing below can decide
+    // how much room to reserve for it: once a table's cards are all assigned, every row shows only the arrow.
+    const canAnyCardBeAssigned = canWriteCompanyCards && !isAssigningCardDisabled && (companyCardEntries ?? []).some((entry) => !entry.isAssigned);
+
     // Mirrors the Accounting section's own eligibility check on the card details page, so the column follows the same
     // rules as that section rather than introducing a second set of them.
     const syncingAccountingIntegration = CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES.find((integration) => integration === connectionSyncProgress?.connectionName);
@@ -243,7 +247,6 @@ function WorkspaceCompanyCardsTable({
                       sortable: true,
                       dynamicSizing: {
                           getContentToMeasure: (item: WorkspaceCompanyCardTableItemData) => (item.exportAccountTitle ? [{text: item.exportAccountTitle, fontSize: fontScale.text}] : []),
-                          maxWidth: CONST.TABLES.DYNAMIC_COLUMNS.MAX_EXPORT_ACCOUNT_COLUMN_WIDTH,
                       },
                   },
               ]
@@ -252,9 +255,21 @@ function WorkspaceCompanyCardsTable({
             key: 'actions',
             label: '',
             sortable: false,
-            width: variables.companyCardsTableActionColumnWidth,
             styling: {
                 containerStyles: [styles.justifyContentEnd, styles.pr3],
+            },
+            dynamicSizing: {
+                // A fixed width here would reserve the Assign button's space on every row, including the (usually
+                // more common) already-assigned rows that render only the arrow. Measuring instead means the column
+                // only claims that space when some row in the table can actually show the button.
+                getContentToMeasure: (item) =>
+                    canAnyCardBeAssigned && !item.isAssigned ? [{text: translate('workspace.companyCards.assign'), fontSize: fontScale.text, fontWeight: '700'}] : [],
+                // The Assign button and the arrow are a known, bounded pair of contents, so this column always shows
+                // them in full rather than truncating.
+                shouldFitContent: true,
+                // The button's own padding and its gap from the arrow only apply when some row can show it; otherwise
+                // the column only ever needs to fit the arrow itself.
+                extraWidth: canAnyCardBeAssigned ? styles.ph2.paddingHorizontal * 2 + styles.gap3.gap + variables.iconSizeNormal + styles.pr3.paddingRight : variables.iconSizeNormal,
             },
         },
     ];

--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -18,7 +18,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {resetFailedWorkspaceCompanyCardUnassignment} from '@libs/actions/CompanyCards';
-import {getCompanyCardCustomName, getDefaultCardName} from '@libs/CardUtils';
+import {formatMaskedCardName, getCompanyCardCustomName, getDefaultCardName} from '@libs/CardUtils';
 import {getConnectedIntegration} from '@libs/PolicyUtils';
 import tokenizedSearch from '@libs/tokenizedSearch';
 
@@ -36,6 +36,7 @@ import isLoadingOnyxValue from '@src/types/utils/isLoadingOnyxValue';
 import type {ListRenderItemInfo} from '@shopify/flash-list';
 
 import {companyCardCustomNamesSelector} from '@selectors/Card';
+import {Str} from 'expensify-common';
 import React, {useImperativeHandle, useRef, useState} from 'react';
 import {View} from 'react-native';
 
@@ -204,14 +205,14 @@ function WorkspaceCompanyCardsTable({
             label: translate('common.member'),
             sortable: true,
             dynamicSizing: {
-                // The cell stacks the member's name above the card details or login, so whichever renders wider decides
-                // the column's width.
+                // Mirrors the row's own title/subtitle: the cardholder's name (or the unassigned label) stacked above
+                // their login, so whichever renders wider decides the column's width.
                 getContentToMeasure: (item) => [
                     {
-                        text: item.isAssigned ? (item.cardholder?.displayName ?? item.cardholder?.login ?? '') : translate('workspace.moreFeatures.companyCards.unassignedCards'),
+                        text: item.isAssigned ? Str.removeSMSDomain(item.cardholder?.displayName ?? '') : translate('workspace.moreFeatures.companyCards.unassignedCards'),
                         fontSize: fontScale.text,
                     },
-                    {text: item.customCardName ?? '', fontSize: fontScale.label},
+                    {text: item.isAssigned ? Str.removeSMSDomain(item.cardholder?.login ?? '') : '', fontSize: fontScale.label},
                 ],
                 extraWidth: MEMBER_CELL_AVATAR_WIDTH,
             },
@@ -222,7 +223,7 @@ function WorkspaceCompanyCardsTable({
             sortable: true,
             dynamicSizing: {
                 // Masked card numbers all render at the same length, so this column always fits them in full.
-                getContentToMeasure: (item) => [{text: item.cardName, fontSize: fontScale.text}],
+                getContentToMeasure: (item) => [{text: formatMaskedCardName(item.cardName), fontSize: fontScale.text}],
                 shouldFitContent: true,
             },
         },
@@ -251,14 +252,9 @@ function WorkspaceCompanyCardsTable({
             key: 'actions',
             label: '',
             sortable: false,
+            width: variables.companyCardsTableActionColumnWidth,
             styling: {
                 containerStyles: [styles.justifyContentEnd, styles.pr3],
-            },
-            dynamicSizing: {
-                // Only unassigned rows render the Assign button, so that is the widest content this column ever holds.
-                getContentToMeasure: () => [{text: translate('workspace.companyCards.assign'), fontSize: fontScale.text, fontWeight: '700'}],
-                extraWidth: variables.iconSizeNormal + styles.gap3.gap,
-                shouldFitContent: true,
             },
         },
     ];

--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -253,14 +253,17 @@ function WorkspaceCompanyCardsTable({
             styling: {
                 containerStyles: [styles.justifyContentEnd, styles.pr3],
             },
-            dynamicSizing: {
-                // A fixed width here would reserve the Assign button's space even on rows that only render the arrow.
-                getContentToMeasure: (item) =>
-                    canAnyCardBeAssigned && !item.isAssigned ? [{text: translate('workspace.companyCards.assign'), fontSize: fontScale.text, fontWeight: '700'}] : [],
-                shouldFitContent: true,
-                // Only add the button's padding and gap when some row can actually show it.
-                extraWidth: canAnyCardBeAssigned ? styles.ph2.paddingHorizontal * 2 + styles.gap3.gap + variables.iconSizeNormal + styles.pr3.paddingRight : variables.iconSizeNormal,
-            },
+            // A fixed width would reserve the Assign button's space even when no row can show it, so only measure
+            // content while at least one row can render the button.
+            ...(canAnyCardBeAssigned
+                ? {
+                      dynamicSizing: {
+                          getContentToMeasure: (item) => (!item.isAssigned ? [{text: translate('workspace.companyCards.assign'), fontSize: fontScale.text, fontWeight: '700'}] : []),
+                          shouldFitContent: true,
+                          extraWidth: styles.ph2.paddingHorizontal * 2 + styles.gap3.gap + variables.iconSizeNormal + styles.pr3.paddingRight,
+                      },
+                  }
+                : {width: variables.tableCaretColumnWidth}),
         },
     ];
 

--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -48,7 +48,6 @@ import WorkspaceCompanyCardTableItem from './WorkspaceCompanyCardsTableRow';
 
 type CompanyCardsTableColumnKey = 'member' | 'card' | 'customCardName' | 'exportAccount' | 'actions';
 
-/** Width the member cell's avatar and the space after it take before the name and subtitle start. */
 const MEMBER_CELL_AVATAR_WIDTH = variables.avatarSizeSmall + 12;
 
 type WorkspaceCompanyCardsTableHandle = {
@@ -192,12 +191,10 @@ function WorkspaceCompanyCardsTable({
     const shouldShowGBDisclaimer = isGB && (isNoFeed || hasNoAssignedCard);
     const shouldUseNarrowTableLayout = shouldUseNarrowLayout || isMediumScreenWidth;
 
-    // Whether any row currently renders the Assign button, so the actions column's dynamic sizing below can decide
-    // how much room to reserve for it: once a table's cards are all assigned, every row shows only the arrow.
+    // Drives the actions column's dynamic sizing below: once every card is assigned, no row shows the Assign button.
     const canAnyCardBeAssigned = canWriteCompanyCards && !isAssigningCardDisabled && (companyCardEntries ?? []).some((entry) => !entry.isAssigned);
 
-    // Mirrors the Accounting section's own eligibility check on the card details page, so the column follows the same
-    // rules as that section rather than introducing a second set of them.
+    // Mirrors the Accounting section's own eligibility check on the card details page, so the column follows the same rules.
     const syncingAccountingIntegration = CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES.find((integration) => integration === connectionSyncProgress?.connectionName);
     const connectedIntegration = getConnectedIntegration(policy, CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES) ?? syncingAccountingIntegration;
     const cardExportSettings = getPolicyCardExportSettings(connectedIntegration, policyID, translate, policy);
@@ -209,8 +206,7 @@ function WorkspaceCompanyCardsTable({
             label: translate('common.member'),
             sortable: true,
             dynamicSizing: {
-                // Mirrors the row's own title/subtitle: the cardholder's name (or the unassigned label) stacked above
-                // their login, so whichever renders wider decides the column's width.
+                // Whichever of the cardholder's name (or the unassigned label) or their login renders wider decides the column's width.
                 getContentToMeasure: (item) => [
                     {
                         text: item.isAssigned ? Str.removeSMSDomain(item.cardholder?.displayName ?? '') : translate('workspace.moreFeatures.companyCards.unassignedCards'),
@@ -226,7 +222,6 @@ function WorkspaceCompanyCardsTable({
             label: translate('workspace.companyCards.card'),
             sortable: true,
             dynamicSizing: {
-                // Masked card numbers all render at the same length, so this column always fits them in full.
                 getContentToMeasure: (item) => [{text: formatMaskedCardName(item.cardName), fontSize: fontScale.text}],
                 shouldFitContent: true,
             },
@@ -259,16 +254,11 @@ function WorkspaceCompanyCardsTable({
                 containerStyles: [styles.justifyContentEnd, styles.pr3],
             },
             dynamicSizing: {
-                // A fixed width here would reserve the Assign button's space on every row, including the (usually
-                // more common) already-assigned rows that render only the arrow. Measuring instead means the column
-                // only claims that space when some row in the table can actually show the button.
+                // A fixed width here would reserve the Assign button's space even on rows that only render the arrow.
                 getContentToMeasure: (item) =>
                     canAnyCardBeAssigned && !item.isAssigned ? [{text: translate('workspace.companyCards.assign'), fontSize: fontScale.text, fontWeight: '700'}] : [],
-                // The Assign button and the arrow are a known, bounded pair of contents, so this column always shows
-                // them in full rather than truncating.
                 shouldFitContent: true,
-                // The button's own padding and its gap from the arrow only apply when some row can show it; otherwise
-                // the column only ever needs to fit the arrow itself.
+                // Only add the button's padding and gap when some row can actually show it.
                 extraWidth: canAnyCardBeAssigned ? styles.ph2.paddingHorizontal * 2 + styles.gap3.gap + variables.iconSizeNormal + styles.pr3.paddingRight : variables.iconSizeNormal,
             },
         },

--- a/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceCompanyCardsTable/index.tsx
@@ -13,16 +13,20 @@ import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import usePolicy from '@hooks/usePolicy';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {resetFailedWorkspaceCompanyCardUnassignment} from '@libs/actions/CompanyCards';
 import {getCompanyCardCustomName, getDefaultCardName} from '@libs/CardUtils';
+import {getConnectedIntegration} from '@libs/PolicyUtils';
 import tokenizedSearch from '@libs/tokenizedSearch';
 
+import {getCardExportAccountTitle, getPolicyCardExportSettings} from '@pages/workspace/companyCards/utils';
 import WorkspaceCompanyCardPageEmptyState from '@pages/workspace/companyCards/WorkspaceCompanyCardPageEmptyState';
 import WorkspaceCompanyCardsFeedPendingPage from '@pages/workspace/companyCards/WorkspaceCompanyCardsFeedPendingPage';
 
+import {fontScale} from '@styles/typography';
 import variables from '@styles/variables';
 
 import CONST from '@src/CONST';
@@ -41,7 +45,10 @@ import WorkspaceCompanyCardsTableControls from './WorkspaceCompanyCardsTableCont
 import WorkspaceCompanyCardsTableHeaderButtons from './WorkspaceCompanyCardsTableHeaderButtons';
 import WorkspaceCompanyCardTableItem from './WorkspaceCompanyCardsTableRow';
 
-type CompanyCardsTableColumnKey = 'member' | 'card' | 'customCardName' | 'actions';
+type CompanyCardsTableColumnKey = 'member' | 'card' | 'customCardName' | 'exportAccount' | 'actions';
+
+/** Width the member cell's avatar and the space after it take before the name and subtitle start. */
+const MEMBER_CELL_AVATAR_WIDTH = variables.avatarSizeSmall + 12;
 
 type WorkspaceCompanyCardsTableHandle = {
     clearSelection: () => void;
@@ -114,6 +121,8 @@ function WorkspaceCompanyCardsTable({
     // again rather than being suppressed forever.
     const isFeedConnectionBroken = feedName ? cardFeedErrors[feedName]?.shouldPromptBrokenConnection : false;
 
+    const policy = usePolicy(policyID);
+    const [connectionSyncProgress] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policyID}`);
     const [countryByIp] = useOnyx(ONYXKEYS.COUNTRY);
     const [customCardNames] = useOnyx(ONYXKEYS.NVP_EXPENSIFY_COMPANY_CARDS_CUSTOM_NAMES);
     const [selectedCardKeys, setSelectedCardKeys] = useState<string[]>([]);
@@ -182,28 +191,74 @@ function WorkspaceCompanyCardsTable({
     const shouldShowGBDisclaimer = isGB && (isNoFeed || hasNoAssignedCard);
     const shouldUseNarrowTableLayout = shouldUseNarrowLayout || isMediumScreenWidth;
 
-    const columns: Array<TableColumn<CompanyCardsTableColumnKey>> = [
+    // Mirrors the Accounting section's own eligibility check on the card details page, so the column follows the same
+    // rules as that section rather than introducing a second set of them.
+    const syncingAccountingIntegration = CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES.find((integration) => integration === connectionSyncProgress?.connectionName);
+    const connectedIntegration = getConnectedIntegration(policy, CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES) ?? syncingAccountingIntegration;
+    const cardExportSettings = getPolicyCardExportSettings(connectedIntegration, policyID, translate, policy);
+    const shouldShowExportAccountColumn = !!cardExportSettings?.shouldShowMenuItem;
+
+    const columns: Array<TableColumn<CompanyCardsTableColumnKey, WorkspaceCompanyCardTableItemData>> = [
         {
             key: 'member',
             label: translate('common.member'),
             sortable: true,
+            dynamicSizing: {
+                // The cell stacks the member's name above the card details or login, so whichever renders wider decides
+                // the column's width.
+                getContentToMeasure: (item) => [
+                    {
+                        text: item.isAssigned ? (item.cardholder?.displayName ?? item.cardholder?.login ?? '') : translate('workspace.moreFeatures.companyCards.unassignedCards'),
+                        fontSize: fontScale.text,
+                    },
+                    {text: item.customCardName ?? '', fontSize: fontScale.label},
+                ],
+                extraWidth: MEMBER_CELL_AVATAR_WIDTH,
+            },
         },
         {
             key: 'card',
             label: translate('workspace.companyCards.card'),
             sortable: true,
+            dynamicSizing: {
+                // Masked card numbers all render at the same length, so this column always fits them in full.
+                getContentToMeasure: (item) => [{text: item.cardName, fontSize: fontScale.text}],
+                shouldFitContent: true,
+            },
         },
         {
             key: 'customCardName',
             label: translate('workspace.companyCards.cardName'),
             sortable: true,
+            dynamicSizing: {
+                getContentToMeasure: (item) => (item.customCardName ? [{text: item.customCardName, fontSize: fontScale.text}] : []),
+            },
         },
+        ...(shouldShowExportAccountColumn
+            ? [
+                  {
+                      key: 'exportAccount' as const,
+                      label: translate('workspace.moreFeatures.companyCards.exportAccount'),
+                      sortable: true,
+                      dynamicSizing: {
+                          getContentToMeasure: (item: WorkspaceCompanyCardTableItemData) => (item.exportAccountTitle ? [{text: item.exportAccountTitle, fontSize: fontScale.text}] : []),
+                          maxWidth: CONST.TABLES.DYNAMIC_COLUMNS.MAX_EXPORT_ACCOUNT_COLUMN_WIDTH,
+                      },
+                  },
+              ]
+            : []),
         {
             key: 'actions',
             label: '',
             sortable: false,
             styling: {
                 containerStyles: [styles.justifyContentEnd, styles.pr3],
+            },
+            dynamicSizing: {
+                // Only unassigned rows render the Assign button, so that is the widest content this column ever holds.
+                getContentToMeasure: () => [{text: translate('workspace.companyCards.assign'), fontSize: fontScale.text, fontWeight: '700'}],
+                extraWidth: variables.iconSizeNormal + styles.gap3.gap,
+                shouldFitContent: true,
             },
         },
     ];
@@ -224,6 +279,8 @@ function WorkspaceCompanyCardsTable({
                       isAssigned,
                       assignedCard,
                       cardholder,
+                      // Unassigned cards have no details page and so no Accounting section to match, hence no title.
+                      exportAccountTitle: assignedCard ? getCardExportAccountTitle(cardExportSettings, assignedCard) : undefined,
                       errors: isFeedConnectionBroken || assignedCard?.pendingFields?.lastScrape ? undefined : assignedCard?.errors,
                       pendingAction: assignedCard?.pendingAction,
                       onDismissError: () => resetFailedWorkspaceCompanyCardUnassignment(domainOrWorkspaceAccountID, bankName, assignedCard?.cardID),
@@ -262,7 +319,8 @@ function WorkspaceCompanyCardsTable({
             return -1 * orderMultiplier;
         }
 
-        const cardNameSortingResult = localeCompare(a.cardName, b.cardName) * orderMultiplier;
+        const cardNameComparison = localeCompare(a.cardName, b.cardName);
+        const cardNameSortingResult = cardNameComparison * orderMultiplier;
 
         if (!a.isAssigned && !b.isAssigned) {
             return cardNameSortingResult;
@@ -281,6 +339,13 @@ function WorkspaceCompanyCardsTable({
 
         if (activeSorting.columnKey === 'customCardName') {
             return localeCompare(a.customCardName ?? '', b.customCardName ?? '') * orderMultiplier;
+        }
+
+        if (activeSorting.columnKey === 'exportAccount') {
+            const exportAccountComparison = localeCompare(a.exportAccountTitle ?? '', b.exportAccountTitle ?? '');
+
+            // Most cards share the default export account, so ties fall back to the card name for a stable order.
+            return (exportAccountComparison !== 0 ? exportAccountComparison : cardNameComparison) * orderMultiplier;
         }
 
         return 0;
@@ -359,6 +424,7 @@ function WorkspaceCompanyCardsTable({
             isAssigningCardDisabled={isAssigningCardDisabled}
             canWriteCompanyCards={canWriteCompanyCards}
             shouldUseNarrowTableLayout={shouldUseNarrowTableLayout}
+            shouldShowExportAccountColumn={shouldShowExportAccountColumn}
         />
     );
 
@@ -401,6 +467,7 @@ function WorkspaceCompanyCardsTable({
             compareItems={compareItems}
             isItemInSearch={isItemInSearch}
             isItemInFilter={isItemInFilter}
+            shouldUseDynamicColumns
             initialSortColumn="member"
             selectionEnabled={showTableControls}
             selectedKeys={validSelectedCardKeys}

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/WorkspaceExpensifyCardsTableRow.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/WorkspaceExpensifyCardsTableRow.tsx
@@ -29,9 +29,12 @@ type WorkspaceExpensifyCardsTableRowProps = {
     item: WorkspaceExpensifyCardTableRowData;
     rowIndex: number;
     shouldUseNarrowTableLayout: boolean;
+
+    /** Whether the Export account column is shown, so the row must keep its cell in step with the column */
+    shouldShowExportAccountColumn: boolean;
 };
 
-export default function WorkspaceExpensifyCardsTableRow({item, rowIndex, shouldUseNarrowTableLayout}: WorkspaceExpensifyCardsTableRowProps) {
+export default function WorkspaceExpensifyCardsTableRow({item, rowIndex, shouldUseNarrowTableLayout, shouldShowExportAccountColumn}: WorkspaceExpensifyCardsTableRowProps) {
     const icons = useMemoizedLazyExpensifyIcons(['ArrowRight', 'FreezeCard']);
     const styles = useThemeStyles();
     const {translate, formatPhoneNumber, dateFnsLocale} = useLocalize();
@@ -61,7 +64,18 @@ export default function WorkspaceExpensifyCardsTableRow({item, rowIndex, shouldU
         }
     }
 
-    const accessibilityLabel = [cardholderName, item.name, cardType, limitTypeLabel, item.lastFourPAN, statusLabel, formattedLimit, formattedRemainingLimit, frozenByText]
+    const accessibilityLabel = [
+        cardholderName,
+        item.name,
+        cardType,
+        limitTypeLabel,
+        item.lastFourPAN,
+        statusLabel,
+        item.exportAccountTitle,
+        formattedLimit,
+        formattedRemainingLimit,
+        frozenByText,
+    ]
         .filter(Boolean)
         .join(', ');
 
@@ -181,6 +195,19 @@ export default function WorkspaceExpensifyCardsTableRow({item, rowIndex, shouldU
                                 shouldShowTooltip
                                 numberOfLines={1}
                                 text={statusLabel}
+                            />
+                        </View>
+                    )}
+
+                    {!shouldUseNarrowTableLayout && shouldShowExportAccountColumn && (
+                        <View
+                            style={[styles.flex1, styles.mnw0, styles.flexRow, styles.alignItemsCenter]}
+                            {...getCellAccessibilityProps(isTableSemanticsEnabled)}
+                        >
+                            <TextWithTooltip
+                                shouldShowTooltip
+                                numberOfLines={1}
+                                text={item.exportAccountTitle ?? ''}
                             />
                         </View>
                     )}

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -7,12 +7,15 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {filterCardsByPersonalDetails, getTranslationKeyForCardStatus, getTranslationKeyForLimitType} from '@libs/CardUtils';
+import {convertToShortDisplayString} from '@libs/CurrencyUtils';
 import {getLatestErrorMessage} from '@libs/ErrorUtils';
 
 import WorkspaceCardListLabels from '@pages/workspace/expensifyCard/WorkspaceCardListLabels';
 
+import {fontScale} from '@styles/typography';
 import variables from '@styles/variables';
 
+import CONST from '@src/CONST';
 import type {Card, PersonalDetails, PersonalDetailsList} from '@src/types/onyx';
 import type {CardLimitType} from '@src/types/onyx/Card';
 import type ExpensifyCardSettings from '@src/types/onyx/ExpensifyCardSettings';
@@ -28,7 +31,10 @@ import {View} from 'react-native';
 
 import WorkspaceExpensifyCardsTableRow from './WorkspaceExpensifyCardsTableRow';
 
-type WorkspaceExpensifyCardTableColumnKey = 'name' | 'type' | 'limitType' | 'lastFour' | 'status' | 'limit' | 'remainingLimit' | 'actions';
+/** Width the member cell's avatar and the space after it take before the name and subtitle start. */
+const MEMBER_CELL_AVATAR_WIDTH = variables.avatarSizeSmall + 12;
+
+type WorkspaceExpensifyCardTableColumnKey = 'name' | 'type' | 'limitType' | 'lastFour' | 'status' | 'exportAccount' | 'limit' | 'remainingLimit' | 'actions';
 
 type WorkspaceExpensifyCardTableRowData = TableData & {
     cardID: number;
@@ -41,6 +47,7 @@ type WorkspaceExpensifyCardTableRowData = TableData & {
     currency?: string;
     isVirtual: boolean;
     limitType: CardLimitType | undefined;
+    exportAccountTitle?: string;
     frozenByDisplayName?: string;
     frozenByAccountID?: number;
     frozenDate?: string;
@@ -72,6 +79,9 @@ type WorkspaceExpensifyCardsTableProps = {
     /** Base card settings used to display labels */
     cardSettingsBase?: ExpensifyCardSettingsBase;
 
+    /** Whether the Export account column is shown, mirroring the eligibility check on the card details page */
+    shouldShowExportAccountColumn: boolean;
+
     /** Personal details used for search filtering */
     personalDetails?: PersonalDetailsList;
 
@@ -91,6 +101,7 @@ export default function WorkspaceExpensifyCardsTable({
     onRowSelectionChange,
     cardSettings,
     cardSettingsBase,
+    shouldShowExportAccountColumn,
     personalDetails,
     listFooterComponent,
     listFooterComponentStyle,
@@ -103,16 +114,25 @@ export default function WorkspaceExpensifyCardsTable({
     const shouldUseNarrowTableLayout = shouldUseNarrowLayout || isMediumScreenWidth;
     const errorMessage = getLatestErrorMessage(cardSettings) ?? '';
 
-    const columns: Array<TableColumn<WorkspaceExpensifyCardTableColumnKey>> = [
+    const columns: Array<TableColumn<WorkspaceExpensifyCardTableColumnKey, WorkspaceExpensifyCardTableRowData>> = [
         {
             key: 'name',
             label: translate('workspace.expensifyCard.name'),
             sortable: true,
             styling: {
                 // Cardholder names and card titles are the longest values in the table, so this column takes the
-                // space freed up by giving Type, Last 4 and Status fixed widths. Limit type still needs a full share
-                // to fit its longest value, so this stops at double rather than taking everything.
+                // space freed up by giving Type, Last 4 and Status fixed widths. This flex only applies to the static
+                // fallback layout, since dynamic column widths below resolve to px tracks instead.
                 flex: 2,
+            },
+            dynamicSizing: {
+                // The cell stacks the cardholder's name above the card's own title, so whichever renders wider decides
+                // the column's width.
+                getContentToMeasure: (item) => [
+                    {text: item.cardholder?.displayName ?? item.cardholder?.login ?? '', fontSize: fontScale.text},
+                    {text: item.name, fontSize: fontScale.label},
+                ],
+                extraWidth: MEMBER_CELL_AVATAR_WIDTH,
             },
         },
         {
@@ -128,10 +148,10 @@ export default function WorkspaceExpensifyCardsTable({
             key: 'limitType',
             label: translate('workspace.card.issueNewCard.limitType'),
             sortable: true,
-            styling: {
-                // minWidth: 0 lets the grid track size purely from its 1fr share instead of the cell content,
-                // so a long limit type value truncates instead of widening the column.
-                containerStyles: [styles.mnw0],
+            dynamicSizing: {
+                getContentToMeasure: (item) => [{text: translate(getTranslationKeyForLimitType(item.limitType)), fontSize: fontScale.text}],
+                // A limit type is one of a short, known set of labels, so the column always shows them in full.
+                shouldFitContent: true,
             },
         },
         {
@@ -149,12 +169,30 @@ export default function WorkspaceExpensifyCardsTable({
                 containerStyles: [styles.mnw0],
             },
         },
+        ...(shouldShowExportAccountColumn
+            ? [
+                  {
+                      key: 'exportAccount' as const,
+                      label: translate('workspace.moreFeatures.companyCards.exportAccount'),
+                      sortable: true,
+                      dynamicSizing: {
+                          getContentToMeasure: (item: WorkspaceExpensifyCardTableRowData) => (item.exportAccountTitle ? [{text: item.exportAccountTitle, fontSize: fontScale.text}] : []),
+                          maxWidth: CONST.TABLES.DYNAMIC_COLUMNS.MAX_EXPORT_ACCOUNT_COLUMN_WIDTH,
+                      },
+                  },
+              ]
+            : []),
         {
             key: 'limit',
             label: translate('workspace.expensifyCard.limit'),
             sortable: true,
             styling: {
                 containerStyles: [styles.justifyContentEnd],
+            },
+            dynamicSizing: {
+                getContentToMeasure: (item) => [{text: convertToShortDisplayString(item.limit, item.currency), fontSize: fontScale.text}],
+                // A truncated currency amount is misleading, so this column always shows it in full.
+                shouldFitContent: true,
             },
         },
         {
@@ -163,6 +201,10 @@ export default function WorkspaceExpensifyCardsTable({
             sortable: true,
             styling: {
                 containerStyles: [styles.justifyContentEnd],
+            },
+            dynamicSizing: {
+                getContentToMeasure: (item) => [{text: convertToShortDisplayString(item.remainingLimit, item.currency), fontSize: fontScale.text}],
+                shouldFitContent: true,
             },
         },
         {
@@ -208,6 +250,14 @@ export default function WorkspaceExpensifyCardsTable({
             return (item1.remainingLimit - item2.remainingLimit) * orderMultiplier;
         }
 
+        if (activeSorting.columnKey === 'exportAccount') {
+            const exportAccountComparison = localeCompare(item1.exportAccountTitle ?? '', item2.exportAccountTitle ?? '');
+
+            if (exportAccountComparison !== 0) {
+                return exportAccountComparison * orderMultiplier;
+            }
+        }
+
         const cardholderName1 = item1.cardholder?.displayName ?? item1.cardholder?.login ?? '';
         const cardholderName2 = item2.cardholder?.displayName ?? item2.cardholder?.login ?? '';
         return localeCompare(cardholderName1, cardholderName2) * orderMultiplier;
@@ -220,6 +270,7 @@ export default function WorkspaceExpensifyCardsTable({
             item={item}
             rowIndex={index}
             shouldUseNarrowTableLayout={shouldUseNarrowTableLayout}
+            shouldShowExportAccountColumn={shouldShowExportAccountColumn}
         />
     );
 
@@ -248,6 +299,7 @@ export default function WorkspaceExpensifyCardsTable({
             renderItem={renderCardItem}
             compareItems={compareItems}
             isItemInSearch={isItemInSearch}
+            shouldUseDynamicColumns
             initialSortColumn="name"
             narrowLayoutSortColumn="name"
             title={translate('workspace.common.expensifyCard')}

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -9,6 +9,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {filterCardsByPersonalDetails, getTranslationKeyForCardStatus, getTranslationKeyForLimitType} from '@libs/CardUtils';
 import {convertToShortDisplayString} from '@libs/CurrencyUtils';
 import {getLatestErrorMessage} from '@libs/ErrorUtils';
+import {temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
 
 import WorkspaceCardListLabels from '@pages/workspace/expensifyCard/WorkspaceCardListLabels';
 
@@ -108,7 +109,7 @@ export default function WorkspaceExpensifyCardsTable({
     listContentContainerStyle,
 }: WorkspaceExpensifyCardsTableProps) {
     const styles = useThemeStyles();
-    const {translate, localeCompare} = useLocalize();
+    const {translate, localeCompare, formatPhoneNumber} = useLocalize();
     const {shouldUseNarrowLayout, isMediumScreenWidth} = useResponsiveLayout();
 
     const shouldUseNarrowTableLayout = shouldUseNarrowLayout || isMediumScreenWidth;
@@ -129,7 +130,7 @@ export default function WorkspaceExpensifyCardsTable({
                 // The cell stacks the cardholder's name above the card's own title, so whichever renders wider decides
                 // the column's width.
                 getContentToMeasure: (item) => [
-                    {text: item.cardholder?.displayName ?? item.cardholder?.login ?? '', fontSize: fontScale.text},
+                    {text: temporaryGetDisplayNameOrDefault({passedPersonalDetails: item.cardholder, translate, formatPhoneNumber}), fontSize: fontScale.text},
                     {text: item.name, fontSize: fontScale.label},
                 ],
                 extraWidth: MEMBER_CELL_AVATAR_WIDTH,

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -16,7 +16,6 @@ import WorkspaceCardListLabels from '@pages/workspace/expensifyCard/WorkspaceCar
 import {fontScale} from '@styles/typography';
 import variables from '@styles/variables';
 
-import CONST from '@src/CONST';
 import type {Card, PersonalDetails, PersonalDetailsList} from '@src/types/onyx';
 import type {CardLimitType} from '@src/types/onyx/Card';
 import type ExpensifyCardSettings from '@src/types/onyx/ExpensifyCardSettings';
@@ -178,7 +177,6 @@ export default function WorkspaceExpensifyCardsTable({
                       sortable: true,
                       dynamicSizing: {
                           getContentToMeasure: (item: WorkspaceExpensifyCardTableRowData) => (item.exportAccountTitle ? [{text: item.exportAccountTitle, fontSize: fontScale.text}] : []),
-                          maxWidth: CONST.TABLES.DYNAMIC_COLUMNS.MAX_EXPORT_ACCOUNT_COLUMN_WIDTH,
                       },
                   },
               ]

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -31,7 +31,6 @@ import {View} from 'react-native';
 
 import WorkspaceExpensifyCardsTableRow from './WorkspaceExpensifyCardsTableRow';
 
-/** Width the member cell's avatar and the space after it take before the name and subtitle start. */
 const MEMBER_CELL_AVATAR_WIDTH = variables.avatarSizeSmall + 12;
 
 type WorkspaceExpensifyCardTableColumnKey = 'name' | 'type' | 'limitType' | 'lastFour' | 'status' | 'exportAccount' | 'limit' | 'remainingLimit' | 'actions';
@@ -120,8 +119,7 @@ export default function WorkspaceExpensifyCardsTable({
             label: translate('workspace.expensifyCard.name'),
             sortable: true,
             dynamicSizing: {
-                // The cell stacks the cardholder's name above the card's own title, so whichever renders wider decides
-                // the column's width.
+                // Whichever of the cardholder's name or the card's title renders wider decides the column's width.
                 getContentToMeasure: (item) => [
                     {text: temporaryGetDisplayNameOrDefault({passedPersonalDetails: item.cardholder, translate, formatPhoneNumber}), fontSize: fontScale.text},
                     {text: item.name, fontSize: fontScale.label},
@@ -137,7 +135,6 @@ export default function WorkspaceExpensifyCardsTable({
                 getContentToMeasure: (item) => [
                     {text: item.isVirtual ? translate('workspace.expensifyCard.virtual') : translate('workspace.expensifyCard.physical'), fontSize: fontScale.text},
                 ],
-                // Type is one of exactly two known labels, so the column always shows them in full.
                 shouldFitContent: true,
             },
         },
@@ -147,7 +144,6 @@ export default function WorkspaceExpensifyCardsTable({
             sortable: true,
             dynamicSizing: {
                 getContentToMeasure: (item) => [{text: translate(getTranslationKeyForLimitType(item.limitType)), fontSize: fontScale.text}],
-                // A limit type is one of a short, known set of labels, so the column always shows them in full.
                 shouldFitContent: true,
             },
         },
@@ -157,7 +153,6 @@ export default function WorkspaceExpensifyCardsTable({
             sortable: true,
             dynamicSizing: {
                 getContentToMeasure: (item) => [{text: item.lastFourPAN, fontSize: fontScale.text}],
-                // The last 4 digits are always exactly 4 characters, so the column always shows them in full.
                 shouldFitContent: true,
             },
         },
@@ -170,7 +165,6 @@ export default function WorkspaceExpensifyCardsTable({
                     const statusTranslationKey = getTranslationKeyForCardStatus(item.card.state, item.isVirtual);
                     return statusTranslationKey ? [{text: translate(statusTranslationKey), fontSize: fontScale.text}] : [];
                 },
-                // A status is one of a short, known set of labels, so the column always shows them in full.
                 shouldFitContent: true,
             },
         },
@@ -195,7 +189,6 @@ export default function WorkspaceExpensifyCardsTable({
             },
             dynamicSizing: {
                 getContentToMeasure: (item) => [{text: convertToShortDisplayString(item.limit, item.currency), fontSize: fontScale.text}],
-                // A truncated currency amount is misleading, so this column always shows it in full.
                 shouldFitContent: true,
             },
         },

--- a/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
+++ b/src/components/Tables/WorkspaceExpensifyCardsTable/index.tsx
@@ -119,12 +119,6 @@ export default function WorkspaceExpensifyCardsTable({
             key: 'name',
             label: translate('workspace.expensifyCard.name'),
             sortable: true,
-            styling: {
-                // Cardholder names and card titles are the longest values in the table, so this column takes the
-                // space freed up by giving Type, Last 4 and Status fixed widths. This flex only applies to the static
-                // fallback layout, since dynamic column widths below resolve to px tracks instead.
-                flex: 2,
-            },
             dynamicSizing: {
                 // The cell stacks the cardholder's name above the card's own title, so whichever renders wider decides
                 // the column's width.
@@ -139,9 +133,12 @@ export default function WorkspaceExpensifyCardsTable({
             key: 'type',
             label: translate('common.type'),
             sortable: true,
-            width: variables.tableTypeColumnWidth,
-            styling: {
-                containerStyles: [styles.mnw0],
+            dynamicSizing: {
+                getContentToMeasure: (item) => [
+                    {text: item.isVirtual ? translate('workspace.expensifyCard.virtual') : translate('workspace.expensifyCard.physical'), fontSize: fontScale.text},
+                ],
+                // Type is one of exactly two known labels, so the column always shows them in full.
+                shouldFitContent: true,
             },
         },
         {
@@ -158,15 +155,23 @@ export default function WorkspaceExpensifyCardsTable({
             key: 'lastFour',
             label: translate('workspace.expensifyCard.lastFour'),
             sortable: true,
-            width: variables.tableLastFourColumnWidth,
+            dynamicSizing: {
+                getContentToMeasure: (item) => [{text: item.lastFourPAN, fontSize: fontScale.text}],
+                // The last 4 digits are always exactly 4 characters, so the column always shows them in full.
+                shouldFitContent: true,
+            },
         },
         {
             key: 'status',
             label: translate('common.status'),
             sortable: true,
-            width: variables.tableCardStatusColumnWidth,
-            styling: {
-                containerStyles: [styles.mnw0],
+            dynamicSizing: {
+                getContentToMeasure: (item) => {
+                    const statusTranslationKey = getTranslationKeyForCardStatus(item.card.state, item.isVirtual);
+                    return statusTranslationKey ? [{text: translate(statusTranslationKey), fontSize: fontScale.text}] : [];
+                },
+                // A status is one of a short, known set of labels, so the column always shows them in full.
+                shouldFitContent: true,
             },
         },
         ...(shouldShowExportAccountColumn

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6519,6 +6519,7 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
                 expensifyCardBannerLearnMoreButton: 'Mehr erfahren',
                 statementCloseDateTitle: 'Abrechnungsschlussdatum',
                 statementCloseDateDescription: 'Teile uns mit, wann dein Kreditkartenkontoauszug abgeschlossen wird, und wir erstellen einen passenden Auszug in Expensify.',
+                exportAccount: 'Konto exportieren',
             },
             workflows: {
                 title: 'Workflows',

--- a/src/languages/el.ts
+++ b/src/languages/el.ts
@@ -6644,6 +6644,7 @@ _Για πιο αναλυτικές οδηγίες, [επισκεφθείτε τ
                 expensifyCardBannerLearnMoreButton: 'Μάθετε περισσότερα',
                 statementCloseDateTitle: 'Ημερομηνία λήξης κατάστασης λογαριασμού',
                 statementCloseDateDescription: 'Ενημερώστε μας πότε κλείνει το αντίγραφο κίνησης της κάρτας σας και θα δημιουργήσουμε ένα αντίστοιχο αντίγραφο κίνησης στο Expensify.',
+                exportAccount: 'Εξαγωγή λογαριασμού',
             },
             workflows: {
                 title: 'Ροές εργασιών',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6604,6 +6604,7 @@ const translations = {
                 neverUpdated: 'Never',
                 noAccountsFound: 'No accounts found',
                 defaultCard: 'Default card',
+                exportAccount: 'Export account',
                 downgradeTitle: `Can't downgrade workspace`,
                 downgradeSubTitle: `This workspace can't be downgraded because multiple card feeds are connected (excluding Expensify Cards). Please <a href="#">keep only one card feed</a> to proceed.`,
                 noAccountsFoundDescription: (connection: string) => `Please add the account in ${connection} and sync the connection again`,

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -6398,6 +6398,7 @@ ${amount} para ${merchant} - ${date}`,
                 expensifyCardBannerLearnMoreButton: 'Más información',
                 statementCloseDateTitle: 'Fecha de cierre del estado de cuenta',
                 statementCloseDateDescription: 'Indícanos cuándo cierra el estado de cuenta de tu tarjeta y crearemos uno correspondiente en Expensify.',
+                exportAccount: 'Exportar cuenta',
             },
             workflows: {
                 title: 'Flujos de trabajo',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6536,6 +6536,7 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
                 expensifyCardBannerLearnMoreButton: 'En savoir plus',
                 statementCloseDateTitle: 'Date de clôture du relevé',
                 statementCloseDateDescription: 'Indiquez-nous la date de clôture de votre relevé de carte, et nous créerons un relevé correspondant dans Expensify.',
+                exportAccount: 'Exporter le compte',
             },
             workflows: {
                 title: 'Workflows',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -6487,6 +6487,7 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
                 expensifyCardBannerLearnMoreButton: 'Scopri di più',
                 statementCloseDateTitle: 'Data di chiusura dell’estratto conto',
                 statementCloseDateDescription: 'Facci sapere quando si chiude l’estratto conto della tua carta e creeremo un estratto conto corrispondente in Expensify.',
+                exportAccount: 'Esporta conto',
             },
             workflows: {
                 title: 'Flussi di lavoro',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6399,6 +6399,7 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
                 expensifyCardBannerLearnMoreButton: '詳細はこちら',
                 statementCloseDateTitle: '取引明細書の締め日',
                 statementCloseDateDescription: 'カード明細の締め日を教えていただければ、Expensify 内に対応する明細を作成します。',
+                exportAccount: 'アカウントを書き出す',
             },
             workflows: {
                 title: 'ワークフロー',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6469,6 +6469,7 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
                 expensifyCardBannerLearnMoreButton: 'Meer informatie',
                 statementCloseDateTitle: 'Sluitingsdatum afschrift',
                 statementCloseDateDescription: 'Laat ons weten wanneer je creditcardafschrift wordt afgesloten, dan maken wij een bijpassend afschrift in Expensify aan.',
+                exportAccount: 'Account exporteren',
             },
             workflows: {
                 title: 'Workflows',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6496,6 +6496,7 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
                 expensifyCardBannerLearnMoreButton: 'Dowiedz się więcej',
                 statementCloseDateTitle: 'Data zamknięcia zestawienia',
                 statementCloseDateDescription: 'Daj nam znać, kiedy kończy się okres rozliczeniowy Twojej karty, a utworzymy w Expensify pasujące zestawienie.',
+                exportAccount: 'Eksportuj konto',
             },
             workflows: {
                 title: 'Przepływy pracy',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6473,6 +6473,7 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
                 expensifyCardBannerLearnMoreButton: 'Saiba mais',
                 statementCloseDateTitle: 'Data de fechamento do extrato',
                 statementCloseDateDescription: 'Informe quando o seu fechamento da fatura do cartão ocorrer e criaremos uma fatura correspondente no Expensify.',
+                exportAccount: 'Exportar conta',
             },
             workflows: {
                 title: 'Fluxos de trabalho',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -6240,6 +6240,7 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
                 expensifyCardBannerLearnMoreButton: '了解详情',
                 statementCloseDateTitle: '账单结算日',
                 statementCloseDateDescription: '请告诉我们您的信用卡账单结算日期，我们会在 Expensify 中创建一份相应的对账单。',
+                exportAccount: '导出账户',
             },
             workflows: {
                 title: '工作流程',

--- a/src/pages/workspace/companyCards/utils.tsx
+++ b/src/pages/workspace/companyCards/utils.tsx
@@ -618,4 +618,3 @@ function getCompanyCardDetailsBackPath(
 }
 
 export {getCardExportAccountTitle, getCompanyCardDetailsBackPath, getExportMenuItem, getPolicyCardExportSettings};
-export type {CardExportSettings};

--- a/src/pages/workspace/companyCards/utils.tsx
+++ b/src/pages/workspace/companyCards/utils.tsx
@@ -16,7 +16,8 @@ import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Card, CompanyCardFeedWithDomainID, Policy} from '@src/types/onyx';
-import type {Account, PolicyConnectionName} from '@src/types/onyx/Policy';
+import type {CardFeedWithNumber} from '@src/types/onyx/CardFeeds';
+import type {PolicyConnectionName} from '@src/types/onyx/Policy';
 
 import type {ValueOf} from 'type-fest';
 
@@ -31,55 +32,186 @@ type ExportIntegration = {
     shouldShowMenuItem?: boolean;
 };
 
-function getExportMenuItem(
+/** An export account candidate, normalized so every integration shares one resolution path. */
+type ExportAccountOption = {
+    /** Value stored in the card's export NVP, and the option's value */
+    id: string;
+
+    /** Text shown for this account */
+    label: string;
+
+    /** Option key, which QBO and QBD key by label because they stored display names before they stored ids */
+    keyForList: string;
+};
+
+/** A Rillet or DualEntry account, which the connection config can point at by GL code rather than by id. */
+type ProgramAccountOption = ExportAccountOption & {
+    /** Value the connection config stores to reference this account: the GL code for Rillet, the id for DualEntry */
+    configKey: string;
+
+    /** Whether the account is offered in the option list */
+    isSelectable: boolean;
+};
+
+/** One NVP resolved against one flat candidate list. Used by QBO, Xero, NetSuite, Sage Intacct and QBD. */
+type SingleAccountExport = {
+    type: typeof CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT;
+
+    /** The card NVP holding this integration's export account */
+    nvpKey: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES>;
+
+    accounts: ExportAccountOption[];
+
+    /** Shown when the card follows the workspace default */
+    defaultLabel: string;
+
+    /** The workspace's own export account, only reachable when the card has no NVP of its own */
+    workspaceDefaultAccountID?: string;
+
+    /** Whether a missed id match should be retried against the account labels */
+    shouldFallBackToLabelMatch?: boolean;
+};
+
+/** One NVP resolved against a program account that each card feed can override. Used by Rillet and DualEntry. */
+type ProgramAccountExport = {
+    type: typeof CONST.COMPANY_CARDS.EXPORT_RESOLVER.PROGRAM_ACCOUNT;
+
+    /** The card NVP holding this integration's export account */
+    nvpKey: typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT | typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT;
+
+    /** Every account, in connection order, because an account that is no longer offered can still be the resolved one */
+    accounts: ProgramAccountOption[];
+
+    /** Config key of the workspace wide program account */
+    workspaceProgramAccountKey?: string;
+
+    /** Program account overrides, per card feed */
+    programAccountKeysByFeed?: Record<CardFeedWithNumber, string>;
+
+    /** Prefixes the resolved title */
+    exportsToLabel: string;
+
+    /** Marks the workspace default inside the title, already lower cased */
+    defaultTitleSuffix: string;
+
+    /** Marks the workspace default in the option list */
+    defaultOptionPrefix: string;
+};
+
+/**
+ * Everything about a workspace's card export that does not depend on an individual card. Resolve this once per
+ * workspace, then resolve each card's title against it.
+ */
+type CardExportSettings = {
+    description?: string;
+    exportPageLink?: string;
+    exportType?: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES>;
+    shouldShowMenuItem?: boolean;
+    shouldHideMenuItemDescription?: boolean;
+    shouldShowMenuItemIcon?: boolean;
+
+    /** Absent when the connection's export configuration has no per card account to resolve */
+    accountSelection?: SingleAccountExport | ProgramAccountExport;
+};
+
+/** One card's resolved export account. */
+type CardExportAccountSelection = {
+    title?: string;
+
+    /** Whether the card follows the workspace default */
+    isDefaultTitle: boolean;
+
+    /** Resolved account id, which marks the selected option */
+    selectedAccountID?: string;
+
+    /** Program account for this card's feed, which marks the default option */
+    programAccountID?: string;
+};
+
+/**
+ * Puts an integration's accounts into the shared shape. QBO and QBD keyed their options by display name before ids
+ * were stored, so those two pass `shouldKeyByLabel`.
+ */
+function normalizeAccounts(accounts: Array<{id: string; name: string}> | undefined, shouldKeyByLabel = false): ExportAccountOption[] {
+    return (accounts ?? []).map(({id, name}) => ({id, label: name, keyForList: shouldKeyByLabel ? name : id}));
+}
+
+/**
+ * Builds the option list for an integration that resolves one NVP against a flat account list, with the workspace
+ * default prepended. The default entry carries the label in all three of its fields, which is what every integration
+ * did before they shared this builder.
+ */
+function buildSingleAccountOptions(accountSelection: SingleAccountExport, selection: CardExportAccountSelection): SelectorType[] {
+    const options =
+        accountSelection.accounts.length > 0
+            ? [{id: accountSelection.defaultLabel, label: accountSelection.defaultLabel, keyForList: accountSelection.defaultLabel}, ...accountSelection.accounts]
+            : [];
+
+    return options.map((option) => ({
+        value: option.id,
+        text: option.label,
+        keyForList: option.keyForList,
+        isSelected: selection.isDefaultTitle ? option.label === accountSelection.defaultLabel : option.id === selection.selectedAccountID,
+    }));
+}
+
+/**
+ * Builds the option list for an integration whose default comes from a program account. The program account's option
+ * carries an empty value, which is how these two integrations signal "follow the default" to the export account page.
+ */
+function buildProgramAccountOptions(accountSelection: ProgramAccountExport, selection: CardExportAccountSelection, styles: ThemeStyles): SelectorType[] {
+    const options = accountSelection.accounts
+        .filter((account) => account.isSelectable)
+        .map((account) => ({
+            value: selection.programAccountID === account.id ? '' : account.id,
+            text: `${selection.programAccountID === account.id ? `${accountSelection.defaultOptionPrefix} - ` : ''}${account.label}`,
+            keyForList: account.id,
+            isSelected: selection.selectedAccountID === account.id,
+        }));
+
+    return sortDefaultToTop(options, (option) => selection.programAccountID === option.keyForList, styles);
+}
+
+function buildExportAccountOptions(accountSelection: CardExportSettings['accountSelection'], selection: CardExportAccountSelection, styles: ThemeStyles): SelectorType[] {
+    if (!accountSelection) {
+        return [];
+    }
+
+    return accountSelection.type === CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT
+        ? buildSingleAccountOptions(accountSelection, selection)
+        : buildProgramAccountOptions(accountSelection, selection, styles);
+}
+
+/**
+ * Resolves everything about a workspace's card export that is the same for all of its cards. This is the expensive
+ * half of the work, so a list of cards resolves it once and then resolves each card's title against the result.
+ */
+function getPolicyCardExportSettings(
     connectionName: PolicyConnectionName | undefined,
     policyID: string,
     translate: LocaleContextProps['translate'],
-    styles: ThemeStyles,
     policy?: Policy,
-    companyCard?: Card,
     backTo?: string | undefined,
-): ExportIntegration | undefined {
+): CardExportSettings | undefined {
     const basePath = ROUTES.POLICY_ACCOUNTING.getRoute(policyID);
     const currentConnectionName = getCurrentAccountingIntegrationName(policy, translate);
     const defaultCard = translate('workspace.moreFeatures.companyCards.defaultCard');
     const defaultVendor = translate('workspace.accounting.defaultVendor');
     const defaultAccount = translate('workspace.accounting.defaultAccount');
 
-    const defaultMenuItem: Account & {value?: string} = {
-        name: defaultCard,
-        value: defaultCard,
-        id: defaultCard,
-        currency: '',
-    };
-
-    const defaultVendorMenuItem: Account & {value?: string} = {
-        name: defaultVendor,
-        value: defaultVendor,
-        id: defaultVendor,
-        currency: '',
-    };
-
-    const defaultAccountMenuItem: Account & {value?: string} = {
-        name: defaultAccount,
-        value: defaultAccount,
-        id: defaultAccount,
-        currency: '',
-    };
-
     // The default option label matches the export method: a vendor bill exports to a vendor, a journal entry/check to an account, and a card to a card.
-    const getDefaultExportLabel = (exportDestination: string | undefined): {defaultLabel: string; defaultLabelMenuItem: Account & {value?: string}} => {
+    const getDefaultExportLabel = (exportDestination: string | undefined): string => {
         switch (exportDestination) {
             case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL:
             case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL:
-                return {defaultLabel: defaultVendor, defaultLabelMenuItem: defaultVendorMenuItem};
+                return defaultVendor;
             case CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.JOURNAL_ENTRY:
             case CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.CHECK:
             case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.JOURNAL_ENTRY:
             case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.CHECK:
-                return {defaultLabel: defaultAccount, defaultLabelMenuItem: defaultAccountMenuItem};
+                return defaultAccount;
             default:
-                return {defaultLabel: defaultCard, defaultLabelMenuItem: defaultMenuItem};
+                return defaultCard;
         }
     };
 
@@ -99,81 +231,63 @@ function getExportMenuItem(
             const typeReimbursable = reimbursableExpensesExportDestination ? translate(`workspace.qbo.accounts.${reimbursableExpensesExportDestination}`) : undefined;
             const type = typeNonReimbursable ?? typeReimbursable;
             const description = currentConnectionName && type ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, type) : undefined;
-            let data: Account[];
-            let shouldShowMenuItem = nonReimbursableExpensesExportDestination !== CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL;
-            let selectedAccount: Account | undefined;
-            const defaultExportAccount = nonReimbursableExpensesAccount?.name ?? reimbursableExpensesAccount?.name;
-            let isDefaultTitle = false;
-            let exportType: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES> | undefined;
+            const exportPageLink = createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_ONLINE_EXPORT.path, backTo ?? basePath);
+            const shouldShowMenuItem = nonReimbursableExpensesExportDestination !== CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL;
+            const workspaceDefaultAccountID = nonReimbursableExpensesAccount?.name ?? reimbursableExpensesAccount?.name;
             const qboConfig = nonReimbursableExpensesExportDestination ?? reimbursableExpensesExportDestination;
+            const defaultLabel = getDefaultExportLabel(qboConfig);
+
             switch (qboConfig) {
                 case CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.JOURNAL_ENTRY:
                 case CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.CHECK:
                 case CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL:
-                case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD: {
-                    data = creditCards ?? [];
-                    isDefaultTitle =
-                        !companyCard?.nameValuePairs?.quickbooks_online_export_account ||
-                        companyCard?.nameValuePairs?.quickbooks_online_export_account === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE;
-                    selectedAccount = (creditCards ?? []).find((currentCard) => currentCard.id === (companyCard?.nameValuePairs?.quickbooks_online_export_account ?? defaultExportAccount));
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT;
-                    break;
-                }
-                case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD: {
-                    data = quickbooksOnlineBankAccounts ?? [];
-                    isDefaultTitle =
-                        !companyCard?.nameValuePairs?.quickbooks_online_export_account_debit ||
-                        companyCard?.nameValuePairs?.quickbooks_online_export_account_debit === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE;
-                    selectedAccount = (quickbooksOnlineBankAccounts ?? []).find(
-                        (bank) => bank.id === (companyCard?.nameValuePairs?.quickbooks_online_export_account_debit ?? defaultExportAccount),
-                    );
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT_DEBIT;
-                    break;
-                }
+                case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD:
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT,
+                            accounts: normalizeAccounts(creditCards, true),
+                            defaultLabel,
+                            workspaceDefaultAccountID,
+                        },
+                    };
+                case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD:
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT_DEBIT,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT_DEBIT,
+                            accounts: normalizeAccounts(quickbooksOnlineBankAccounts, true),
+                            defaultLabel,
+                            workspaceDefaultAccountID,
+                        },
+                    };
                 default:
-                    shouldShowMenuItem = false;
-                    data = [];
+                    return {description, exportPageLink, shouldShowMenuItem: false};
             }
-            const {defaultLabel, defaultLabelMenuItem} = getDefaultExportLabel(qboConfig);
-            const resultData = data.length > 0 ? [defaultLabelMenuItem, ...data] : data;
-
-            return {
-                description,
-                title: isDefaultTitle ? defaultLabel : selectedAccount?.name,
-                exportType,
-                shouldShowMenuItem,
-                exportPageLink: createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_ONLINE_EXPORT.path, backTo ?? basePath),
-                data: resultData.map((card) => ({
-                    value: card.id,
-                    text: card.name,
-                    keyForList: card.name,
-                    isSelected: isDefaultTitle ? card.name === defaultLabel : card.id === selectedAccount?.id,
-                })),
-            };
         }
         case CONST.POLICY.CONNECTIONS.NAME.XERO: {
             const type = translate('workspace.xero.bankAccount');
             const description = currentConnectionName && type ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, type) : undefined;
-            const exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT;
-            const defaultExportAccount = exportConfiguration?.nonReimbursableAccount;
-            const isDefaultTitle =
-                !companyCard?.nameValuePairs?.xero_export_bank_account || companyCard?.nameValuePairs?.xero_export_bank_account === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE;
-            const selectedAccount = (bankAccounts ?? []).find((bank) => bank.id === (companyCard?.nameValuePairs?.xero_export_bank_account ?? defaultExportAccount));
-            const resultData = (bankAccounts ?? [])?.length > 0 ? [defaultAccountMenuItem, ...(bankAccounts ?? [])] : bankAccounts;
 
             return {
                 description,
-                exportType,
                 shouldShowMenuItem: !!exportConfiguration?.nonReimbursableAccount,
-                title: isDefaultTitle ? defaultAccount : selectedAccount?.name,
-                data: (resultData ?? []).map((card) => {
-                    return {
-                        value: card.id,
-                        text: card.name,
-                        keyForList: card.id,
-                        isSelected: isDefaultTitle ? card.name === defaultAccount : selectedAccount?.id === card.id,
-                    };
-                }),
+                exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT,
+                accountSelection: {
+                    type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                    nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT,
+                    accounts: normalizeAccounts(bankAccounts),
+                    defaultLabel: defaultAccount,
+                    workspaceDefaultAccountID: exportConfiguration?.nonReimbursableAccount,
+                },
             };
         }
         case CONST.POLICY.CONNECTIONS.NAME.NETSUITE: {
@@ -184,67 +298,42 @@ function getExportMenuItem(
                 ? translate(`workspace.netsuite.exportDestination.values.${config.reimbursableExpensesExportDestination}.label`)
                 : undefined;
             const type = typeNonreimbursable ?? typeReimbursable;
-            let title: string | undefined = '';
-            let exportType: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES> | undefined;
-            let shouldShowMenuItem = true;
             const description = currentConnectionName && type ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, type) : undefined;
-            let data: SelectorType[];
-            let defaultExportAccount: string | undefined = '';
-            let isDefaultTitle = false;
-
+            const exportPageLink = createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_NETSUITE_EXPORT.path, backTo ?? basePath);
             const netSuiteConfig = config?.nonreimbursableExpensesExportDestination ?? config?.reimbursableExpensesExportDestination;
 
             switch (netSuiteConfig) {
-                case CONST.NETSUITE_EXPORT_DESTINATION.VENDOR_BILL: {
-                    const vendors = policy?.connections?.netsuite?.options.data.vendors;
-                    defaultExportAccount = config?.defaultVendor;
-                    isDefaultTitle = !companyCard?.nameValuePairs?.netsuite_export_vendor || companyCard?.nameValuePairs?.netsuite_export_vendor === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE;
-                    const selectedVendor = vendors?.find(({id}) => id === (companyCard?.nameValuePairs?.netsuite_export_vendor ?? defaultExportAccount));
-                    title = isDefaultTitle ? defaultVendor : selectedVendor?.name;
-                    const resultData = (vendors ?? []).length > 0 ? [defaultVendorMenuItem, ...(vendors ?? [])] : vendors;
-                    data = (resultData ?? []).map(({id, name}) => {
-                        return {
-                            value: id,
-                            text: name,
-                            keyForList: id,
-                            isSelected: isDefaultTitle ? name === defaultVendor : selectedVendor?.id === id,
-                        };
-                    });
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR;
-                    break;
-                }
-                case CONST.NETSUITE_EXPORT_DESTINATION.JOURNAL_ENTRY: {
-                    const payableAccounts = policy?.connections?.netsuite?.options.data.payableList;
-                    defaultExportAccount = config?.payableAcct;
-                    isDefaultTitle =
-                        !companyCard?.nameValuePairs?.netsuite_export_payable_account ||
-                        companyCard?.nameValuePairs?.netsuite_export_payable_account === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE;
-                    const selectedPayableAccount = payableAccounts?.find(({id}) => id === (companyCard?.nameValuePairs?.netsuite_export_payable_account ?? defaultExportAccount));
-                    title = isDefaultTitle ? defaultAccount : selectedPayableAccount?.name;
-                    const resultData = (payableAccounts ?? []).length > 0 ? [defaultAccountMenuItem, ...(payableAccounts ?? [])] : payableAccounts;
-                    data = (resultData ?? []).map(({id, name}) => {
-                        return {
-                            value: id,
-                            text: name,
-                            keyForList: id,
-                            isSelected: isDefaultTitle ? name === defaultAccount : selectedPayableAccount?.id === id,
-                        };
-                    });
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_ACCOUNT;
-                    break;
-                }
+                case CONST.NETSUITE_EXPORT_DESTINATION.VENDOR_BILL:
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem: true,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR,
+                            accounts: normalizeAccounts(policy?.connections?.netsuite?.options.data.vendors),
+                            defaultLabel: defaultVendor,
+                            workspaceDefaultAccountID: config?.defaultVendor,
+                        },
+                    };
+                case CONST.NETSUITE_EXPORT_DESTINATION.JOURNAL_ENTRY:
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem: true,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_ACCOUNT,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_ACCOUNT,
+                            accounts: normalizeAccounts(policy?.connections?.netsuite?.options.data.payableList),
+                            defaultLabel: defaultAccount,
+                            workspaceDefaultAccountID: config?.payableAcct,
+                        },
+                    };
                 default:
-                    shouldShowMenuItem = false;
-                    data = [];
+                    return {description, exportPageLink, shouldShowMenuItem: false};
             }
-            return {
-                description,
-                title,
-                shouldShowMenuItem,
-                exportType,
-                data,
-                exportPageLink: createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_NETSUITE_EXPORT.path, backTo ?? basePath),
-            };
         }
         case CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT: {
             const isNonReimbursable = !!exportConfig?.nonReimbursable;
@@ -253,77 +342,50 @@ function getExportMenuItem(
             const typeReimbursable = isReimbursable ? translate(`workspace.sageIntacct.reimbursableExpenses.values.${exportConfig.reimbursable}`) : undefined;
             const type = typeNonReimbursable ?? typeReimbursable;
             const description = currentConnectionName && type ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, type) : undefined;
-            let exportType: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES> | undefined;
-            let title: string | undefined = '';
-            let isDefaultTitle = false;
-
-            let shouldShowMenuItem = true;
-            let data: SelectorType[];
-
+            const exportPageLink = createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_EXPORT.path, backTo ?? basePath);
             const sageConfig = exportConfig?.nonReimbursable ?? exportConfig?.reimbursable;
 
             switch (sageConfig) {
                 case CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL:
-                case CONST.SAGE_INTACCT_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL: {
-                    const defaultExportAccount = isNonReimbursable ? getSageIntacctNonReimbursableActiveDefaultVendor(policy) : exportConfig?.reimbursableExpenseReportDefaultVendor;
-                    isDefaultTitle = !!(
-                        companyCard?.nameValuePairs?.intacct_export_vendor === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE || !companyCard?.nameValuePairs?.intacct_export_vendor
-                    );
-                    const vendors = policy?.connections?.intacct?.data?.vendors ?? [];
-                    const selectedVendorID = companyCard?.nameValuePairs?.intacct_export_vendor ?? defaultExportAccount;
-                    const selectedVendor = (vendors ?? []).find(({id}) => id === selectedVendorID);
-                    title = isDefaultTitle ? defaultVendor : selectedVendor?.value;
-                    const resultData = (vendors ?? []).length > 0 ? [defaultVendorMenuItem, ...(vendors ?? [])] : vendors;
-                    data = (resultData ?? []).map(({id, value}) => {
-                        return {
-                            value: id,
-                            text: value,
-                            keyForList: id,
-                            isSelected: isDefaultTitle ? value === defaultVendor : selectedVendor?.id === id,
-                        };
-                    });
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR;
-                    break;
-                }
+                case CONST.SAGE_INTACCT_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL:
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem: true,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR,
+                            // Sage Intacct holds a vendor's display text in `value`, so that is the label rather than `name`.
+                            accounts: (policy?.connections?.intacct?.data?.vendors ?? []).map(({id, value}) => ({id, label: value, keyForList: id})),
+                            defaultLabel: defaultVendor,
+                            workspaceDefaultAccountID: isNonReimbursable ? getSageIntacctNonReimbursableActiveDefaultVendor(policy) : exportConfig?.reimbursableExpenseReportDefaultVendor,
+                        },
+                    };
                 case CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE: {
-                    const intacctCreditCards = policy?.connections?.intacct?.data?.creditCards ?? [];
                     const activeDefaultVendor = getSageIntacctNonReimbursableActiveDefaultVendor(policy);
-
                     const defaultVendorAccount = (policy?.connections?.intacct?.data?.vendors ?? []).find((vendor) => vendor.id === activeDefaultVendor);
-                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                    const defaultExportAccount = exportConfig?.nonReimbursableAccount || defaultVendorAccount;
-                    isDefaultTitle = !!(
-                        companyCard?.nameValuePairs?.intacct_export_charge_card === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE || !companyCard?.nameValuePairs?.intacct_export_charge_card
-                    );
-                    const selectedVendorID = companyCard?.nameValuePairs?.intacct_export_charge_card ?? defaultExportAccount;
-                    const selectedCard = (intacctCreditCards ?? []).find(({id}) => id === selectedVendorID);
-                    title = isDefaultTitle ? defaultCard : selectedCard?.name;
-                    const resultData = (intacctCreditCards ?? []).length > 0 ? [defaultMenuItem, ...(intacctCreditCards ?? [])] : intacctCreditCards;
 
-                    data = (resultData ?? []).map(({id, name}) => {
-                        return {
-                            value: id,
-                            text: name,
-                            keyForList: id,
-                            isSelected: isDefaultTitle ? name === defaultCard : selectedCard?.id === id,
-                        };
-                    });
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_CHARGE_CARD;
-                    break;
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem: true,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_CHARGE_CARD,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_CHARGE_CARD,
+                            accounts: normalizeAccounts(policy?.connections?.intacct?.data?.creditCards),
+                            defaultLabel: defaultCard,
+                            // A card with no export NVP of its own is titled from `defaultLabel`, so this id is never
+                            // looked up. It is kept for parity with the other integrations.
+                            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                            workspaceDefaultAccountID: exportConfig?.nonReimbursableAccount || defaultVendorAccount?.id,
+                        },
+                    };
                 }
                 default:
-                    shouldShowMenuItem = false;
-                    data = [];
+                    return {description, exportPageLink, shouldShowMenuItem: false};
             }
-
-            return {
-                description,
-                shouldShowMenuItem,
-                exportType,
-                title,
-                exportPageLink: createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_EXPORT.path, backTo ?? ROUTES.POLICY_ACCOUNTING.getRoute(policyID)),
-                data,
-            };
         }
         case CONST.POLICY.CONNECTIONS.NAME.QBD: {
             const nonReimbursableExpenses = exportQBD?.nonReimbursable;
@@ -332,158 +394,187 @@ function getExportMenuItem(
             const typeReimbursable = reimbursableExpenses ? translate(`workspace.qbd.accounts.${reimbursableExpenses}`) : undefined;
             const type = typeNonReimbursable ?? typeReimbursable;
             const description = currentConnectionName && type ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, type) : undefined;
-            let data: Account[];
-            let shouldShowMenuItem =
+            const exportPageLink = createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_EXPORT.path, backTo ?? basePath);
+            const shouldShowMenuItem =
                 nonReimbursableExpenses !== CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CHECK &&
                 nonReimbursableExpenses !== CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL;
-            let title: string | undefined = '';
-            let selectedAccount: Account | undefined;
-            let isDefaultTitle = false;
-            let exportType: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES> | undefined;
             const qbdConfig = nonReimbursableExpenses ?? reimbursableExpenses;
-            const {defaultLabel, defaultLabelMenuItem} = getDefaultExportLabel(qbdConfig);
+
             switch (qbdConfig) {
                 case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.JOURNAL_ENTRY:
                 case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.CHECK:
                 case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL:
-                case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD: {
-                    data = creditCardAccounts ?? [];
-                    selectedAccount =
-                        (creditCardAccounts ?? []).find((account) => account.id === companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit) ??
-                        (creditCardAccounts ?? []).find((account) => account.name === companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit);
-                    isDefaultTitle =
-                        companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE ||
-                        !companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit;
-                    title = isDefaultTitle ? defaultLabel : selectedAccount?.name;
-                    exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_DESKTOP_EXPORT_ACCOUNT_CREDIT;
-                    break;
-                }
+                case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD:
+                    return {
+                        description,
+                        exportPageLink,
+                        shouldShowMenuItem,
+                        exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_DESKTOP_EXPORT_ACCOUNT_CREDIT,
+                        accountSelection: {
+                            type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT,
+                            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_DESKTOP_EXPORT_ACCOUNT_CREDIT,
+                            accounts: normalizeAccounts(creditCardAccounts, true),
+                            defaultLabel: getDefaultExportLabel(qbdConfig),
+                            // Classic saved an account id in this NVP while NewDot used to save the display name, so a
+                            // missed id match is retried against the labels.
+                            shouldFallBackToLabelMatch: true,
+                        },
+                    };
                 default:
-                    shouldShowMenuItem = false;
-                    data = [];
+                    return {description, exportPageLink, shouldShowMenuItem: false};
             }
-
-            const resultData = data.length > 0 ? [defaultLabelMenuItem, ...data] : data;
-
-            return {
-                description,
-                title,
-                exportType,
-                shouldShowMenuItem,
-                exportPageLink: createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_EXPORT.path, backTo ?? basePath),
-                data: resultData.map((card) => ({
-                    value: card.id,
-                    text: card.name,
-                    keyForList: card.name,
-                    isSelected: isDefaultTitle ? card.name === defaultLabel : card.id === selectedAccount?.id,
-                })),
-            };
         }
         case CONST.POLICY.CONNECTIONS.NAME.RILLET: {
             const rilletConfig = policy?.connections?.rillet?.config;
             const rilletData = policy?.connections?.rillet?.data;
-            const exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT;
             const exportReimbursable = rilletConfig?.export?.reimbursable ?? CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL;
             const exportNonReimbursable = rilletConfig?.export?.nonReimbursable ?? CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE;
-            const shouldShowMenuItem =
-                rilletConfig?.export?.exportToMultipleAccounts &&
-                exportReimbursable === CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL &&
-                exportNonReimbursable === CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE;
-            const creditCardAccountCode = rilletConfig?.export?.creditCardAccountCode;
-            const cardProgramsUsingCustomAccounts = rilletConfig?.export?.cardProgramAccounts;
-            const cardProgramAccountCode = (companyCard?.bank ? cardProgramsUsingCustomAccounts?.[companyCard.bank] : undefined) ?? creditCardAccountCode;
-            const cardProgramAccount = rilletData?.accounts?.find((account) => account.code === cardProgramAccountCode);
-            const isUsingCustomAccount = companyCard?.nameValuePairs && CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT in companyCard.nameValuePairs;
-            const cardAccountID =
-                (companyCard?.nameValuePairs && CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT in companyCard.nameValuePairs
-                    ? companyCard.nameValuePairs[CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT]
-                    : undefined) ?? cardProgramAccount?.id;
-            const cardAccount = rilletData?.accounts?.find((account) => account.id === cardAccountID);
-            const cardAccountDisplayName = cardAccount ? `${cardAccount.code} ${cardAccount.name}${isUsingCustomAccount ? '' : ` (${translate('common.default').toLocaleLowerCase()})`}` : '';
-            const title = `${translate('common.exportsTo')} ${cardAccountDisplayName}`;
-            const description = currentConnectionName
-                ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, translate('workspace.rillet.cardAccount.label'))
-                : undefined;
-            const filteredUnprocessedData =
-                rilletData?.accounts
-                    ?.filter(
-                        (accountItem) =>
-                            accountItem.type === CONST.RILLET_ACCOUNT_TYPE.LIABILITY &&
-                            accountItem.subtype === CONST.RILLET_ACCOUNT_SUBTYPE.CREDIT_CARD &&
-                            accountItem.status === CONST.RILLET_ACCOUNT_STATUS.ACTIVE,
-                    )
-                    .map((accountItem) => ({
-                        value: cardProgramAccount?.id === accountItem.id ? '' : accountItem.id,
-                        text: `${cardProgramAccount?.id === accountItem.id ? `${translate('common.default')} - ` : ''}${accountItem.code} ${accountItem.name}`,
-                        keyForList: accountItem.id,
-                        isSelected: cardAccountID === accountItem.id,
-                    })) ?? [];
-            const filteredData = sortDefaultToTop(filteredUnprocessedData, (accountItem) => cardProgramAccount?.id === accountItem.keyForList, styles);
 
             return {
-                title,
-                description,
-                exportType,
+                description: currentConnectionName
+                    ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, translate('workspace.rillet.cardAccount.label'))
+                    : undefined,
+                exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT,
                 shouldHideMenuItemDescription: true,
                 shouldShowMenuItemIcon: true,
-                shouldShowMenuItem,
-                data: filteredData,
+                shouldShowMenuItem:
+                    rilletConfig?.export?.exportToMultipleAccounts &&
+                    exportReimbursable === CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL &&
+                    exportNonReimbursable === CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE,
+                accountSelection: {
+                    type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.PROGRAM_ACCOUNT,
+                    nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT,
+                    accounts: (rilletData?.accounts ?? []).map((account) => ({
+                        id: account.id,
+                        label: `${account.code} ${account.name}`,
+                        keyForList: account.id,
+                        configKey: account.code,
+                        isSelectable:
+                            account.type === CONST.RILLET_ACCOUNT_TYPE.LIABILITY &&
+                            account.subtype === CONST.RILLET_ACCOUNT_SUBTYPE.CREDIT_CARD &&
+                            account.status === CONST.RILLET_ACCOUNT_STATUS.ACTIVE,
+                    })),
+                    workspaceProgramAccountKey: rilletConfig?.export?.creditCardAccountCode,
+                    programAccountKeysByFeed: rilletConfig?.export?.cardProgramAccounts,
+                    exportsToLabel: translate('common.exportsTo'),
+                    defaultTitleSuffix: translate('common.default').toLocaleLowerCase(),
+                    defaultOptionPrefix: translate('common.default'),
+                },
             };
         }
-
         case CONST.POLICY.CONNECTIONS.NAME.DUALENTRY: {
             const dualentryConfig = policy?.connections?.dualEntry?.config;
             const dualentryData = policy?.connections?.dualEntry?.data;
-            const exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT;
             const exportReimbursable = dualentryConfig?.export?.reimbursable ?? CONST.DUALENTRY_EXPORT_REIMBURSABLE.VENDOR_BILL;
             const exportNonReimbursable = dualentryConfig?.export?.nonReimbursable ?? CONST.DUALENTRY_EXPORT_NON_REIMBURSABLE.DIRECT_EXPENSE;
-            const shouldShowMenuItem =
-                dualentryConfig?.export?.exportToMultipleAccounts &&
-                exportReimbursable === CONST.DUALENTRY_EXPORT_REIMBURSABLE.VENDOR_BILL &&
-                exportNonReimbursable === CONST.DUALENTRY_EXPORT_NON_REIMBURSABLE.DIRECT_EXPENSE;
-            const creditCardAccountID = dualentryConfig?.export?.creditCardAccountID;
-            const cardProgramsUsingCustomAccounts = dualentryConfig?.export?.cardProgramAccounts;
-            const cardProgramAccountID = (companyCard?.bank ? cardProgramsUsingCustomAccounts?.[companyCard.bank] : undefined) ?? creditCardAccountID;
-            const cardProgramAccount = dualentryData?.accounts?.find((account) => account.id === cardProgramAccountID);
-            const isUsingCustomAccount = companyCard?.nameValuePairs && CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT in companyCard.nameValuePairs;
-            const cardAccountID =
-                (companyCard?.nameValuePairs && CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT in companyCard.nameValuePairs
-                    ? companyCard.nameValuePairs[CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT]
-                    : undefined) ?? cardProgramAccount?.id;
-            const cardAccount = dualentryData?.accounts?.find((account) => account.id === cardAccountID);
-            const cardAccountDisplayName = cardAccount ? `${cardAccount.id} ${cardAccount.name}${isUsingCustomAccount ? '' : ` (${translate('common.default').toLocaleLowerCase()})`}` : '';
-            const title = `${translate('common.exportsTo')} ${cardAccountDisplayName}`;
-            const description = currentConnectionName
-                ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, translate('workspace.dualEntry.cardAccount.label'))
-                : undefined;
-            const filteredUnprocessedData =
-                dualentryData?.accounts
-                    ?.filter(
-                        (accountItem) =>
-                            accountItem.isActive && (accountItem.accountType === CONST.DUALENTRY_ACCOUNT_TYPE.CREDIT_CARD || accountItem.accountType === CONST.DUALENTRY_ACCOUNT_TYPE.BANK),
-                    )
-                    .map((accountItem) => ({
-                        value: cardProgramAccount?.id === accountItem.id ? '' : accountItem.id,
-                        text: `${cardProgramAccount?.id === accountItem.id ? `${translate('common.default')} - ` : ''}${accountItem.id} ${accountItem.name}`,
-                        keyForList: accountItem.id,
-                        isSelected: cardAccountID === accountItem.id,
-                    })) ?? [];
-            const filteredData = sortDefaultToTop(filteredUnprocessedData, (accountItem) => cardProgramAccount?.id === accountItem.keyForList, styles);
 
             return {
-                title,
-                description,
-                exportType,
+                description: currentConnectionName
+                    ? translate('workspace.moreFeatures.companyCards.integrationExport', currentConnectionName, translate('workspace.dualEntry.cardAccount.label'))
+                    : undefined,
+                exportType: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT,
                 shouldHideMenuItemDescription: true,
                 shouldShowMenuItemIcon: true,
-                shouldShowMenuItem,
-                data: filteredData,
+                shouldShowMenuItem:
+                    dualentryConfig?.export?.exportToMultipleAccounts &&
+                    exportReimbursable === CONST.DUALENTRY_EXPORT_REIMBURSABLE.VENDOR_BILL &&
+                    exportNonReimbursable === CONST.DUALENTRY_EXPORT_NON_REIMBURSABLE.DIRECT_EXPENSE,
+                accountSelection: {
+                    type: CONST.COMPANY_CARDS.EXPORT_RESOLVER.PROGRAM_ACCOUNT,
+                    nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT,
+                    accounts: (dualentryData?.accounts ?? []).map((account) => ({
+                        id: account.id,
+                        label: `${account.id} ${account.name}`,
+                        keyForList: account.id,
+                        // DualEntry's config references a program account by id, where Rillet's references it by GL code.
+                        configKey: account.id,
+                        isSelectable: account.isActive && (account.accountType === CONST.DUALENTRY_ACCOUNT_TYPE.CREDIT_CARD || account.accountType === CONST.DUALENTRY_ACCOUNT_TYPE.BANK),
+                    })),
+                    workspaceProgramAccountKey: dualentryConfig?.export?.creditCardAccountID,
+                    programAccountKeysByFeed: dualentryConfig?.export?.cardProgramAccounts,
+                    exportsToLabel: translate('common.exportsTo'),
+                    defaultTitleSuffix: translate('common.default').toLocaleLowerCase(),
+                    defaultOptionPrefix: translate('common.default'),
+                },
             };
         }
-
         default:
             return undefined;
     }
+}
+
+/**
+ * Resolves one card's export account against its workspace's export settings. This is the cheap half of the work: a
+ * couple of lookups and no allocation, so a table can call it per row.
+ */
+function getCardExportAccountSelection(settings: CardExportSettings | undefined, companyCard: Card | undefined): CardExportAccountSelection {
+    const accountSelection = settings?.accountSelection;
+
+    if (!accountSelection) {
+        return {isDefaultTitle: false};
+    }
+
+    if (accountSelection.type === CONST.COMPANY_CARDS.EXPORT_RESOLVER.SINGLE_ACCOUNT) {
+        const nvpValue = companyCard?.nameValuePairs?.[accountSelection.nvpKey];
+        const isDefaultTitle = !nvpValue || nvpValue === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE;
+        const candidateID = nvpValue ?? accountSelection.workspaceDefaultAccountID;
+        const selectedAccount =
+            accountSelection.accounts.find((account) => account.id === candidateID) ??
+            (accountSelection.shouldFallBackToLabelMatch ? accountSelection.accounts.find((account) => account.label === candidateID) : undefined);
+
+        return {
+            isDefaultTitle,
+            title: isDefaultTitle ? accountSelection.defaultLabel : selectedAccount?.label,
+            selectedAccountID: selectedAccount?.id,
+        };
+    }
+
+    const programAccountKey = (companyCard?.bank ? accountSelection.programAccountKeysByFeed?.[companyCard.bank] : undefined) ?? accountSelection.workspaceProgramAccountKey;
+    const programAccount = accountSelection.accounts.find((account) => account.configKey === programAccountKey);
+    const isUsingCustomAccount = !!companyCard?.nameValuePairs && accountSelection.nvpKey in companyCard.nameValuePairs;
+    const selectedAccountID = (isUsingCustomAccount ? companyCard?.nameValuePairs?.[accountSelection.nvpKey] : undefined) ?? programAccount?.id;
+    const selectedAccount = accountSelection.accounts.find((account) => account.id === selectedAccountID);
+    const accountDisplayName = selectedAccount ? `${selectedAccount.label}${isUsingCustomAccount ? '' : ` (${accountSelection.defaultTitleSuffix})`}` : '';
+
+    return {
+        isDefaultTitle: !isUsingCustomAccount,
+        title: `${accountSelection.exportsToLabel} ${accountDisplayName}`,
+        selectedAccountID,
+        programAccountID: programAccount?.id,
+    };
+}
+
+/**
+ * The accounting export account a card is mapped to, which is the value the card details page shows in its Accounting
+ * section.
+ */
+function getCardExportAccountTitle(settings: CardExportSettings | undefined, companyCard: Card | undefined): string | undefined {
+    return getCardExportAccountSelection(settings, companyCard).title;
+}
+
+function getExportMenuItem(
+    connectionName: PolicyConnectionName | undefined,
+    policyID: string,
+    translate: LocaleContextProps['translate'],
+    styles: ThemeStyles,
+    policy?: Policy,
+    companyCard?: Card,
+    backTo?: string | undefined,
+): ExportIntegration | undefined {
+    const settings = getPolicyCardExportSettings(connectionName, policyID, translate, policy, backTo);
+
+    if (!settings) {
+        return undefined;
+    }
+
+    const {accountSelection, ...menuItem} = settings;
+    const selection = getCardExportAccountSelection(settings, companyCard);
+
+    return {
+        ...menuItem,
+        title: selection.title,
+        data: buildExportAccountOptions(accountSelection, selection, styles),
+    };
 }
 
 /**
@@ -526,4 +617,5 @@ function getCompanyCardDetailsBackPath(
     return createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_COMPANY_CARD_DETAILS.getRoute(feed, cardID), detailsBasePath);
 }
 
-export {getCompanyCardDetailsBackPath, getExportMenuItem};
+export {getCardExportAccountTitle, getCompanyCardDetailsBackPath, getExportMenuItem, getPolicyCardExportSettings};
+export type {CardExportSettings};

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
@@ -36,10 +36,12 @@ import {getExpensifyCardFeedDescription} from '@libs/ExpensifyCardFeedSelectorUt
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import {temporaryGetDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
-import {getMemberAccountIDsForWorkspace} from '@libs/PolicyUtils';
+import {getConnectedIntegration, getMemberAccountIDsForWorkspace} from '@libs/PolicyUtils';
 
 import Navigation from '@navigation/Navigation';
 import type {WorkspaceSplitNavigatorParamList} from '@navigation/types';
+
+import {getCardExportAccountTitle, getPolicyCardExportSettings} from '@pages/workspace/companyCards/utils';
 
 import variables from '@styles/variables';
 
@@ -79,6 +81,7 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
     const [domains] = useOnyx(ONYXKEYS.COLLECTION.DOMAIN);
     const [cardList] = useOnyx(ONYXKEYS.CARD_LIST);
+    const [connectionSyncProgress] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CONNECTION_SYNC_PROGRESS}${policyID}`);
     const settings = getCardSettings(cardSettings);
     const {allFeeds: allAdminExpensifyCardFeeds} = useExpensifyCardFeedsForFeedSelector(policyID);
     const shouldShowSelector = allAdminExpensifyCardFeeds.length >= 1;
@@ -104,6 +107,13 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
             }}
         />
     );
+
+    // Mirrors the Accounting section's own eligibility check on the card details page, so the column follows the same
+    // rules as that section rather than introducing a second set of them.
+    const syncingAccountingIntegration = CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES.find((integration) => integration === connectionSyncProgress?.connectionName);
+    const connectedIntegration = getConnectedIntegration(policy, CONST.POLICY.CONNECTIONS.ACCOUNTING_CONNECTION_NAMES) ?? syncingAccountingIntegration;
+    const cardExportSettings = getPolicyCardExportSettings(connectedIntegration, policyID, translate, policy);
+    const shouldShowExportAccountColumn = !!cardExportSettings?.shouldShowMenuItem;
 
     const settlementCurrency = useCurrencyForExpensifyCard({policyID, fundID});
     const shouldShowEuUkDisclaimer = isCurrencySupportedForECards(settlementCurrency);
@@ -149,6 +159,7 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
                     currency: settlementCurrency,
                     isVirtual: !!card.nameValuePairs?.isVirtual,
                     limitType: card.nameValuePairs?.limitType,
+                    exportAccountTitle: getCardExportAccountTitle(cardExportSettings, card),
                     frozenByDisplayName,
                     frozenByAccountID: card.nameValuePairs?.frozen?.byAccountID,
                     frozenDate: card.nameValuePairs?.frozen?.date,
@@ -158,7 +169,7 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
                     onClose: () => clearDeletePaymentMethodError(`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${defaultFundID}_${CONST.EXPENSIFY_CARD.BANK}`, card.cardID),
                 };
             }),
-        [allCards, defaultFundID, personalDetails, settlementCurrency, translate, formatPhoneNumber],
+        [allCards, cardExportSettings, defaultFundID, personalDetails, settlementCurrency, translate, formatPhoneNumber],
     );
 
     const bulkExportOptions: Array<DropdownOption<typeof CONST.EXPENSIFY_CARD.BULK_ACTIONS.EXPORT_CSV>> = [
@@ -359,6 +370,7 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
                         onRowSelectionChange={setSelectedCardKeys}
                         cardSettings={cardSettings}
                         cardSettingsBase={settings}
+                        shouldShowExportAccountColumn={shouldShowExportAccountColumn}
                         personalDetails={personalDetails}
                         listFooterComponent={disclaimerFooter}
                         listFooterComponentStyle={[styles.flexGrow1, styles.justifyContentEnd]}

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -153,6 +153,7 @@ export default {
     domainTableActionColumnWidth: 64,
     domainAdminsTableActionColumnWidth: 140,
     agentsTableActionColumnWidth: 260,
+    companyCardsTableActionColumnWidth: 140,
     workspaceTableActionColumnWidth: 64,
     workspaceMembersRoleColumnWidth: 148,
     sectionMenuItemHeight: 52,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -153,7 +153,6 @@ export default {
     domainTableActionColumnWidth: 64,
     domainAdminsTableActionColumnWidth: 140,
     agentsTableActionColumnWidth: 260,
-    companyCardsTableActionColumnWidth: 140,
     workspaceTableActionColumnWidth: 64,
     workspaceMembersRoleColumnWidth: 148,
     sectionMenuItemHeight: 52,

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -147,8 +147,6 @@ export default {
     tableRequireFieldsTypeColumnWidth: 112,
     tableSwitchColumnWidth: 58,
     tableCaretColumnWidth: 20,
-    tableLastFourColumnWidth: 72,
-    tableCardStatusColumnWidth: 128,
     workspaceTagsTableCountColumnWidth: 100,
     domainTableActionColumnWidth: 64,
     domainAdminsTableActionColumnWidth: 140,

--- a/tests/ui/WorkspaceCompanyCardsExportAccountColumnTest.tsx
+++ b/tests/ui/WorkspaceCompanyCardsExportAccountColumnTest.tsx
@@ -80,10 +80,16 @@ jest.mock('@components/Table', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const {View} = require('react-native');
 
-    function MockTable({children, columns, data, compareItems}: MockTableProps) {
+    // Kept outside MockTable, which the React Compiler treats as a component: capturing render props into a module
+    // variable is only for this test's assertions and would otherwise look like an impure component body.
+    function captureTableProps(columns: MockTableProps['columns'], data: MockTableProps['data'], compareItems: MockTableProps['compareItems']) {
         capturedColumns = columns;
         capturedData = data;
         capturedCompareItems = compareItems;
+    }
+
+    function MockTable({children, columns, data, compareItems}: MockTableProps) {
+        captureTableProps(columns, data, compareItems);
         return <View testID="WorkspaceCompanyCardsTable">{children}</View>;
     }
 

--- a/tests/ui/WorkspaceCompanyCardsExportAccountColumnTest.tsx
+++ b/tests/ui/WorkspaceCompanyCardsExportAccountColumnTest.tsx
@@ -14,6 +14,8 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {Card} from '@src/types/onyx';
 import type {CompanyCardFeedWithDomainID, CompanyCardFeedWithNumber} from '@src/types/onyx/CardFeeds';
 
+import type {PartialDeep} from 'type-fest';
+
 import React from 'react';
 import Onyx from 'react-native-onyx';
 
@@ -120,7 +122,7 @@ jest.mock('@components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTa
     return () => <View testID="WorkspaceCompanyCardsTableHeaderButtons" />;
 });
 
-function buildAssignedCard(overrides?: Partial<Card>): Card {
+function buildAssignedCard(overrides?: PartialDeep<Card, {recurseIntoArrays: true}>): Card {
     return createMock<Card>({
         cardID: 555,
         accountID: ACCOUNT_ID,

--- a/tests/ui/WorkspaceCompanyCardsExportAccountColumnTest.tsx
+++ b/tests/ui/WorkspaceCompanyCardsExportAccountColumnTest.tsx
@@ -1,0 +1,308 @@
+import {render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import type {CompareItemsCallback, TableColumn} from '@components/Table';
+import WorkspaceCompanyCardsTable from '@components/Tables/WorkspaceCompanyCardsTable';
+import type {WorkspaceCompanyCardTableItemData} from '@components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableRow';
+
+import type {UseCompanyCardsResult} from '@hooks/useCompanyCards';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Card} from '@src/types/onyx';
+import type {CompanyCardFeedWithDomainID, CompanyCardFeedWithNumber} from '@src/types/onyx/CardFeeds';
+
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import createMock from '../utils/createMock';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+TestHelper.setupApp();
+
+const POLICY_ID = 'policy123';
+const DOMAIN_OR_WORKSPACE_ACCOUNT_ID = 11111111;
+const FEED_NAME = `${CONST.COMPANY_CARD.FEED_BANK_NAME.CHASE}#${DOMAIN_OR_WORKSPACE_ACCOUNT_ID}` as CompanyCardFeedWithDomainID;
+const BANK_NAME = CONST.COMPANY_CARD.FEED_BANK_NAME.CHASE as CompanyCardFeedWithNumber;
+const ACCOUNT_ID = 1;
+const QBO_EXPORT_ACCOUNT_NVP = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT;
+
+let capturedColumns: Array<TableColumn<string, WorkspaceCompanyCardTableItemData>> = [];
+let capturedData: WorkspaceCompanyCardTableItemData[] = [];
+let capturedCompareItems: CompareItemsCallback<WorkspaceCompanyCardTableItemData, string> | undefined;
+
+jest.mock('@hooks/useLazyAsset', () => ({
+    useMemoizedLazyIllustrations: () => ({}),
+    useMemoizedLazyExpensifyIcons: () => ({}),
+}));
+
+jest.mock('@hooks/useCardFeedErrors', () => ({
+    __esModule: true,
+    default: () => ({cardFeedErrors: {}}),
+}));
+
+jest.mock('@hooks/useNetwork', () => ({
+    __esModule: true,
+    default: () => ({isOffline: false}),
+}));
+
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: () => ({shouldUseNarrowLayout: false, isMediumScreenWidth: false}),
+}));
+
+jest.mock('@components/ActivityIndicator', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+    return () => <View testID="WorkspaceCompanyCardsTableLoadingIndicator" />;
+});
+
+jest.mock('@pages/workspace/companyCards/WorkspaceCompanyCardPageEmptyState', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+    return () => <View testID="WorkspaceCompanyCardPageEmptyState" />;
+});
+
+type MockTableProps = {
+    children?: React.ReactNode;
+    columns: Array<TableColumn<string, WorkspaceCompanyCardTableItemData>>;
+    data: WorkspaceCompanyCardTableItemData[];
+    compareItems: CompareItemsCallback<WorkspaceCompanyCardTableItemData, string>;
+};
+
+// The real Table drives a FlashList and its own text measurement, neither of which this test needs: it only checks
+// what WorkspaceCompanyCardsTable computes and hands to Table, so the mock captures those props instead of rendering
+// the grid.
+jest.mock('@components/Table', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+
+    function MockTable({children, columns, data, compareItems}: MockTableProps) {
+        capturedColumns = columns;
+        capturedData = data;
+        capturedCompareItems = compareItems;
+        return <View testID="WorkspaceCompanyCardsTable">{children}</View>;
+    }
+
+    MockTable.FilterBar = () => <View testID="WorkspaceCompanyCardsTableFilterBar" />;
+    MockTable.Header = () => <View testID="WorkspaceCompanyCardsTableHeader" />;
+    MockTable.ListHeader = ({children}: {children?: React.ReactNode}) => children ?? null;
+    MockTable.Body = () => <View testID="WorkspaceCompanyCardsTableBody" />;
+    MockTable.EmptyState = () => <View testID="WorkspaceCompanyCardsTableEmptyState" />;
+    MockTable.NoResultsState = () => <View testID="WorkspaceCompanyCardsTableNoResultsState" />;
+    MockTable.LoadingState = () => <View testID="WorkspaceCompanyCardsTableLoadingIndicator" />;
+    return {
+        __esModule: true,
+        default: MockTable,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        composeTableListHeader: jest.requireActual('@components/Table/composeTableListHeader').default,
+    };
+});
+
+jest.mock('@components/CardFeedIcon', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+    return () => <View testID="CardFeedIcon" />;
+});
+
+jest.mock('@components/Tables/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+    return () => <View testID="WorkspaceCompanyCardsTableHeaderButtons" />;
+});
+
+function buildAssignedCard(overrides?: Partial<Card>): Card {
+    return createMock<Card>({
+        cardID: 555,
+        accountID: ACCOUNT_ID,
+        bank: BANK_NAME,
+        state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+        domainName: 'test.exfy',
+        fraud: 'none',
+        lastUpdated: '',
+        nameValuePairs: {},
+        ...overrides,
+    });
+}
+
+function buildCompanyCards(assignedCard?: Card): UseCompanyCardsResult {
+    return createMock<UseCompanyCardsResult>({
+        feedName: FEED_NAME,
+        bankName: BANK_NAME,
+        assignedCards: assignedCard ? {[assignedCard.cardID]: assignedCard} : {},
+        companyCardEntries: [
+            {
+                cardName: '4321',
+                encryptedCardNumber: 'enc-4321',
+                isAssigned: !!assignedCard,
+                assignedCard,
+            },
+        ],
+        workspaceCardFeedsStatus: {[DOMAIN_OR_WORKSPACE_ACCOUNT_ID]: {isLoading: false}},
+        selectedFeed: {feed: BANK_NAME, status: {}},
+        isInitiallyLoadingFeeds: false,
+        isNoFeed: false,
+        isFeedPending: false,
+        isFeedAdded: true,
+        onyxMetadata: {
+            cardListMetadata: {status: 'loaded'},
+            allCardFeedsMetadata: {status: 'loaded'},
+            lastSelectedFeedMetadata: {status: 'loaded'},
+        },
+    });
+}
+
+function renderTable(companyCards: UseCompanyCardsResult) {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+            <WorkspaceCompanyCardsTable
+                policyID={POLICY_ID}
+                isPolicyLoaded
+                isPageFetchPending={false}
+                domainOrWorkspaceAccountID={DOMAIN_OR_WORKSPACE_ACCOUNT_ID}
+                companyCards={companyCards}
+                onAssignCard={jest.fn()}
+                isAssigningCardDisabled={false}
+                canWriteCompanyCards
+                isSelectionModeEnabled={false}
+                onReloadPage={jest.fn()}
+                onReloadFeed={jest.fn()}
+            />
+        </ComposeProviders>,
+    );
+}
+
+async function setQBOPolicy(nvpExportAccount?: string) {
+    await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, {
+        id: POLICY_ID,
+        connections: {
+            quickbooksOnline: {
+                config: {
+                    nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD,
+                },
+                data: {
+                    creditCards: [{id: 'qbo-cc-1', name: 'Amex Corporate', currency: 'USD'}],
+                },
+            },
+        },
+    });
+    await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+        [ACCOUNT_ID]: {accountID: ACCOUNT_ID, displayName: 'Alice Smith', login: 'alice@example.com'},
+    });
+
+    return buildAssignedCard({nameValuePairs: nvpExportAccount === undefined ? {} : {[QBO_EXPORT_ACCOUNT_NVP]: nvpExportAccount}});
+}
+
+describe('WorkspaceCompanyCardsTable Export account column', () => {
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('shows the column and the resolved title when the connection is eligible', async () => {
+        const card = await setQBOPolicy('qbo-cc-1');
+        renderTable(buildCompanyCards(card));
+        await waitForBatchedUpdates();
+
+        expect(screen.getByTestId('WorkspaceCompanyCardsTable')).toBeTruthy();
+        expect(capturedColumns.map((column) => column.key)).toContain('exportAccount');
+        expect(capturedData.at(0)?.exportAccountTitle).toBe('Amex Corporate');
+    });
+
+    it('hides the column when the details page would hide the Accounting section too', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, {
+            id: POLICY_ID,
+            connections: {
+                quickbooksOnline: {
+                    config: {nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL},
+                    data: {creditCards: []},
+                },
+            },
+        });
+        renderTable(buildCompanyCards(buildAssignedCard()));
+        await waitForBatchedUpdates();
+
+        expect(capturedColumns.map((column) => column.key)).not.toContain('exportAccount');
+    });
+
+    it('hides the column when no accounting connection exists', async () => {
+        renderTable(buildCompanyCards(buildAssignedCard()));
+        await waitForBatchedUpdates();
+
+        expect(capturedColumns.map((column) => column.key)).not.toContain('exportAccount');
+    });
+
+    it('shows the default label when the card has no export NVP', async () => {
+        const card = await setQBOPolicy(undefined);
+        renderTable(buildCompanyCards(card));
+        await waitForBatchedUpdates();
+
+        expect(capturedData.at(0)?.exportAccountTitle).toBe(TestHelper.translateLocal('workspace.moreFeatures.companyCards.defaultCard'));
+    });
+
+    it('renders an empty export cell for an unassigned card without crashing', async () => {
+        await setQBOPolicy('qbo-cc-1');
+        renderTable(buildCompanyCards(undefined));
+        await waitForBatchedUpdates();
+
+        expect(capturedData.at(0)?.isAssigned).toBe(false);
+        expect(capturedData.at(0)?.exportAccountTitle).toBeUndefined();
+    });
+
+    it('sorts by export account title, falling back to the card name on ties', async () => {
+        await setQBOPolicy('qbo-cc-1');
+        const cardA = buildAssignedCard({cardID: 1, nameValuePairs: {[QBO_EXPORT_ACCOUNT_NVP]: 'qbo-cc-1'}});
+        const cardB = buildAssignedCard({cardID: 2, nameValuePairs: {[QBO_EXPORT_ACCOUNT_NVP]: CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE}});
+        renderTable(buildCompanyCards(cardA));
+        await waitForBatchedUpdates();
+
+        expect(capturedCompareItems).toBeDefined();
+
+        const rowA = createMock<WorkspaceCompanyCardTableItemData>({
+            keyForList: 'a',
+            cardName: '1111',
+            isAssigned: true,
+            isCardDeleted: false,
+            assignedCard: cardA,
+            exportAccountTitle: 'Amex Corporate',
+        });
+        const rowB = createMock<WorkspaceCompanyCardTableItemData>({
+            keyForList: 'b',
+            cardName: '2222',
+            isAssigned: true,
+            isCardDeleted: false,
+            assignedCard: cardB,
+            exportAccountTitle: TestHelper.translateLocal('workspace.moreFeatures.companyCards.defaultCard'),
+        });
+
+        const ascending = capturedCompareItems?.(rowA, rowB, {columnKey: 'exportAccount', order: CONST.SEARCH.SORT_ORDER.ASC});
+        expect(ascending).toBeLessThan(0);
+
+        const descending = capturedCompareItems?.(rowA, rowB, {columnKey: 'exportAccount', order: CONST.SEARCH.SORT_ORDER.DESC});
+        expect(descending).toBeGreaterThan(0);
+
+        // Two rows sharing the default export account fall back to the card name for a stable order.
+        const rowC = createMock<WorkspaceCompanyCardTableItemData>({...rowB, keyForList: 'c', cardName: '0000'});
+        const tieBreak = capturedCompareItems?.(rowB, rowC, {columnKey: 'exportAccount', order: CONST.SEARCH.SORT_ORDER.ASC});
+        expect(tieBreak).toBeGreaterThan(0);
+    });
+
+    it('keeps rendering when the export column disappears mid-session', async () => {
+        const card = await setQBOPolicy('qbo-cc-1');
+        renderTable(buildCompanyCards(card));
+        await waitForBatchedUpdates();
+
+        expect(capturedColumns.map((column) => column.key)).toContain('exportAccount');
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, {
+            connections: {quickbooksOnline: {config: {nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL}}},
+        });
+        await waitForBatchedUpdates();
+
+        expect(capturedColumns.map((column) => column.key)).not.toContain('exportAccount');
+        expect(screen.getByTestId('WorkspaceCompanyCardsTable')).toBeTruthy();
+    });
+});

--- a/tests/ui/WorkspaceExpensifyCardsExportAccountColumnTest.tsx
+++ b/tests/ui/WorkspaceExpensifyCardsExportAccountColumnTest.tsx
@@ -44,9 +44,15 @@ jest.mock('@components/Table', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const {View} = require('react-native');
 
-    function MockTable({children, columns, compareItems}: MockTableProps) {
+    // Kept outside MockTable, which the React Compiler treats as a component: capturing render props into a module
+    // variable is only for this test's assertions and would otherwise look like an impure component body.
+    function captureTableProps(columns: MockTableProps['columns'], compareItems: MockTableProps['compareItems']) {
         capturedColumns = columns;
         capturedCompareItems = compareItems;
+    }
+
+    function MockTable({children, columns, compareItems}: MockTableProps) {
+        captureTableProps(columns, compareItems);
         return <View testID="WorkspaceExpensifyCardsTable">{children}</View>;
     }
 

--- a/tests/ui/WorkspaceExpensifyCardsExportAccountColumnTest.tsx
+++ b/tests/ui/WorkspaceExpensifyCardsExportAccountColumnTest.tsx
@@ -1,0 +1,161 @@
+import {render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import type {CompareItemsCallback, TableColumn} from '@components/Table';
+import type {WorkspaceExpensifyCardTableRowData} from '@components/Tables/WorkspaceExpensifyCardsTable';
+import WorkspaceExpensifyCardsTable from '@components/Tables/WorkspaceExpensifyCardsTable';
+
+import CONST from '@src/CONST';
+import type {Card} from '@src/types/onyx';
+
+import React from 'react';
+import Onyx from 'react-native-onyx';
+
+import createMock from '../utils/createMock';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+TestHelper.setupApp();
+
+let capturedColumns: Array<TableColumn<string, WorkspaceExpensifyCardTableRowData>> = [];
+let capturedCompareItems: CompareItemsCallback<WorkspaceExpensifyCardTableRowData, string> | undefined;
+
+jest.mock('@hooks/useLazyAsset', () => ({
+    useMemoizedLazyExpensifyIcons: () => ({}),
+}));
+
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: () => ({shouldUseNarrowLayout: false, isMediumScreenWidth: false}),
+}));
+
+type MockTableProps = {
+    children?: React.ReactNode;
+    columns: Array<TableColumn<string, WorkspaceExpensifyCardTableRowData>>;
+    compareItems: CompareItemsCallback<WorkspaceExpensifyCardTableRowData, string>;
+};
+
+// The real Table drives a FlashList and its own text measurement, neither of which this test needs: it only checks
+// the columns and comparator WorkspaceExpensifyCardsTable computes, so the mock captures those props instead of
+// rendering the grid.
+jest.mock('@components/Table', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+
+    function MockTable({children, columns, compareItems}: MockTableProps) {
+        capturedColumns = columns;
+        capturedCompareItems = compareItems;
+        return <View testID="WorkspaceExpensifyCardsTable">{children}</View>;
+    }
+
+    MockTable.FilterBar = () => <View testID="WorkspaceExpensifyCardsTableFilterBar" />;
+    MockTable.Header = () => <View testID="WorkspaceExpensifyCardsTableHeader" />;
+    MockTable.ListHeader = ({children}: {children?: React.ReactNode}) => children ?? null;
+    MockTable.Body = () => <View testID="WorkspaceExpensifyCardsTableBody" />;
+    MockTable.NoResultsState = () => <View testID="WorkspaceExpensifyCardsTableNoResultsState" />;
+    return {
+        __esModule: true,
+        default: MockTable,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        composeTableListHeader: jest.requireActual('@components/Table/composeTableListHeader').default,
+    };
+});
+
+jest.mock('@pages/workspace/expensifyCard/WorkspaceCardListLabels', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const {View} = require('react-native');
+    return () => <View testID="WorkspaceCardListLabels" />;
+});
+
+function buildCard(overrides?: Partial<Card>): Card {
+    return createMock<Card>({
+        cardID: 999,
+        accountID: 1,
+        bank: CONST.EXPENSIFY_CARD.BANK,
+        state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+        domainName: 'test.exfy',
+        fraud: 'none',
+        lastUpdated: '',
+        availableSpend: 10000,
+        nameValuePairs: {cardTitle: 'Ops card', unapprovedExpenseLimit: 100000, limitType: CONST.EXPENSIFY_CARD.LIMIT_TYPES.MONTHLY},
+        ...overrides,
+    });
+}
+
+function buildRow(overrides?: Partial<WorkspaceExpensifyCardTableRowData>): WorkspaceExpensifyCardTableRowData {
+    const card = overrides?.card ?? buildCard();
+
+    return createMock<WorkspaceExpensifyCardTableRowData>({
+        keyForList: String(card.cardID),
+        cardID: card.cardID,
+        card,
+        lastFourPAN: '1234',
+        name: card.nameValuePairs?.cardTitle ?? '',
+        cardholder: {accountID: 1, displayName: 'Alice Smith', login: 'alice@example.com'},
+        limit: card.nameValuePairs?.unapprovedExpenseLimit ?? 0,
+        remainingLimit: card.availableSpend ?? 0,
+        currency: 'USD',
+        isVirtual: false,
+        limitType: card.nameValuePairs?.limitType,
+        action: jest.fn(),
+        onClose: jest.fn(),
+        ...overrides,
+    });
+}
+
+function renderTable(cards: WorkspaceExpensifyCardTableRowData[], shouldShowExportAccountColumn: boolean) {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+            <WorkspaceExpensifyCardsTable
+                policyID="policy123"
+                cards={cards}
+                selectionEnabled={false}
+                selectedKeys={[]}
+                onRowSelectionChange={jest.fn()}
+                shouldShowExportAccountColumn={shouldShowExportAccountColumn}
+            />
+        </ComposeProviders>,
+    );
+}
+
+describe('WorkspaceExpensifyCardsTable Export account column', () => {
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('shows the column when the caller says the connection is eligible', async () => {
+        renderTable([buildRow({exportAccountTitle: 'Amex Corporate'})], true);
+        await waitForBatchedUpdates();
+
+        expect(screen.getByTestId('WorkspaceExpensifyCardsTable')).toBeTruthy();
+        expect(capturedColumns.map((column) => column.key)).toContain('exportAccount');
+    });
+
+    it('hides the column when the caller says the connection is not eligible', async () => {
+        renderTable([buildRow()], false);
+        await waitForBatchedUpdates();
+
+        expect(capturedColumns.map((column) => column.key)).not.toContain('exportAccount');
+    });
+
+    it('sorts by export account title, falling back to the cardholder name on ties', async () => {
+        renderTable([buildRow()], true);
+        await waitForBatchedUpdates();
+
+        expect(capturedCompareItems).toBeDefined();
+
+        const rowA = buildRow({cardID: 1, cardholder: {accountID: 1, displayName: 'Zed', login: 'zed@example.com'}, exportAccountTitle: 'Amex Corporate'});
+        const rowB = buildRow({cardID: 2, cardholder: {accountID: 2, displayName: 'Ann', login: 'ann@example.com'}, exportAccountTitle: 'Default card'});
+
+        const ascending = capturedCompareItems?.(rowA, rowB, {columnKey: 'exportAccount', order: CONST.SEARCH.SORT_ORDER.ASC});
+        expect(ascending).toBeLessThan(0);
+
+        // Ties on export account title fall through to the cardholder name comparison.
+        const rowC = buildRow({cardID: 3, cardholder: {accountID: 3, displayName: 'Ann', login: 'ann2@example.com'}, exportAccountTitle: 'Amex Corporate'});
+        const tieBreak = capturedCompareItems?.(rowA, rowC, {columnKey: 'exportAccount', order: CONST.SEARCH.SORT_ORDER.ASC});
+        expect(tieBreak).toBeGreaterThan(0);
+    });
+});

--- a/tests/unit/CompanyCardExportTest.ts
+++ b/tests/unit/CompanyCardExportTest.ts
@@ -10,8 +10,11 @@ import CONST from '@src/CONST';
 import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type {Card, CompanyCardFeedWithDomainID, Policy} from '@src/types/onyx';
+import type {QBONonReimbursableExportAccountType, QBOReimbursableExportAccountType} from '@src/types/onyx/Policy';
 
-import {getCompanyCardDetailsBackPath, getExportMenuItem} from '../../src/pages/workspace/companyCards/utils';
+import type {PartialDeep, ValueOf} from 'type-fest';
+
+import {getCardExportAccountTitle, getCompanyCardDetailsBackPath, getExportMenuItem, getPolicyCardExportSettings} from '../../src/pages/workspace/companyCards/utils';
 import createMock from '../utils/createMock';
 import {translateLocal} from '../utils/TestHelper';
 
@@ -94,10 +97,11 @@ function createCard(nvpExportAccount?: string): Card {
     });
 }
 
-describe('getExportMenuItem - QBD credit card account resolution', () => {
-    const translate: LocaleContextProps['translate'] = translateLocal;
-    const themeStyles = createMock<ThemeStyles>({});
+const translate: LocaleContextProps['translate'] = translateLocal;
+const themeStyles = createMock<ThemeStyles>({});
+const basePath = ROUTES.POLICY_ACCOUNTING.getRoute(MOCK_POLICY_ID);
 
+describe('getExportMenuItem - QBD credit card account resolution', () => {
     it('resolves account by ID when NVP contains a QBD ListID (Classic-saved)', () => {
         const policy = createQBDPolicy();
         const card = createCard('80000103-1746639410');
@@ -183,6 +187,666 @@ describe('getExportMenuItem - QBD credit card account resolution', () => {
             const matchingAccount = QBD_CREDIT_CARD_ACCOUNTS.find((account) => account.id === option.value);
             expect(matchingAccount).toBeDefined();
         }
+    });
+});
+
+const QBO_CREDIT_CARDS = [
+    {id: 'qbo-cc-1', name: 'Amex Corporate', currency: 'USD'},
+    {id: 'qbo-cc-2', name: 'Visa Platinum', currency: 'USD'},
+];
+
+const QBO_BANK_ACCOUNTS = [
+    {id: 'qbo-bank-1', name: 'Checking 1234', currency: 'USD'},
+    {id: 'qbo-bank-2', name: 'Savings 5678', currency: 'USD'},
+];
+
+const XERO_BANK_ACCOUNTS = [
+    {id: 'xero-bank-1', name: 'Business Account', currency: 'USD'},
+    {id: 'xero-bank-2', name: 'Petty Cash', currency: 'USD'},
+];
+
+const NETSUITE_VENDORS = [
+    {id: 'ns-vendor-1', name: 'Acme Supplies'},
+    {id: 'ns-vendor-2', name: 'Globex Rentals'},
+];
+
+const NETSUITE_PAYABLE_ACCOUNTS = [
+    {id: 'ns-payable-1', name: 'Accounts Payable'},
+    {id: 'ns-payable-2', name: 'Corporate Card Payable'},
+];
+
+const INTACCT_VENDORS = [
+    {id: 'intacct-vendor-1', name: 'intacct-vendor-1', value: 'Acme Vendor'},
+    {id: 'intacct-vendor-2', name: 'intacct-vendor-2', value: 'Umbrella Vendor'},
+];
+
+const INTACCT_CREDIT_CARDS = [
+    {id: 'intacct-card-1', name: 'Intacct Amex'},
+    {id: 'intacct-card-2', name: 'Intacct Visa'},
+];
+
+const RILLET_ACCOUNTS = [
+    {
+        id: 'rillet-1',
+        code: '2100',
+        name: 'Amex Payable',
+        type: CONST.RILLET_ACCOUNT_TYPE.LIABILITY,
+        subtype: CONST.RILLET_ACCOUNT_SUBTYPE.CREDIT_CARD,
+        status: CONST.RILLET_ACCOUNT_STATUS.ACTIVE,
+    },
+    {
+        id: 'rillet-2',
+        code: '2200',
+        name: 'Visa Payable',
+        type: CONST.RILLET_ACCOUNT_TYPE.LIABILITY,
+        subtype: CONST.RILLET_ACCOUNT_SUBTYPE.CREDIT_CARD,
+        status: CONST.RILLET_ACCOUNT_STATUS.ACTIVE,
+    },
+    {
+        id: 'rillet-3',
+        code: '2300',
+        name: 'Retired Card',
+        type: CONST.RILLET_ACCOUNT_TYPE.LIABILITY,
+        subtype: CONST.RILLET_ACCOUNT_SUBTYPE.CREDIT_CARD,
+        status: CONST.RILLET_ACCOUNT_STATUS.INACTIVE,
+    },
+    {
+        id: 'rillet-4',
+        code: '6000',
+        name: 'Office Expense',
+        type: CONST.RILLET_ACCOUNT_TYPE.EXPENSE,
+        subtype: 'Office',
+        status: CONST.RILLET_ACCOUNT_STATUS.ACTIVE,
+    },
+];
+
+const DUALENTRY_ACCOUNTS = [
+    {id: 'de-1', number: '2100', name: 'Amex Payable', accountType: CONST.DUALENTRY_ACCOUNT_TYPE.CREDIT_CARD, isActive: true},
+    {id: 'de-2', number: '2200', name: 'Visa Payable', accountType: CONST.DUALENTRY_ACCOUNT_TYPE.CREDIT_CARD, isActive: true},
+    {id: 'de-3', number: '2300', name: 'Retired Card', accountType: CONST.DUALENTRY_ACCOUNT_TYPE.CREDIT_CARD, isActive: false},
+    {id: 'de-4', number: '6000', name: 'Office Expense', accountType: CONST.DUALENTRY_ACCOUNT_TYPE.EXPENSE, isActive: true},
+];
+
+function createBasePolicy(connections: PartialDeep<Policy['connections'], {recurseIntoArrays: true}>): Policy {
+    return createMock<Policy>({
+        id: MOCK_POLICY_ID,
+        name: 'Test Policy',
+        type: CONST.POLICY.TYPE.TEAM,
+        role: CONST.POLICY.ROLE.ADMIN,
+        owner: 'test@export.com',
+        ownerAccountID: 1,
+        outputCurrency: 'USD',
+        connections,
+    });
+}
+
+/**
+ * Builds a card carrying a single export NVP, so one helper covers every integration's NVP key. Passing `undefined`
+ * leaves the NVP off entirely, which is what an unconfigured card looks like.
+ */
+function createCardWithExportNVP(nvpKey: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES>, nvpValue?: string, bank?: Card['bank']): Card {
+    const nameValuePairs: Partial<NonNullable<Card['nameValuePairs']>> = {};
+    if (nvpValue !== undefined) {
+        nameValuePairs[nvpKey] = nvpValue;
+    }
+
+    return createMock<Card>({
+        cardID: 2002,
+        state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+        bank: bank ?? CONST.COMPANY_CARD.FEED_BANK_NAME.VISA,
+        domainName: 'test.exfy',
+        fraud: 'none',
+        lastUpdated: '',
+        nameValuePairs,
+    });
+}
+
+describe('getExportMenuItem - QBO', () => {
+    function createQBOPolicy(nonReimbursableExpensesExportDestination: QBONonReimbursableExportAccountType, reimbursableExpensesExportDestination?: QBOReimbursableExportAccountType) {
+        return createBasePolicy({
+            quickbooksOnline: {
+                config: {
+                    nonReimbursableExpensesExportDestination,
+                    reimbursableExpensesExportDestination,
+                    nonReimbursableExpensesAccount: {id: 'qbo-cc-2', name: 'Visa Platinum', currency: 'USD'},
+                },
+                data: {
+                    creditCards: QBO_CREDIT_CARDS,
+                    bankAccounts: QBO_BANK_ACCOUNTS,
+                },
+            },
+        });
+    }
+
+    it('resolves a credit card export against the credit card list', () => {
+        const policy = createQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT, 'qbo-cc-1');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Amex Corporate');
+        expect(result?.shouldShowMenuItem).toBe(true);
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT);
+        expect(result?.exportPageLink).toBe(createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_ONLINE_EXPORT.path, basePath));
+        expect(result?.data).toHaveLength(QBO_CREDIT_CARDS.length + 1);
+
+        const selectedOption = result?.data?.find((item) => item.isSelected);
+        expect(selectedOption?.value).toBe('qbo-cc-1');
+        expect(selectedOption?.text).toBe('Amex Corporate');
+        expect(selectedOption?.keyForList).toBe('Amex Corporate');
+    });
+
+    it('resolves a debit card export against the bank account list and its own NVP', () => {
+        const policy = createQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT_DEBIT, 'qbo-bank-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Savings 5678');
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT_DEBIT);
+        expect(result?.data).toHaveLength(QBO_BANK_ACCOUNTS.length + 1);
+    });
+
+    it('hides the menu item for a vendor bill export', () => {
+        const policy = createQBOPolicy(CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT, 'qbo-cc-1');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBe(false);
+    });
+
+    it.each([CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.JOURNAL_ENTRY, CONST.QUICKBOOKS_REIMBURSABLE_ACCOUNT_TYPE.CHECK])(
+        'labels the default option as an account for a %s reimbursable export',
+        (reimbursableExpensesExportDestination) => {
+            const policy = createBasePolicy({
+                quickbooksOnline: {
+                    config: {reimbursableExpensesExportDestination},
+                    data: {creditCards: QBO_CREDIT_CARDS},
+                },
+            });
+            const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT);
+
+            const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+            expect(result?.title).toBe(translateLocal('workspace.accounting.defaultAccount'));
+        },
+    );
+
+    it('returns no options for an unrecognized export destination', () => {
+        const policy = createBasePolicy({
+            quickbooksOnline: {
+                data: {creditCards: QBO_CREDIT_CARDS},
+            },
+        });
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBe(false);
+        expect(result?.data).toEqual([]);
+    });
+});
+
+describe('getExportMenuItem - Xero', () => {
+    function createXeroPolicy(nonReimbursableAccount: string) {
+        return createBasePolicy({
+            xero: {
+                config: {export: {nonReimbursableAccount}},
+                data: {bankAccounts: XERO_BANK_ACCOUNTS},
+            },
+        });
+    }
+
+    it('resolves the bank account named by the NVP and keys options by id', () => {
+        const policy = createXeroPolicy('xero-bank-1');
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT, 'xero-bank-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.XERO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Petty Cash');
+        expect(result?.shouldShowMenuItem).toBe(true);
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT);
+        expect(result?.data).toHaveLength(XERO_BANK_ACCOUNTS.length + 1);
+
+        const selectedOption = result?.data?.find((item) => item.isSelected);
+        expect(selectedOption?.value).toBe('xero-bank-2');
+        expect(selectedOption?.keyForList).toBe('xero-bank-2');
+    });
+
+    it.each([undefined, CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE])('shows the default account label when the NVP is %s', (nvpValue) => {
+        const policy = createXeroPolicy('xero-bank-1');
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT, nvpValue);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.XERO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(translateLocal('workspace.accounting.defaultAccount'));
+    });
+
+    it('hides the menu item when the workspace has no non-reimbursable account', () => {
+        const policy = createXeroPolicy('');
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT, 'xero-bank-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.XERO, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBe(false);
+    });
+});
+
+describe('getExportMenuItem - NetSuite', () => {
+    function createNetSuitePolicy(nonreimbursableExpensesExportDestination: ValueOf<typeof CONST.NETSUITE_EXPORT_DESTINATION>) {
+        return createBasePolicy({
+            netsuite: {
+                options: {
+                    config: {
+                        nonreimbursableExpensesExportDestination,
+                        defaultVendor: 'ns-vendor-1',
+                        payableAcct: 'ns-payable-1',
+                    },
+                    data: {
+                        vendors: NETSUITE_VENDORS,
+                        payableList: NETSUITE_PAYABLE_ACCOUNTS,
+                    },
+                },
+            },
+        });
+    }
+
+    it('resolves a vendor bill export against the vendor list', () => {
+        const policy = createNetSuitePolicy(CONST.NETSUITE_EXPORT_DESTINATION.VENDOR_BILL);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR, 'ns-vendor-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.NETSUITE, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Globex Rentals');
+        expect(result?.shouldShowMenuItem).toBe(true);
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR);
+        expect(result?.exportPageLink).toBe(createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_NETSUITE_EXPORT.path, basePath));
+        expect(result?.data).toHaveLength(NETSUITE_VENDORS.length + 1);
+    });
+
+    it('shows the default vendor label for a vendor bill export with no NVP', () => {
+        const policy = createNetSuitePolicy(CONST.NETSUITE_EXPORT_DESTINATION.VENDOR_BILL);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.NETSUITE, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(translateLocal('workspace.accounting.defaultVendor'));
+    });
+
+    it('resolves a journal entry export against the payable account list', () => {
+        const policy = createNetSuitePolicy(CONST.NETSUITE_EXPORT_DESTINATION.JOURNAL_ENTRY);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_ACCOUNT, 'ns-payable-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.NETSUITE, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Corporate Card Payable');
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_ACCOUNT);
+        expect(result?.data).toHaveLength(NETSUITE_PAYABLE_ACCOUNTS.length + 1);
+    });
+
+    it('hides the menu item for an expense report export', () => {
+        const policy = createNetSuitePolicy(CONST.NETSUITE_EXPORT_DESTINATION.EXPENSE_REPORT);
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR, 'ns-vendor-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.NETSUITE, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBe(false);
+        expect(result?.data).toEqual([]);
+    });
+});
+
+describe('getExportMenuItem - Sage Intacct', () => {
+    it("titles a vendor bill export from the vendor's value rather than its name", () => {
+        const policy = createBasePolicy({
+            intacct: {
+                config: {
+                    export: {
+                        nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL,
+                        nonReimbursableVendor: 'intacct-vendor-1',
+                    },
+                },
+                data: {vendors: INTACCT_VENDORS},
+            },
+        });
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR, 'intacct-vendor-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Umbrella Vendor');
+        expect(result?.shouldShowMenuItem).toBe(true);
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR);
+        expect(result?.exportPageLink).toBe(createDynamicRoute(DYNAMIC_ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_EXPORT.path, basePath));
+        expect(result?.data).toHaveLength(INTACCT_VENDORS.length + 1);
+
+        const selectedOption = result?.data?.find((item) => item.isSelected);
+        expect(selectedOption?.value).toBe('intacct-vendor-2');
+        expect(selectedOption?.text).toBe('Umbrella Vendor');
+    });
+
+    it('falls back to the reimbursable export type when no non-reimbursable one is set', () => {
+        const policy = createBasePolicy({
+            intacct: {
+                config: {
+                    export: {
+                        reimbursable: CONST.SAGE_INTACCT_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL,
+                        reimbursableExpenseReportDefaultVendor: 'intacct-vendor-1',
+                    },
+                },
+                data: {vendors: INTACCT_VENDORS},
+            },
+        });
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR, 'intacct-vendor-1');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Acme Vendor');
+        expect(result?.shouldShowMenuItem).toBe(true);
+    });
+
+    it("titles a credit card charge export from the card's name", () => {
+        const policy = createBasePolicy({
+            intacct: {
+                config: {
+                    export: {
+                        nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.CREDIT_CARD_CHARGE,
+                        nonReimbursableAccount: 'intacct-card-1',
+                    },
+                },
+                data: {vendors: INTACCT_VENDORS, creditCards: INTACCT_CREDIT_CARDS},
+            },
+        });
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_CHARGE_CARD, 'intacct-card-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe('Intacct Visa');
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_CHARGE_CARD);
+        expect(result?.data).toHaveLength(INTACCT_CREDIT_CARDS.length + 1);
+    });
+
+    it('hides the menu item for an expense report export', () => {
+        const policy = createBasePolicy({
+            intacct: {
+                config: {export: {reimbursable: CONST.SAGE_INTACCT_REIMBURSABLE_EXPENSE_TYPE.EXPENSE_REPORT}},
+                data: {vendors: INTACCT_VENDORS},
+            },
+        });
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBe(false);
+        expect(result?.data).toEqual([]);
+    });
+});
+
+describe('getExportMenuItem - Rillet', () => {
+    const exportsTo = translateLocal('common.exportsTo');
+    const defaultSuffix = translateLocal('common.default').toLocaleLowerCase();
+
+    function createRilletPolicy(exportOverrides?: {exportToMultipleAccounts?: boolean; cardProgramAccounts?: Record<string, string>}) {
+        return createBasePolicy({
+            rillet: {
+                config: {
+                    export: {
+                        exportToMultipleAccounts: exportOverrides?.exportToMultipleAccounts ?? true,
+                        reimbursable: CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL,
+                        nonReimbursable: CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE,
+                        creditCardAccountCode: '2100',
+                        cardProgramAccounts: exportOverrides?.cardProgramAccounts,
+                    },
+                },
+                data: {accounts: RILLET_ACCOUNTS},
+            },
+        });
+    }
+
+    it('marks the workspace program account as the default in the title', () => {
+        const policy = createRilletPolicy();
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.RILLET, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} 2100 Amex Payable (${defaultSuffix})`);
+        expect(result?.shouldShowMenuItem).toBe(true);
+        expect(result?.shouldHideMenuItemDescription).toBe(true);
+        expect(result?.shouldShowMenuItemIcon).toBe(true);
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT);
+    });
+
+    it('drops the default suffix when the card names its own account', () => {
+        const policy = createRilletPolicy();
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT, 'rillet-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.RILLET, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} 2200 Visa Payable`);
+    });
+
+    it("uses the card feed's program account override", () => {
+        const policy = createRilletPolicy({cardProgramAccounts: {[CONST.COMPANY_CARD.FEED_BANK_NAME.VISA]: '2200'}});
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT, undefined, CONST.COMPANY_CARD.FEED_BANK_NAME.VISA);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.RILLET, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} 2200 Visa Payable (${defaultSuffix})`);
+
+        const defaultOption = result?.data?.at(0);
+        expect(defaultOption?.keyForList).toBe('rillet-2');
+        expect(defaultOption?.value).toBe('');
+        expect(defaultOption?.text).toBe(`${translateLocal('common.default')} - 2200 Visa Payable`);
+    });
+
+    it('offers only active credit card accounts while still resolving an inactive one as the title', () => {
+        const policy = createRilletPolicy();
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT, 'rillet-3');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.RILLET, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} 2300 Retired Card`);
+        expect(result?.data?.map((item) => item.keyForList)).toEqual(['rillet-1', 'rillet-2']);
+    });
+
+    it('hides the menu item when the workspace does not export to multiple accounts', () => {
+        const policy = createRilletPolicy({exportToMultipleAccounts: false});
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.RILLET, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBeFalsy();
+    });
+});
+
+describe('getExportMenuItem - DualEntry', () => {
+    const exportsTo = translateLocal('common.exportsTo');
+    const defaultSuffix = translateLocal('common.default').toLocaleLowerCase();
+
+    function createDualEntryPolicy(exportOverrides?: {exportToMultipleAccounts?: boolean; cardProgramAccounts?: Record<string, string>}) {
+        return createBasePolicy({
+            dualEntry: {
+                config: {
+                    export: {
+                        exportToMultipleAccounts: exportOverrides?.exportToMultipleAccounts ?? true,
+                        reimbursable: CONST.DUALENTRY_EXPORT_REIMBURSABLE.VENDOR_BILL,
+                        nonReimbursable: CONST.DUALENTRY_EXPORT_NON_REIMBURSABLE.DIRECT_EXPENSE,
+                        creditCardAccountID: 'de-1',
+                        cardProgramAccounts: exportOverrides?.cardProgramAccounts,
+                    },
+                },
+                data: {accounts: DUALENTRY_ACCOUNTS},
+            },
+        });
+    }
+
+    it('prefixes the title with the account id and marks the workspace default', () => {
+        const policy = createDualEntryPolicy();
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.DUALENTRY, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} de-1 Amex Payable (${defaultSuffix})`);
+        expect(result?.shouldShowMenuItem).toBe(true);
+        expect(result?.exportType).toBe(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT);
+    });
+
+    it("matches the program account by id and uses the card feed's override", () => {
+        const policy = createDualEntryPolicy({cardProgramAccounts: {[CONST.COMPANY_CARD.FEED_BANK_NAME.VISA]: 'de-2'}});
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT, undefined, CONST.COMPANY_CARD.FEED_BANK_NAME.VISA);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.DUALENTRY, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} de-2 Visa Payable (${defaultSuffix})`);
+    });
+
+    it('offers only active credit card and bank accounts', () => {
+        const policy = createDualEntryPolicy();
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT, 'de-2');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.DUALENTRY, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.title).toBe(`${exportsTo} de-2 Visa Payable`);
+        expect(result?.data?.map((item) => item.keyForList)).toEqual(['de-1', 'de-2']);
+    });
+
+    it('hides the menu item when the workspace does not export to multiple accounts', () => {
+        const policy = createDualEntryPolicy({exportToMultipleAccounts: false});
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.DUALENTRY, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(result?.shouldShowMenuItem).toBeFalsy();
+    });
+});
+
+describe('getExportMenuItem - unsupported connections', () => {
+    it.each([CONST.POLICY.CONNECTIONS.NAME.CERTINIA, undefined])('returns undefined for %s', (connectionName) => {
+        const policy = createBasePolicy({});
+        const card = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_FINANCIALFORCE_EXPORT_VENDOR);
+
+        expect(getExportMenuItem(connectionName, MOCK_POLICY_ID, translate, themeStyles, policy, card)).toBeUndefined();
+    });
+});
+
+describe('getPolicyCardExportSettings + getCardExportAccountTitle', () => {
+    const connectionsToTest = [
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.QBO,
+            policy: createBasePolicy({
+                quickbooksOnline: {
+                    config: {nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD},
+                    data: {creditCards: QBO_CREDIT_CARDS},
+                },
+            }),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT,
+            matchingAccountID: 'qbo-cc-1',
+        },
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.XERO,
+            policy: createBasePolicy({xero: {config: {export: {nonReimbursableAccount: 'xero-bank-1'}}, data: {bankAccounts: XERO_BANK_ACCOUNTS}}}),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT,
+            matchingAccountID: 'xero-bank-2',
+        },
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.NETSUITE,
+            policy: createBasePolicy({
+                netsuite: {options: {config: {nonreimbursableExpensesExportDestination: CONST.NETSUITE_EXPORT_DESTINATION.VENDOR_BILL}, data: {vendors: NETSUITE_VENDORS}}},
+            }),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR,
+            matchingAccountID: 'ns-vendor-2',
+        },
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT,
+            policy: createBasePolicy({
+                intacct: {config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL}}, data: {vendors: INTACCT_VENDORS}},
+            }),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR,
+            matchingAccountID: 'intacct-vendor-2',
+        },
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.QBD,
+            policy: createQBDPolicy(),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_DESKTOP_EXPORT_ACCOUNT_CREDIT,
+            matchingAccountID: '80000104-1746639411',
+        },
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.RILLET,
+            policy: createBasePolicy({
+                rillet: {
+                    config: {
+                        export: {
+                            exportToMultipleAccounts: true,
+                            reimbursable: CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL,
+                            nonReimbursable: CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE,
+                            creditCardAccountCode: '2100',
+                        },
+                    },
+                    data: {accounts: RILLET_ACCOUNTS},
+                },
+            }),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT,
+            matchingAccountID: 'rillet-2',
+        },
+        {
+            name: CONST.POLICY.CONNECTIONS.NAME.DUALENTRY,
+            policy: createBasePolicy({
+                dualEntry: {
+                    config: {
+                        export: {
+                            exportToMultipleAccounts: true,
+                            reimbursable: CONST.DUALENTRY_EXPORT_REIMBURSABLE.VENDOR_BILL,
+                            nonReimbursable: CONST.DUALENTRY_EXPORT_NON_REIMBURSABLE.DIRECT_EXPENSE,
+                            creditCardAccountID: 'de-1',
+                        },
+                    },
+                    data: {accounts: DUALENTRY_ACCOUNTS},
+                },
+            }),
+            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT,
+            matchingAccountID: 'de-2',
+        },
+    ] as const;
+
+    it.each(
+        connectionsToTest.flatMap(({name, policy, nvpKey, matchingAccountID}) => [
+            {name, policy, card: createCardWithExportNVP(nvpKey, matchingAccountID), label: `${name} - matched NVP`},
+            {name, policy, card: createCardWithExportNVP(nvpKey), label: `${name} - unset NVP (default)`},
+            {name, policy, card: createCardWithExportNVP(nvpKey, CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE), label: `${name} - DEFAULT_EXPORT_TYPE`},
+        ]),
+    )('$label: getCardExportAccountTitle matches getExportMenuItem().title', ({name, policy, card}) => {
+        const settings = getPolicyCardExportSettings(name, MOCK_POLICY_ID, translate, policy);
+        const legacyResult = getExportMenuItem(name, MOCK_POLICY_ID, translate, themeStyles, policy, card);
+
+        expect(getCardExportAccountTitle(settings, card)).toBe(legacyResult?.title);
+        expect(settings?.shouldShowMenuItem).toBe(legacyResult?.shouldShowMenuItem);
+    });
+
+    it('resolves a different title per card feed when a single settings object is reused across Rillet cards', () => {
+        const policy = createBasePolicy({
+            rillet: {
+                config: {
+                    export: {
+                        exportToMultipleAccounts: true,
+                        reimbursable: CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL,
+                        nonReimbursable: CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE,
+                        creditCardAccountCode: '2100',
+                        cardProgramAccounts: {[CONST.COMPANY_CARD.FEED_BANK_NAME.VISA]: '2200'},
+                    },
+                },
+                data: {accounts: RILLET_ACCOUNTS},
+            },
+        });
+        const settings = getPolicyCardExportSettings(CONST.POLICY.CONNECTIONS.NAME.RILLET, MOCK_POLICY_ID, translate, policy);
+
+        const visaCard = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT, undefined, CONST.COMPANY_CARD.FEED_BANK_NAME.VISA);
+        const otherFeedCard = createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT, undefined, CONST.COMPANY_CARD.FEED_BANK_NAME.MASTER_CARD);
+
+        expect(getCardExportAccountTitle(settings, visaCard)).toContain('2200 Visa Payable');
+        expect(getCardExportAccountTitle(settings, otherFeedCard)).toContain('2100 Amex Payable');
+    });
+
+    it('returns undefined when there is no export settings for the card', () => {
+        expect(getCardExportAccountTitle(undefined, createCardWithExportNVP(CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT))).toBeUndefined();
     });
 });
 

--- a/tests/unit/CompanyCardExportTest.ts
+++ b/tests/unit/CompanyCardExportTest.ts
@@ -729,98 +729,10 @@ describe('getExportMenuItem - unsupported connections', () => {
 });
 
 describe('getPolicyCardExportSettings + getCardExportAccountTitle', () => {
-    const connectionsToTest = [
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.QBO,
-            policy: createBasePolicy({
-                quickbooksOnline: {
-                    config: {nonReimbursableExpensesExportDestination: CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD},
-                    data: {creditCards: QBO_CREDIT_CARDS},
-                },
-            }),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_ONLINE_EXPORT_ACCOUNT,
-            matchingAccountID: 'qbo-cc-1',
-        },
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.XERO,
-            policy: createBasePolicy({xero: {config: {export: {nonReimbursableAccount: 'xero-bank-1'}}, data: {bankAccounts: XERO_BANK_ACCOUNTS}}}),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_XERO_EXPORT_BANK_ACCOUNT,
-            matchingAccountID: 'xero-bank-2',
-        },
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.NETSUITE,
-            policy: createBasePolicy({
-                netsuite: {options: {config: {nonreimbursableExpensesExportDestination: CONST.NETSUITE_EXPORT_DESTINATION.VENDOR_BILL}, data: {vendors: NETSUITE_VENDORS}}},
-            }),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_NETSUITE_EXPORT_VENDOR,
-            matchingAccountID: 'ns-vendor-2',
-        },
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT,
-            policy: createBasePolicy({
-                intacct: {config: {export: {nonReimbursable: CONST.SAGE_INTACCT_NON_REIMBURSABLE_EXPENSE_TYPE.VENDOR_BILL}}, data: {vendors: INTACCT_VENDORS}},
-            }),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_INTACCT_EXPORT_VENDOR,
-            matchingAccountID: 'intacct-vendor-2',
-        },
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.QBD,
-            policy: createQBDPolicy(),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_DESKTOP_EXPORT_ACCOUNT_CREDIT,
-            matchingAccountID: '80000104-1746639411',
-        },
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.RILLET,
-            policy: createBasePolicy({
-                rillet: {
-                    config: {
-                        export: {
-                            exportToMultipleAccounts: true,
-                            reimbursable: CONST.RILLET_EXPORT_REIMBURSABLE.VENDOR_BILL,
-                            nonReimbursable: CONST.RILLET_EXPORT_NON_REIMBURSABLE.CREDIT_CARD_CHARGE,
-                            creditCardAccountCode: '2100',
-                        },
-                    },
-                    data: {accounts: RILLET_ACCOUNTS},
-                },
-            }),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_RILLET_EXPORT_ACCOUNT,
-            matchingAccountID: 'rillet-2',
-        },
-        {
-            name: CONST.POLICY.CONNECTIONS.NAME.DUALENTRY,
-            policy: createBasePolicy({
-                dualEntry: {
-                    config: {
-                        export: {
-                            exportToMultipleAccounts: true,
-                            reimbursable: CONST.DUALENTRY_EXPORT_REIMBURSABLE.VENDOR_BILL,
-                            nonReimbursable: CONST.DUALENTRY_EXPORT_NON_REIMBURSABLE.DIRECT_EXPENSE,
-                            creditCardAccountID: 'de-1',
-                        },
-                    },
-                    data: {accounts: DUALENTRY_ACCOUNTS},
-                },
-            }),
-            nvpKey: CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_DUALENTRY_EXPORT_ACCOUNT,
-            matchingAccountID: 'de-2',
-        },
-    ] as const;
-
-    it.each(
-        connectionsToTest.flatMap(({name, policy, nvpKey, matchingAccountID}) => [
-            {name, policy, card: createCardWithExportNVP(nvpKey, matchingAccountID), label: `${name} - matched NVP`},
-            {name, policy, card: createCardWithExportNVP(nvpKey), label: `${name} - unset NVP (default)`},
-            {name, policy, card: createCardWithExportNVP(nvpKey, CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE), label: `${name} - DEFAULT_EXPORT_TYPE`},
-        ]),
-    )('$label: getCardExportAccountTitle matches getExportMenuItem().title', ({name, policy, card}) => {
-        const settings = getPolicyCardExportSettings(name, MOCK_POLICY_ID, translate, policy);
-        const legacyResult = getExportMenuItem(name, MOCK_POLICY_ID, translate, themeStyles, policy, card);
-
-        expect(getCardExportAccountTitle(settings, card)).toBe(legacyResult?.title);
-        expect(settings?.shouldShowMenuItem).toBe(legacyResult?.shouldShowMenuItem);
-    });
-
+    // getExportMenuItem is a thin composition of these two functions (see utils.tsx), and every case above already
+    // exercises both of them through it with real title/shouldShowMenuItem assertions. So this describe only covers
+    // behavior that is specific to calling the two functions directly, the way the tables do: resolving many cards
+    // against one settings object, and the settings-not-found guard the unassigned-card row relies on.
     it('resolves a different title per card feed when a single settings object is reused across Rillet cards', () => {
         const policy = createBasePolicy({
             rillet: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/100422
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

**Prereq:** Workspace with an accounting integration connected, where the export destination shows the **Accounting** section on card details (e.g. Credit Card, not Vendor Bill).

1. Go to **Workspaces > [workspace] > Company cards**. Verify **Export account** appears after **Card name** and matches the card details **Accounting** value.
2. Go to **Workspaces > [workspace] > Expensify Card**. Verify **Export account** appears between **Status** and **Limit**, with values matching card details.
3. On both tables, sort by **Export account** ascending/descending and verify sorting works.
4. Assign a card to a member on a policy with no export NVP. Verify the workspace default label appears (e.g. **Default vendor/account/card**).
5. Verify an **unassigned** Company card shows a blank Export account, not the default label.
6. Change the export destination to one that hides the Accounting section (e.g. Vendor Bill). Verify **Export account** disappears from both tables and remaining columns render correctly.
7. Disconnect the accounting integration. Verify **Export account** remains absent.
8. Repeat step 1 for **direct, commercial, and CSV import** card feeds and verify identical behavior.
9. If Rillet/DualEntry is available, verify cards on different feeds show their feed-specific `cardProgramAccounts` override, with **(default)** only when no custom NVP exists.
10. Narrow the browser/mobile viewport. Verify **Export account** hides without affecting other columns.
11. Widen the viewport. Verify the column reappears and columns align correctly.
12. Resize slowly with varying export account lengths. Verify smooth resizing, truncation with hover tooltip, and no collapsed columns.
13. On Company cards, verify the **Assign** button on unassigned rows is fully visible.
14. Select multiple cards on both tables and verify selection/actions still work correctly.


- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as tests

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/23822f04-df8d-4dd2-96dc-b9e1ed00d322

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/17c30071-5208-4099-8c44-cfe51060d897

</details>
