### PR TITLE
[No QA] Update ProposalPolice edit timestamp on every substantive edit

### DIFF
--- a/.github/actions/javascript/proposalPoliceComment/index.js
+++ b/.github/actions/javascript/proposalPoliceComment/index.js
@@ -52845,6 +52845,11 @@ ${duplicateDetection_default}
 var DUPLICATE_CHECK_WITHDRAW_MESSAGE = "#### \u{1F6AB} Duplicated proposal withdrawn by \u{1F916} ProposalPolice.";
 var SUBSTANTIVE_EDIT_MESSAGE_PREFIX = "\u{1F6A8} Edited by **proposal-police**:";
 var SUBSTANTIVE_EDIT_MESSAGE_REGEX = /^🚨 Edited by \*\*proposal-police\*\*:[^\n]*\n+/;
+function stripSubstantiveEditBanner(body) {
+  const trimmedStart = body.trimStart();
+  const stripped = trimmedStart.replace(SUBSTANTIVE_EDIT_MESSAGE_REGEX, "");
+  return stripped === trimmedStart ? body : stripped;
+}
 function buildTemplateReminderMessage(proposalAuthor) {
   return `\u26A0\uFE0F @${proposalAuthor} Thanks for your proposal. Please update it to follow the [proposal template](https://github.com/Expensify/App/blob/main/contributingGuides/PROPOSAL_TEMPLATE.md?plain=1), as proposals are only reviewed if they follow that format (note the mandatory sections).`;
 }
@@ -66353,14 +66358,19 @@ async function run() {
     }
     return;
   }
