### PR TITLE
Fix debug banner overlap on Workspaces and Domains wide layouts

### DIFF
--- a/src/components/Navigation/DebugTabView.tsx
+++ b/src/components/Navigation/DebugTabView.tsx
@@ -10,6 +10,7 @@ import useReportAttributes from '@hooks/useReportAttributes';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useRootNavigationState from '@hooks/useRootNavigationState';
 import {useSidebarOrderedReportsState} from '@hooks/useSidebarOrderedReports';
+import useSidePanelDisplayStatus from '@hooks/useSidePanelDisplayStatus';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -42,6 +43,8 @@ import {View} from 'react-native';
 
 import NAVIGATION_TABS from './NavigationTabBar/NAVIGATION_TABS';
 
+const FULL_WIDTH_TAB_ROOT_SCREENS = new Set([SCREENS.WORKSPACES_LIST, SCREENS.DOMAINS_LIST]);
+
 function getActiveTabRoute(rootState: NavigationState | undefined) {
     if (!rootState) {
         return undefined;
@@ -52,6 +55,18 @@ function getActiveTabRoute(rootState: NavigationState | undefined) {
     // and just be visually covered by it.
     const tabRoute = rootState.routes.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
     return tabRoute?.state?.routes?.[tabRoute.state.index ?? 0];
+}
+
+function useDebugTabViewHeight(): number {
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const [isDebugModeEnabled] = useOnyx(ONYXKEYS.IS_DEBUG_MODE_ENABLED);
+    const {status} = useIndicatorStatus();
+
+    if (shouldUseNarrowLayout || !isDebugModeEnabled || !getSettingsMessage(status)) {
+        return 0;
+    }
+
+    return variables.debugTabViewHeight;
 }
 
 function getSettingsMessage(status: IndicatorStatus | undefined): TranslationPaths | undefined {
@@ -138,8 +153,10 @@ function DebugTabView({selectedTab}: Props) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {shouldUseNarrowLayout, isExtraLargeScreenWidth} = useResponsiveLayout();
+    const {shouldHideSidePanel} = useSidePanelDisplayStatus();
     const {windowWidth} = useWindowDimensions();
+    const sidePanelOffset = isExtraLargeScreenWidth && !shouldHideSidePanel ? variables.sidePanelWidth : 0;
     const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
     const reportAttributes = useReportAttributes();
     const {status, indicatorColor, indicatorPolicyID} = useIndicatorStatus();
@@ -157,9 +174,8 @@ function DebugTabView({selectedTab}: Props) {
             return false;
         }
         const focusedLeaf = getFocusedLeafScreenName(activeRoute.state) ?? activeRoute.name;
-        // Scoped to WORKSPACES_LIST — the only full-width tab root among the three tabs
-        // (Inbox/Settings/Workspaces) gated by the tab filter further below.
-        return focusedLeaf === SCREENS.WORKSPACES_LIST;
+        // Both roots of the Workspaces tab render WorkspaceListLayout and have no sidebar.
+        return FULL_WIDTH_TAB_ROOT_SCREENS.has(focusedLeaf);
     });
 
     const message = useMemo((): TranslationPaths | undefined => {
@@ -223,7 +239,7 @@ function DebugTabView({selectedTab}: Props) {
     if (shouldUseNarrowLayout) {
         positionStyle = {bottom: 0, left: 0, right: 0};
     } else if (isOnFullWidthTabRoot) {
-        positionStyle = {...verticalAnchor, left: variables.navigationTabBarSize, width: windowWidth - variables.navigationTabBarSize};
+        positionStyle = {...verticalAnchor, left: variables.navigationTabBarSize, width: windowWidth - variables.navigationTabBarSize - sidePanelOffset};
     } else {
         positionStyle = {...verticalAnchor, left: variables.navigationTabBarSize, width: variables.sideBarWithLHBWidth - variables.cropBorderWidth};
     }
@@ -239,7 +255,14 @@ function DebugTabView({selectedTab}: Props) {
         >
             <View
                 testID="DebugTabView"
-                style={[StyleUtils.getBackgroundColorStyle(theme.cardBG), styles.p3, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}
+                style={[
+                    StyleUtils.getBackgroundColorStyle(theme.cardBG),
+                    styles.p3,
+                    styles.flexRow,
+                    styles.justifyContentBetween,
+                    styles.alignItemsCenter,
+                    {minHeight: variables.debugTabViewHeight},
+                ]}
             >
                 <View style={[styles.flexRow, styles.gap2, styles.flex1, styles.alignItemsCenter]}>
                     <Icon
@@ -256,4 +279,5 @@ function DebugTabView({selectedTab}: Props) {
     );
 }
 
+export {getSettingsMessage, useDebugTabViewHeight};
 export default DebugTabView;

--- a/src/components/Navigation/DebugTabView.tsx
+++ b/src/components/Navigation/DebugTabView.tsx
@@ -261,7 +261,7 @@ function DebugTabView({selectedTab}: Props) {
                     styles.flexRow,
                     styles.justifyContentBetween,
                     styles.alignItemsCenter,
-                    {minHeight: variables.debugTabViewHeight},
+                    StyleUtils.getMinimumHeight(variables.debugTabViewHeight),
                 ]}
             >
                 <View style={[styles.flexRow, styles.gap2, styles.flex1, styles.alignItemsCenter]}>

--- a/src/components/Navigation/DebugTabView.tsx
+++ b/src/components/Navigation/DebugTabView.tsx
@@ -43,7 +43,7 @@ import {View} from 'react-native';
 
 import NAVIGATION_TABS from './NavigationTabBar/NAVIGATION_TABS';
 
-const FULL_WIDTH_TAB_ROOT_SCREENS = new Set([SCREENS.WORKSPACES_LIST, SCREENS.DOMAINS_LIST]);
+const FULL_WIDTH_TAB_ROOT_SCREENS = new Set<string>([SCREENS.WORKSPACES_LIST, SCREENS.DOMAINS_LIST]);
 
 function getActiveTabRoute(rootState: NavigationState | undefined) {
     if (!rootState) {

--- a/src/components/WorkspaceListLayout.tsx
+++ b/src/components/WorkspaceListLayout.tsx
@@ -1,3 +1,5 @@
+import {useDebugTabViewHeight} from '@components/Navigation/DebugTabView';
+
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -83,6 +85,7 @@ function WorkspaceListLayout({children, activeTabKey, headerButton, headerCompon
     const {translate} = useLocalize();
 
     const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const debugTabViewHeight = useDebugTabViewHeight();
     const shouldDisplayButtonsInSeparateLine = useShouldDisplayButtonsInSeparateLine();
 
     const isWorkspacesListPage = activeTabKey === 'workspaces';
@@ -122,6 +125,12 @@ function WorkspaceListLayout({children, activeTabKey, headerButton, headerCompon
                     </TopBarWithLoadingBar>
 
                     {content}
+                    {debugTabViewHeight > 0 && (
+                        <View
+                            style={{height: debugTabViewHeight}}
+                            testID="DebugTabViewSpacer"
+                        />
+                    )}
                     {!shouldUseNarrowLayout && <OfflineIndicator style={styles.pl5} />}
                 </View>
             </View>

--- a/src/components/WorkspaceListLayout.tsx
+++ b/src/components/WorkspaceListLayout.tsx
@@ -1,5 +1,3 @@
-import {useDebugTabViewHeight} from '@components/Navigation/DebugTabView';
-
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -14,6 +12,7 @@ import SCREENS from '@src/SCREENS';
 import React from 'react';
 import {View} from 'react-native';
 
+import {useDebugTabViewHeight} from './Navigation/DebugTabView';
 import NAVIGATION_TABS from './Navigation/NavigationTabBar/NAVIGATION_TABS';
 import TabBarBottomContent from './Navigation/TabBarBottomContent';
 import TopBarWithLoadingBar from './Navigation/TopBarWithLoadingBar';

--- a/src/components/WorkspaceListLayout.tsx
+++ b/src/components/WorkspaceListLayout.tsx
@@ -2,6 +2,7 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useShouldDisplayButtonsInSeparateLine from '@hooks/useShouldDisplayButtonsInSeparateLine';
+import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import Navigation from '@libs/Navigation/Navigation';
@@ -81,6 +82,7 @@ function WorkspaceListHeaderContent({activeTabKey, headerButton, shouldShowHeade
 
 function WorkspaceListLayout({children, activeTabKey, headerButton, headerComponent, scrollHeaderWithTable = false}: WorkspaceListLayoutProps) {
     const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
 
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -124,13 +126,13 @@ function WorkspaceListLayout({children, activeTabKey, headerButton, headerCompon
                     </TopBarWithLoadingBar>
 
                     {content}
+                    {!shouldUseNarrowLayout && <OfflineIndicator style={styles.pl5} />}
                     {debugTabViewHeight > 0 && (
                         <View
-                            style={{height: debugTabViewHeight}}
+                            style={StyleUtils.getHeight(debugTabViewHeight)}
                             testID="DebugTabViewSpacer"
                         />
                     )}
-                    {!shouldUseNarrowLayout && <OfflineIndicator style={styles.pl5} />}
                 </View>
             </View>
         </ScreenWrapper>

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -67,7 +67,6 @@ export default {
     fontSizeMedium: getValueUsingPixelRatio(16, 22),
     fontSizeLarge: getValueUsingPixelRatio(17, 19),
     fontSizeHero: 36,
-    fontSizeH1: 19,
     fontSizeH2: 19,
     fontSizeXLarge: getValueUsingPixelRatio(22, 28),
     fontSizeXXLarge: 28,
@@ -162,7 +161,9 @@ export default {
     sectionMenuItemHeightCompact: 44,
     optionsListSectionHeaderHeight: getValueUsingPixelRatio(32, 38),
     overlayOpacity: 0.72,
-    lineHeightXSmall: getValueUsingPixelRatio(11, 17),
+    // fontSizeExtraSmall is fixed at 9, so the line height must never scale below the font's natural line height (~1.18em = 10.62),
+    // otherwise Android clamps the descent and clips descenders and underlines at small device font scales.
+    lineHeightXSmall: Math.max(getValueUsingPixelRatio(11, 17), 11),
     lineHeightFinePrint: 12,
     lineHeightSmall: getValueUsingPixelRatio(14, 16),
     lineHeightNormal: getValueUsingPixelRatio(16, 21),

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -30,6 +30,8 @@ const avatarSizes = {
 
 export default {
     bottomTabHeight: 72,
+    // styles.p3 (12) on each side of the DebugTabView row plus the View button (componentSizeNormal).
+    debugTabViewHeight: 64,
     contentHeaderHeight: getValueUsingPixelRatio(72, 100),
     contentHeaderDesktopHeight: getValueUsingPixelRatio(80, 100),
     componentSizeSmall: getValueUsingPixelRatio(28, 32),
@@ -65,6 +67,7 @@ export default {
     fontSizeMedium: getValueUsingPixelRatio(16, 22),
     fontSizeLarge: getValueUsingPixelRatio(17, 19),
     fontSizeHero: 36,
+    fontSizeH1: 19,
     fontSizeH2: 19,
     fontSizeXLarge: getValueUsingPixelRatio(22, 28),
     fontSizeXXLarge: 28,
@@ -159,9 +162,7 @@ export default {
     sectionMenuItemHeightCompact: 44,
     optionsListSectionHeaderHeight: getValueUsingPixelRatio(32, 38),
     overlayOpacity: 0.72,
-    // fontSizeExtraSmall is fixed at 9, so the line height must never scale below the font's natural line height (~1.18em = 10.62),
-    // otherwise Android clamps the descent and clips descenders and underlines at small device font scales.
-    lineHeightXSmall: Math.max(getValueUsingPixelRatio(11, 17), 11),
+    lineHeightXSmall: getValueUsingPixelRatio(11, 17),
     lineHeightFinePrint: 12,
     lineHeightSmall: getValueUsingPixelRatio(14, 16),
     lineHeightNormal: getValueUsingPixelRatio(16, 21),

--- a/tests/ui/BottomTabBarTest.tsx
+++ b/tests/ui/BottomTabBarTest.tsx
@@ -9,6 +9,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useRootNavigationState from '@hooks/useRootNavigationState';
 import {SidebarOrderedReportsContextProvider} from '@hooks/useSidebarOrderedReports';
+import useSidePanelDisplayStatus from '@hooks/useSidePanelDisplayStatus';
 
 import type Navigation from '@libs/Navigation/Navigation';
 import navigationRef from '@libs/Navigation/navigationRef';
@@ -53,6 +54,11 @@ const setMockFocusedTab = (tabName: string) => {
 jest.mock('@hooks/useResponsiveLayout', () => ({
     __esModule: true,
     default: jest.fn(),
+}));
+
+jest.mock('@hooks/useSidePanelDisplayStatus', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({shouldHideSidePanel: true})),
 }));
 
 jest.mock('@hooks/useWindowDimensions', () => jest.fn(() => ({windowWidth: 1280})));
@@ -198,7 +204,17 @@ describe('DebugTabView', () => {
 
     describe('Wide layout', () => {
         beforeEach(() => {
-            jest.mocked(useResponsiveLayout).mockReturnValue(createMock<ReturnType<typeof useResponsiveLayout>>({shouldUseNarrowLayout: false}));
+            jest.mocked(useResponsiveLayout).mockReturnValue(
+                createMock<ReturnType<typeof useResponsiveLayout>>({
+                    shouldUseNarrowLayout: false,
+                    isExtraLargeScreenWidth: false,
+                }),
+            );
+            jest.mocked(useSidePanelDisplayStatus).mockReturnValue(
+                createMock<ReturnType<typeof useSidePanelDisplayStatus>>({
+                    shouldHideSidePanel: true,
+                }),
+            );
             Onyx.set(ONYXKEYS.IS_DEBUG_MODE_ENABLED, true);
             Onyx.set(ONYXKEYS.LOGINS, {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -250,6 +266,55 @@ describe('DebugTabView', () => {
                     bottom: 0,
                     left: variables.navigationTabBarSize,
                     width: 1280 - variables.navigationTabBarSize,
+                }),
+            );
+        });
+
+        it('positions at full width for domains tab', async () => {
+            setMockFocusedTab(SCREENS.DOMAINS_LIST);
+
+            renderWithNavigation(<DebugTabView selectedTab={NAVIGATION_TABS.WORKSPACES} />);
+
+            const container = await screen.findByTestId('DebugTabViewContainer');
+            const style: unknown = container.props.style;
+            if (!Array.isArray(style)) {
+                throw new Error('Expected DebugTabViewContainer style to be an array.');
+            }
+            expect(style.at(0)).toEqual(
+                expect.objectContaining({
+                    bottom: 0,
+                    left: variables.navigationTabBarSize,
+                    width: 1280 - variables.navigationTabBarSize,
+                }),
+            );
+        });
+
+        it('excludes side panel width when Concierge is open on the workspaces root', async () => {
+            jest.mocked(useResponsiveLayout).mockReturnValue(
+                createMock<ReturnType<typeof useResponsiveLayout>>({
+                    shouldUseNarrowLayout: false,
+                    isExtraLargeScreenWidth: true,
+                }),
+            );
+            jest.mocked(useSidePanelDisplayStatus).mockReturnValue(
+                createMock<ReturnType<typeof useSidePanelDisplayStatus>>({
+                    shouldHideSidePanel: false,
+                }),
+            );
+            setMockFocusedTab(SCREENS.WORKSPACES_LIST);
+
+            renderWithNavigation(<DebugTabView selectedTab={NAVIGATION_TABS.WORKSPACES} />);
+
+            const container = await screen.findByTestId('DebugTabViewContainer');
+            const style: unknown = container.props.style;
+            if (!Array.isArray(style)) {
+                throw new Error('Expected DebugTabViewContainer style to be an array.');
+            }
+            expect(style.at(0)).toEqual(
+                expect.objectContaining({
+                    bottom: 0,
+                    left: variables.navigationTabBarSize,
+                    width: 1280 - variables.navigationTabBarSize - variables.sidePanelWidth,
                 }),
             );
         });

--- a/tests/unit/hooks/useDebugTabViewHeight.test.ts
+++ b/tests/unit/hooks/useDebugTabViewHeight.test.ts
@@ -1,0 +1,132 @@
+import {renderHook} from '@testing-library/react-native';
+
+import {useDebugTabViewHeight} from '@components/Navigation/DebugTabView';
+
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+
+import variables from '@styles/variables';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import Onyx from 'react-native-onyx';
+
+import createMock from '../../utils/createMock';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+
+jest.mock('@hooks/useResponsiveLayout', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+describe('useDebugTabViewHeight', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+        jest.clearAllMocks();
+        jest.mocked(useResponsiveLayout).mockReturnValue(
+            createMock<ReturnType<typeof useResponsiveLayout>>({
+                shouldUseNarrowLayout: false,
+            }),
+        );
+    });
+
+    afterEach(async () => {
+        await Onyx.clear();
+    });
+
+    it('returns debugTabViewHeight on wide layout with debug mode and a mapped indicator status', async () => {
+        await Onyx.multiSet({
+            [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: true,
+            [ONYXKEYS.LOGINS]: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1_foo@bar.com': {
+                    partnerID: 1,
+                    partnerUserID: 'foo@bar.com',
+                    errorFields: {
+                        addedLogin: {
+                            message: 'Partner name is missing!',
+                        },
+                    },
+                },
+            },
+        });
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDebugTabViewHeight());
+
+        expect(result.current).toBe(variables.debugTabViewHeight);
+    });
+
+    it('returns 0 when debug mode is off', async () => {
+        await Onyx.multiSet({
+            [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: false,
+            [ONYXKEYS.LOGINS]: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1_foo@bar.com': {
+                    partnerID: 1,
+                    partnerUserID: 'foo@bar.com',
+                    errorFields: {
+                        addedLogin: {
+                            message: 'Partner name is missing!',
+                        },
+                    },
+                },
+            },
+        });
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDebugTabViewHeight());
+
+        expect(result.current).toBe(0);
+    });
+
+    it('returns 0 on narrow layout', async () => {
+        jest.mocked(useResponsiveLayout).mockReturnValue(
+            createMock<ReturnType<typeof useResponsiveLayout>>({
+                shouldUseNarrowLayout: true,
+            }),
+        );
+
+        await Onyx.multiSet({
+            [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: true,
+            [ONYXKEYS.LOGINS]: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1_foo@bar.com': {
+                    partnerID: 1,
+                    partnerUserID: 'foo@bar.com',
+                    errorFields: {
+                        addedLogin: {
+                            message: 'Partner name is missing!',
+                        },
+                    },
+                },
+            },
+        });
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDebugTabViewHeight());
+
+        expect(result.current).toBe(0);
+    });
+
+    it('returns 0 for a truthy status with no mapped debug message', async () => {
+        await Onyx.multiSet({
+            [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: true,
+            [ONYXKEYS.PRIVATE_PERSONAL_DETAILS]: {
+                errorFields: {
+                    phoneNumber: CONST.ERROR.API_EXCEPTION,
+                },
+            },
+        });
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useDebugTabViewHeight());
+
+        expect(result.current).toBe(0);
+    });
+});

--- a/tests/unit/hooks/useDebugTabViewHeight.test.ts
+++ b/tests/unit/hooks/useDebugTabViewHeight.test.ts
@@ -1,6 +1,6 @@
 import {renderHook} from '@testing-library/react-native';
 
-import {useDebugTabViewHeight} from '@components/Navigation/DebugTabView';
+import {getSettingsMessage, useDebugTabViewHeight} from '@components/Navigation/DebugTabView';
 
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 
@@ -119,7 +119,7 @@ describe('useDebugTabViewHeight', () => {
             [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: true,
             [ONYXKEYS.PRIVATE_PERSONAL_DETAILS]: {
                 errorFields: {
-                    phoneNumber: CONST.ERROR.API_EXCEPTION,
+                    phoneNumber: {error: 'Invalid phone number'},
                 },
             },
         });
@@ -127,6 +127,7 @@ describe('useDebugTabViewHeight', () => {
 
         const {result} = renderHook(() => useDebugTabViewHeight());
 
+        expect(getSettingsMessage(CONST.INDICATOR_STATUS.HAS_PHONE_NUMBER_ERROR)).toBeUndefined();
         expect(result.current).toBe(0);
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
On wide layout the debug banner (`DebugTabView`) is absolutely positioned at the bottom while `WorkspaceListLayout` never reserves its height, so the last Workspaces row sits underneath. Domains used the wrong geometry because `DOMAINS_LIST` was missing from the full-width whitelist (319px sidebar bar on a page with no sidebar). With Concierge open, banner width ignored the side-panel inset and ran under the panel.

This PR corrects the geometry (both Workspaces + Domains roots, subtract side panel when open) and reserves a fixed 64px in `WorkspaceListLayout` so both lists and the offline indicator clear the banner.

### Fixed Issues
$ https://github.com/Expensify/App/issues/99976
PROPOSAL: https://github.com/Expensify/App/issues/99976#issuecomment-5545281751

### Precondition
- Sign in with an account that has a **failed subscription** (red account indicator; debug banner message: *"There's a billing problem with your subscription"*)
- Use **wide desktop** Chrome or Safari (window width **> 800px**)

### Tests
1. Open Test Tools (`Ctrl+D` / `Cmd+D`) and enable **Debug mode**
2. Go to **Workspaces → Workspaces**, scroll to the bottom — verify the **last workspace row is fully visible** above the debug banner (not covered)
3. Go to **Workspaces → Domains** — verify the debug banner **spans the full content width** and does **not overlap** the bottom of the list
4. With window width **> 1300px**, open **Concierge** — verify the debug banner **ends at the side panel edge** and the **View** button stays visible (not hidden under Concierge)
5. Turn **Debug mode** off — verify **no blank spacer** appears at the bottom of Workspaces or Domains
6. Narrow the window to **mobile width (≤ 800px)** — verify **no regression** (banner stays in-flow; list content is not overlapped)

- [x] Verify that no errors appear in the JS console

### Offline tests
**Precondition:** Same as Tests (failed subscription account, wide desktop, Debug mode on)

1. Go to **Workspaces → Workspaces**
2. Open Test Tools and enable **Force offline**
3. Verify **"You appear to be offline"** is fully visible **above** the debug banner (not covered by it)
4. Repeat on **Workspaces → Domains**
5. Disable Force offline

- [x] Verify that no errors appear in the JS console

### QA Steps

**Precondition**
- Account with failed subscription (banner: billing problem message)
- Wide desktop Chrome/Safari (> 800px)

**Steps**
1. Enable Debug mode (Test Tools)
2. Workspaces list: scroll to bottom — last row visible above banner
3. Domains list: banner full width, no bottom overlap
4. Window > 1300px + Concierge open — banner stops at panel edge, View button visible
5. Debug mode off — no empty spacer on Workspaces/Domains
6. Mobile width — no overlap regression
7. Force offline on Workspaces — offline message visible above banner
8. Force offline on Domains — offline message visible above banner

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/c93f777b-c773-4b47-a540-26746052b9a0



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/1dafdfe8-7ab0-4f82-8dd4-ab99d246c209



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/8d5693db-a4df-4455-a817-f07924459bcd

<img width="320" height="596" alt="Screenshot 2026-09-14 at 1 03 46 AM" src="https://github.com/user-attachments/assets/1f184063-d507-4a75-ab99-52654bb9e4e1" />


</details>

<details>
<summary>iOS: mWeb Safari</summary>



https://github.com/user-attachments/assets/bf5185c9-1495-4be7-bc65-4917873969a8

<img width="320" height="596" alt="Screenshot 2026-09-14 at 1 03 15 AM" src="https://github.com/user-attachments/assets/efdc1bb6-c57f-4db8-abb8-c5a998e0d7ba" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

**Workspaces / Domains — before vs after**

| Before | After |
|:-------------------:|:-----------------------------:|
| <video src="https://github.com/user-attachments/assets/e4a289c4-a09c-48ec-aa3e-f4a10b121cfa" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/37267b53-bd3e-4516-bb8b-98d327fbc617" controls width="100%"></video> |

**Concierge side panel (>1300px) — before vs after**

| Before | After |
|:---------------------------:|:--------------------------:|
| <video src="https://github.com/user-attachments/assets/80d4974e-ad41-484c-98c7-1298e3a95642" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/3ab76be5-21af-4c45-ba8c-ff085224d816" controls width="100%"></video> |

</details>