-  if (isCommentEditedEvent(payload) && payload.comment.body.trim().startsWith(SUBSTANTIVE_EDIT_MESSAGE_PREFIX)) {
-    console.log("Comment was already edited by proposal-police once, so only refreshing its recorded copy.\n", payload.comment.body);
-    await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment.user.login, payload.comment.body.trim().replace(SUBSTANTIVE_EDIT_MESSAGE_REGEX, ""));
+  const previousProposalBody = stripSubstantiveEditBanner(payload.changes.body?.from ?? "");
+  const editedProposalBody = stripSubstantiveEditBanner(payload.comment?.body ?? "");
+  const isAlreadyBannered = editedProposalBody !== (payload.comment?.body ?? "");
+  if (previousProposalBody === editedProposalBody) {
+    console.log("Proposal text is unchanged after stripping any edit banner, skipping the edit check.");
+    if (isAlreadyBannered) {
+      await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment.user.login, editedProposalBody);
+    }
     return;
   }
   const response = await openAI.promptResponses({
     instructions: buildEditCheckInstructions(),
-    input: buildEditCheckInput(payload.changes.body?.from, payload.comment?.body),
+    input: buildEditCheckInput(previousProposalBody, editedProposalBody),
     model: PROPOSAL_POLICE_MODEL,
     promptCacheKey: "proposal-police-edit-check",
     textFormat: EDIT_CHECK_RESPONSE_FORMAT
@@ -66372,6 +66382,9 @@ async function run() {
   const action = parsedResponse?.action ?? CONST_default.NO_ACTION;
   if (action === CONST_default.NO_ACTION) {
     console.log("Detected NO_ACTION for comment, returning early.");
+    if (isAlreadyBannered) {
+      await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment.user.login, editedProposalBody);
+    }
     return;
   }
   if (action === CONST_default.ACTION_EDIT) {
@@ -66382,9 +66395,9 @@ async function run() {
       comment_id: commentID,
       body: `${buildSubstantiveEditMessage(formattedDate)}
 
-${payload.comment?.body}`
+${editedProposalBody}`
     });
-    await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment?.user.login ?? "", payload.comment?.body ?? "");
+    await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment?.user.login ?? "", editedProposalBody);
   }
 }
 if (import.meta.main) {

--- a/.github/actions/javascript/proposalPoliceComment/proposalPoliceComment.ts
+++ b/.github/actions/javascript/proposalPoliceComment/proposalPoliceComment.ts
@@ -11,8 +11,7 @@ import {
     buildSubstantiveEditMessage,
     buildTemplateReminderMessage,
     DUPLICATE_CHECK_WITHDRAW_MESSAGE,
-    SUBSTANTIVE_EDIT_MESSAGE_PREFIX,
-    SUBSTANTIVE_EDIT_MESSAGE_REGEX,
+    stripSubstantiveEditBanner,
 } from '@prompts/proposalPolice/messages';
 import {
     COMMENT_INTENT_RESPONSE_FORMAT,
@@ -310,21 +309,27 @@ async function run() {
         return;
     }
 
-    // A comment we already bannered must never be bannered again, which is the only thing the edit check
-    // decides, so skip it. The proposal text can still have changed though, and without this the
-    // Conversation would keep serving every future duplicate check the copy stored before this edit.
-    // `startsWith` rather than `includes`, matching the ^-anchored regex used to strip it below: a comment
-    // that merely quotes the banner further down has not been flagged, and stripping would leave it in place.
-    if (isCommentEditedEvent(payload) && payload.comment.body.trim().startsWith(SUBSTANTIVE_EDIT_MESSAGE_PREFIX)) {
-        console.log('Comment was already edited by proposal-police once, so only refreshing its recorded copy.\n', payload.comment.body);
-        // Store the proposal itself, not the banner a previous run prepended to it
-        await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment.user.login, payload.comment.body.trim().replace(SUBSTANTIVE_EDIT_MESSAGE_REGEX, ''));
+    // Strip any banner a previous run prepended so the edit check compares proposal text to
+    // proposal text. Leaving it on either side would make a timestamp-only difference look
+    // substantial, and prepending another banner on ACTION_EDIT would stack them.
+    const previousProposalBody = stripSubstantiveEditBanner(payload.changes.body?.from ?? '');
+    const editedProposalBody = stripSubstantiveEditBanner(payload.comment?.body ?? '');
+    const isAlreadyBannered = editedProposalBody !== (payload.comment?.body ?? '');
+
+    // Our own banner prepend comes back as another edited event. After stripping, the proposal
+    // is unchanged, so there is nothing to classify — and calling the model would just spend a
+    // request on a difference we introduced.
+    if (previousProposalBody === editedProposalBody) {
+        console.log('Proposal text is unchanged after stripping any edit banner, skipping the edit check.');
+        if (isAlreadyBannered) {
+            await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment.user.login, editedProposalBody);
+        }
         return;
     }
 
     const response = await openAI.promptResponses({
         instructions: buildEditCheckInstructions(),
-        input: buildEditCheckInput(payload.changes.body?.from, payload.comment?.body),
+        input: buildEditCheckInput(previousProposalBody, editedProposalBody),
         model: PROPOSAL_POLICE_MODEL,
         promptCacheKey: 'proposal-police-edit-check',
         textFormat: EDIT_CHECK_RESPONSE_FORMAT,
@@ -340,6 +345,11 @@ async function run() {
     const action = parsedResponse?.action ?? CONST.NO_ACTION;
     if (action === CONST.NO_ACTION) {
         console.log('Detected NO_ACTION for comment, returning early.');
+        // An already-bannered comment can still have changed in a non-substantive way, and
+        // without this the Conversation would keep serving the copy stored before this edit.
+        if (isAlreadyBannered) {
+            await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment.user.login, editedProposalBody);
+        }
         return;
     }
 
@@ -349,12 +359,12 @@ async function run() {
             ...context.repo,
             /* eslint-disable @typescript-eslint/naming-convention */
             comment_id: commentID,
-            body: `${buildSubstantiveEditMessage(formattedDate)}\n\n${payload.comment?.body}`,
+            body: `${buildSubstantiveEditMessage(formattedDate)}\n\n${editedProposalBody}`,
         });
 
         // The Conversation still holds this proposal as it read before the edit, so refresh it. Only
-        // substantial edits land here; minor rewording is deliberately left as-is.
-        await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment?.user.login ?? '', payload.comment?.body ?? '');
+        // substantial edits land here; minor rewording of a never-bannered comment is deliberately left as-is.
+        await refreshStoredProposal(openAI, issueNumber, commentID, payload.comment?.user.login ?? '', editedProposalBody);
     }
 }
 

--- a/prompts/proposalPolice/messages.ts
+++ b/prompts/proposalPolice/messages.ts
@@ -7,7 +7,8 @@ const DUPLICATE_CHECK_WITHDRAW_MESSAGE = '#### 🚫 Duplicated proposal withdraw
 
 /**
  * Marks a comment ProposalPolice has already flagged as substantively edited. Matched against comment
- * bodies to avoid flagging the same edit twice, so it must stay a literal prefix of the message below.
+ * bodies to detect an already-bannered proposal so the banner can be replaced rather than stacked,
+ * and so it must stay a literal prefix of the message below.
  */
 const SUBSTANTIVE_EDIT_MESSAGE_PREFIX = '🚨 Edited by **proposal-police**:';
 
@@ -17,6 +18,17 @@ const SUBSTANTIVE_EDIT_MESSAGE_PREFIX = '🚨 Edited by **proposal-police**:';
  * ProposalPoliceMessagesTest pins this against buildSubstantiveEditMessage so the two cannot drift.
  */
 const SUBSTANTIVE_EDIT_MESSAGE_REGEX = /^🚨 Edited by \*\*proposal-police\*\*:[^\n]*\n+/;
+
+/**
+ * Drop a banner a previous run prepended, leaving the contributor's proposal. Only leading
+ * whitespace before a real banner is discarded, so a stray newline cannot hide it from the
+ * ^-anchored regex. A comment that never had a complete banner is returned byte-for-byte unchanged.
+ */
+function stripSubstantiveEditBanner(body: string): string {
+    const trimmedStart = body.trimStart();
+    const stripped = trimmedStart.replace(SUBSTANTIVE_EDIT_MESSAGE_REGEX, '');
+    return stripped === trimmedStart ? body : stripped;
+}
 
 function buildTemplateReminderMessage(proposalAuthor: string | undefined): string {
     return `⚠️ @${proposalAuthor} Thanks for your proposal. Please update it to follow the [proposal template](https://github.com/Expensify/App/blob/main/contributingGuides/PROPOSAL_TEMPLATE.md?plain=1), as proposals are only reviewed if they follow that format (note the mandatory sections).`;
@@ -42,6 +54,7 @@ export {
     DUPLICATE_CHECK_WITHDRAW_MESSAGE,
     SUBSTANTIVE_EDIT_MESSAGE_PREFIX,
     SUBSTANTIVE_EDIT_MESSAGE_REGEX,
+    stripSubstantiveEditBanner,
     buildTemplateReminderMessage,
     buildJobClaimReminderMessage,
     buildSubstantiveEditMessage,

--- a/tests/tooling/ProposalPoliceMessages.test.ts
+++ b/tests/tooling/ProposalPoliceMessages.test.ts
@@ -6,6 +6,7 @@ import {
     buildTemplateReminderMessage,
     SUBSTANTIVE_EDIT_MESSAGE_PREFIX,
     SUBSTANTIVE_EDIT_MESSAGE_REGEX,
+    stripSubstantiveEditBanner,
 } from '@prompts/proposalPolice/messages';
 
 const PROPOSAL = ['## Proposal', '', '### What is the root cause of that problem?', 'Some root cause'].join('\n');
@@ -32,6 +33,31 @@ describe('SUBSTANTIVE_EDIT_MESSAGE_REGEX', () => {
 
     it('starts with the prefix used to detect an already-bannered comment', () => {
         expect(buildSubstantiveEditMessage('2026-01-01 00:00:00 UTC').startsWith(SUBSTANTIVE_EDIT_MESSAGE_PREFIX)).toBe(true);
+    });
+});
+
+describe('stripSubstantiveEditBanner', () => {
+    it('returns the proposal from a bannered comment', () => {
+        const bannered = `${buildSubstantiveEditMessage('2026-01-01 00:00:00 UTC')}\n\n${PROPOSAL}`;
+
+        expect(stripSubstantiveEditBanner(bannered)).toBe(PROPOSAL);
+    });
+
+    it('leaves a never-bannered comment byte-for-byte unchanged', () => {
+        expect(stripSubstantiveEditBanner(`\n${PROPOSAL}\n`)).toBe(`\n${PROPOSAL}\n`);
+    });
+
+    it('still finds a banner hidden behind leading whitespace', () => {
+        const bannered = `\n${buildSubstantiveEditMessage('2026-01-01 00:00:00 UTC')}\n\n${PROPOSAL}`;
+
+        expect(stripSubstantiveEditBanner(bannered)).toBe(PROPOSAL);
+    });
+
+    it('leaves a prefix that is missing the trailing newline unchanged', () => {
+        // The regex requires the blank line that separates a real banner from the proposal
+        const lookalike = `${SUBSTANTIVE_EDIT_MESSAGE_PREFIX} not a real banner`;
+
+        expect(stripSubstantiveEditBanner(lookalike)).toBe(lookalike);
     });
 });
 

--- a/tests/tooling/proposalPoliceComment.test.ts
+++ b/tests/tooling/proposalPoliceComment.test.ts
@@ -303,32 +303,103 @@ describe('proposalPoliceComment', () => {
         );
     });
 
-    it('refreshes the recorded proposal when an already-bannered comment is edited again', async () => {
-        // The banner means this comment was flagged on a previous run. It must not be flagged twice, but
-        // the proposal underneath it can still have changed, and the stored copy would otherwise be stuck
-        // at whatever it said before this edit.
+    it('replaces the existing banner when an already-bannered proposal is edited again substantially', async () => {
+        // A later substantive edit must update the timestamp, not stack a second banner on top of the first.
         const bannered = (proposal: string) => `${buildSubstantiveEditMessage('2026-01-01 00:00:00 UTC')}\n\n${proposal}`;
+        const rewrittenProposal = `${VALID_PROPOSAL_BODY}\nyet another solution`;
         mockComments([makeComment({id: 5, login: 'github-actions[bot]', type: 'Bot', body: '<!-- proposal-police-conversation-id: conv_existing -->'})]);
         setPayload({
             action: 'edited',
-            comment: makeComment({id: 7, body: bannered(`${VALID_PROPOSAL_BODY}\nyet another solution`)}),
+            comment: makeComment({id: 7, body: bannered(rewrittenProposal)}),
             changes: {body: {from: bannered(VALID_PROPOSAL_BODY)}},
         });
         mockListConversationItems.mockResolvedValue([conversationMessage('item_7', 7)]);
+        mockPromptResponses.mockResolvedValueOnce({text: JSON.stringify({action: 'ACTION_EDIT'}), responseID: 'resp_edit'});
 
         await run();
 
-        // No second banner, and no model call - the edit check only decides whether to banner
-        expect(mockUpdateComment).not.toHaveBeenCalled();
-        expect(mockPromptResponses).not.toHaveBeenCalled();
+        expect(mockPromptResponses).toHaveBeenCalledTimes(1);
+        const [{input}] = mockPromptResponses.mock.calls.at(0) ?? [{}];
+        // Both sides of the comparison must be the proposal itself, not the banner wrapping it
+        expect(input).not.toContain(SUBSTANTIVE_EDIT_MESSAGE_PREFIX);
+        expect(input).toContain('yet another solution');
+
+        expect(mockUpdateComment).toHaveBeenCalledTimes(1);
+        const updatedBody = mockUpdateComment.mock.calls.at(0)?.at(0)?.body ?? '';
+        expect(updatedBody.startsWith(SUBSTANTIVE_EDIT_MESSAGE_PREFIX)).toBe(true);
+        expect(updatedBody.split(SUBSTANTIVE_EDIT_MESSAGE_PREFIX)).toHaveLength(2);
+        expect(updatedBody).toContain(rewrittenProposal);
+        expect(updatedBody).not.toContain('2026-01-01 00:00:00 UTC');
 
         expect(mockDeleteConversationItem).toHaveBeenCalledWith('conv_existing', 'item_7');
         const [, items] = mockAddConversationItems.mock.calls.at(0) ?? [];
         const storedItem = items?.at(0);
         const storedContent = storedItem && 'content' in storedItem && typeof storedItem.content === 'string' ? storedItem.content : '';
         expect(storedContent).toContain('yet another solution');
-        // The banner is ours, not the contributor's proposal, so it must not pollute future comparisons
         expect(storedContent).not.toContain(SUBSTANTIVE_EDIT_MESSAGE_PREFIX);
+    });
+
+    it('refreshes the recorded proposal when an already-bannered comment is edited non-substantively', async () => {
+        // The timestamp stays put, but the proposal underneath can still have changed, and the stored
+        // copy would otherwise be stuck at whatever it said before this edit.
+        const bannered = (proposal: string) => `${buildSubstantiveEditMessage('2026-01-01 00:00:00 UTC')}\n\n${proposal}`;
+        mockComments([makeComment({id: 5, login: 'github-actions[bot]', type: 'Bot', body: '<!-- proposal-police-conversation-id: conv_existing -->'})]);
+        setPayload({
+            action: 'edited',
+            comment: makeComment({id: 7, body: bannered(`${VALID_PROPOSAL_BODY}\nfixed a typo`)}),
+            changes: {body: {from: bannered(VALID_PROPOSAL_BODY)}},
+        });
+        mockListConversationItems.mockResolvedValue([conversationMessage('item_7', 7)]);
+        mockPromptResponses.mockResolvedValueOnce({text: JSON.stringify({action: 'NO_ACTION'}), responseID: 'resp_edit'});
+
+        await run();
+
+        expect(mockUpdateComment).not.toHaveBeenCalled();
+        expect(mockPromptResponses).toHaveBeenCalledTimes(1);
+
+        expect(mockDeleteConversationItem).toHaveBeenCalledWith('conv_existing', 'item_7');
+        const [, items] = mockAddConversationItems.mock.calls.at(0) ?? [];
+        const storedItem = items?.at(0);
+        const storedContent = storedItem && 'content' in storedItem && typeof storedItem.content === 'string' ? storedItem.content : '';
+        expect(storedContent).toContain('fixed a typo');
+        expect(storedContent).not.toContain(SUBSTANTIVE_EDIT_MESSAGE_PREFIX);
+    });
+
+    it('does not run the edit check when only the banner changed', async () => {
+        // Our own banner prepend comes back as another edited event. After stripping, the proposal
+        // is the same, so classifying it would just spend a request on a difference we introduced.
+        const bannered = (proposal: string) => `${buildSubstantiveEditMessage('2026-01-01 00:00:00 UTC')}\n\n${proposal}`;
+        mockComments([makeComment({id: 5, login: 'github-actions[bot]', type: 'Bot', body: '<!-- proposal-police-conversation-id: conv_existing -->'})]);
+        setPayload({
+            action: 'edited',
+            comment: makeComment({id: 7, body: bannered(VALID_PROPOSAL_BODY)}),
+            changes: {body: {from: VALID_PROPOSAL_BODY}},
+        });
+        mockListConversationItems.mockResolvedValue([conversationMessage('item_7', 7)]);
+
+        await run();
+
+        expect(mockPromptResponses).not.toHaveBeenCalled();
+        expect(mockUpdateComment).not.toHaveBeenCalled();
+        expect(mockAddConversationItems).toHaveBeenCalled();
+    });
+
+    it('does not refresh the recorded proposal when a never-bannered edit is classified as non-substantive', async () => {
+        // Minor rewording of a never-bannered comment is deliberately left as-is, including the stored copy.
+        mockComments([makeComment({id: 5, login: 'github-actions[bot]', type: 'Bot', body: '<!-- proposal-police-conversation-id: conv_existing -->'})]);
+        setPayload({
+            action: 'edited',
+            comment: makeComment({id: 7, body: `${VALID_PROPOSAL_BODY}\nfixed a typo`}),
+            changes: {body: {from: VALID_PROPOSAL_BODY}},
+        });
+        mockListConversationItems.mockResolvedValue([conversationMessage('item_7', 7)]);
+        mockPromptResponses.mockResolvedValueOnce({text: JSON.stringify({action: 'NO_ACTION'}), responseID: 'resp_edit'});
+
+        await run();
+
+        expect(mockUpdateComment).not.toHaveBeenCalled();
+        expect(mockDeleteConversationItem).not.toHaveBeenCalled();
+        expect(mockAddConversationItems).not.toHaveBeenCalled();
     });
 
     it('replaces the recorded proposal after a substantial edit so later duplicate checks see the new text', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
ProposalPolice prepended an edit-timestamp banner on the first substantive edit, then skipped the edit check on every later edit of that comment. Reviewers therefore kept seeing the time of the first rewrite even after later ones.

This removes that early return. Both sides of the edit comparison have the existing banner stripped so the model grades proposal text against proposal text, and a new banner replaces the old one instead of stacking. The recorded duplicate-check copy is still refreshed on later edits of an already-bannered comment.

### Fixed Issues
$ https://github.com/Expensify/App/issues/100731

### Tests
Added automated tests.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
