### PR TITLE
Remove unsafe assertions from navigation and debug helpers

### DIFF
--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -1,5 +1,6 @@
 import getInitialSplitNavigatorState from '@libs/Navigation/AppNavigator/createSplitNavigator/getInitialSplitNavigatorState';
 import TAB_SCREENS from '@libs/Navigation/AppNavigator/Navigators/TAB_SCREENS';
+import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
 import {
     RHP_TO_DOMAIN,
     RHP_TO_HOME,
@@ -10,18 +11,18 @@ import {
     RHP_TO_WORKSPACE,
     RHP_TO_WORKSPACES_LIST,
 } from '@libs/Navigation/linkingConfig/RELATIONS';
-import type {NavigationPartialRoute, NavigationRoute, RootNavigatorParamList} from '@libs/Navigation/types';
+import type {NavigationPartialRoute, NavigationRoute} from '@libs/Navigation/types';
+import {hasKey} from '@libs/ObjectUtils';
 import {getReportOrDraftReport} from '@libs/ReportUtils';
 import {getSearchParamFromPath} from '@libs/Url';
 
 import NAVIGATORS from '@src/NAVIGATORS';
-import type {Route as RoutePath} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
-import type {Screen} from '@src/SCREENS';
 
 import type {NavigationState, PartialState, getStateFromPath as RNGetStateFromPath, Route} from '@react-navigation/native';
 
+import {findFocusedRoute} from '@react-navigation/native';
 import pick from 'lodash/pick';
 
 import buildTabNavigatorNestedState from './buildTabNavigatorNestedState';
@@ -36,7 +37,6 @@ import getParamsFromRoute from './getParamsFromRoute';
 import getStateFromPath from './getStateFromPath';
 import {isFullScreenName} from './isNavigatorName';
 import normalizePath from './normalizePath';
-import replacePathInNestedState from './replacePathInNestedState';
 
 type GetAdaptedStateReturnType = ReturnType<typeof getStateFromPath>;
 
@@ -89,14 +89,14 @@ function isRouteWithReportID(route: NavigationRoute): route is Route<string, {re
  *   without changing the page currently underneath.
  */
 function getMatchingFullScreenRoute(route: NavigationRoute, isDeeplink = false) {
-    const isDynamicScreen = isDynamicRouteScreen(route.name as Screen);
+    const isDynamicScreen = hasKey(normalizedConfigs, route.name) && isDynamicRouteScreen(route.name);
 
     // Check for backTo param. One screen with different backTo value may need different screens visible under the overlay.
     // Dynamic screens are skipped here because they never carry their own backTo - they only
     // inherit it from the screen underneath. Letting backTo dictate the full-screen route for
     // a dynamic screen would resolve the wrong page.
     if (isRouteWithBackToParam(route) && !isDynamicScreen) {
-        const stateForBackTo = getStateFromPath(route.params.backTo as RoutePath);
+        const stateForBackTo = getStateFromPath(route.params.backTo);
 
         // This may happen if the backTo url is invalid.
         const lastRoute = stateForBackTo?.routes.at(-1);
@@ -314,12 +314,12 @@ function getOnboardingAdaptedState(state: PartialState<NavigationState>): Partia
     return getRoutesWithIndex(routes);
 }
 
-function getAdaptedState(state: PartialState<NavigationState<RootNavigatorParamList>>): GetAdaptedStateReturnType {
+function getAdaptedState(state: PartialState<NavigationState>): GetAdaptedStateReturnType {
     let currentState = state;
     const fullScreenRoute = currentState.routes.find((route) => isFullScreenName(route.name));
 
     if (fullScreenRoute?.name === NAVIGATORS.TAB_NAVIGATOR) {
-        let tabState = fullScreenRoute.state as PartialState<NavigationState> | undefined;
+        let tabState = fullScreenRoute.state;
 
         // RN's getStateFromPath emits only the tab matched by the path, so the TAB_NAVIGATOR strip may be sparse.
         // Rebuild the full strip around the active tab — consumers (e.g. REPLACE_FULLSCREEN_UNDER_RHP) expect every tab to be present.
@@ -327,7 +327,7 @@ function getAdaptedState(state: PartialState<NavigationState<RootNavigatorParamL
         if (tabState?.routes && tabState.routes.length < TAB_SCREENS.length) {
             const activeTabRoute = tabState.routes.at(tabState.index ?? tabState.routes.length - 1);
             if (activeTabRoute) {
-                tabState = getTabNavigatorState(activeTabRoute as NavigationPartialRoute).state;
+                tabState = getTabNavigatorState(activeTabRoute).state;
                 const normalizedRoutes = currentState.routes.map((r) => (r === fullScreenRoute ? {...r, state: tabState} : r));
                 currentState = {...currentState, routes: normalizedRoutes};
             }
@@ -336,19 +336,19 @@ function getAdaptedState(state: PartialState<NavigationState<RootNavigatorParamL
         // If TAB_NAVIGATOR contains WORKSPACE_NAVIGATOR, ensure WORKSPACES_LIST is in its nested state
         const wsNavRoute = tabState?.routes?.find((r) => r.name === NAVIGATORS.WORKSPACE_NAVIGATOR);
         if (wsNavRoute) {
-            const wsNavState = wsNavRoute.state as PartialState<NavigationState> | undefined;
+            const wsNavState = wsNavRoute.state;
             const hasWorkspacesList = wsNavState?.routes?.some((r) => r.name === SCREENS.WORKSPACES_LIST);
 
             if (!hasWorkspacesList && wsNavState?.routes?.length) {
                 const updatedNestedState = getRoutesWithIndex([{name: SCREENS.WORKSPACES_LIST}, ...(wsNavState.routes ?? [])]);
                 const updatedWsNavRoute = {...wsNavRoute, state: updatedNestedState};
-                const updatedTabRoutes = (tabState?.routes ?? []).map((r) => (r.name === NAVIGATORS.WORKSPACE_NAVIGATOR ? updatedWsNavRoute : r)) as NavigationPartialRoute[];
+                const updatedTabRoutes = (tabState?.routes ?? []).map((r) => (r.name === NAVIGATORS.WORKSPACE_NAVIGATOR ? updatedWsNavRoute : r));
                 const updatedTabState = {...tabState, routes: updatedTabRoutes};
                 const updatedFullScreenRoute = {
                     ...fullScreenRoute,
                     state: updatedTabState,
                 };
-                const updatedRoutes = currentState.routes.map((r) => (r.name === NAVIGATORS.TAB_NAVIGATOR ? updatedFullScreenRoute : r)) as NavigationPartialRoute[];
+                const updatedRoutes = currentState.routes.map((r) => (r.name === NAVIGATORS.TAB_NAVIGATOR ? updatedFullScreenRoute : r));
                 return getRoutesWithIndex(updatedRoutes);
             }
         }
@@ -358,8 +358,8 @@ function getAdaptedState(state: PartialState<NavigationState<RootNavigatorParamL
     if (!fullScreenRoute) {
         const focusedRoute = findFocusedRouteWithOnyxTabGuard(currentState);
 
-        if (focusedRoute?.path && isDynamicRouteScreen(focusedRoute.name as Screen)) {
-            currentState = getDynamicRouteAdaptedState(currentState, focusedRoute.path) as PartialState<NavigationState<RootNavigatorParamList>>;
+        if (focusedRoute?.path && hasKey(normalizedConfigs, focusedRoute.name) && isDynamicRouteScreen(focusedRoute.name)) {
+            currentState = getDynamicRouteAdaptedState(currentState, focusedRoute.path);
 
             // getDynamicRouteAdaptedState may have already resolved the full screen route.
             // In that case, skip the default full screen route injection below - the state is already complete.
@@ -432,9 +432,12 @@ const getAdaptedStateFromPath: GetAdaptedStateFromPath = (path, options, shouldR
     let normalizedPath = !path.startsWith('/') ? `/${path}` : path;
     normalizedPath = getMatchingNewRoute(normalizedPath) ?? normalizedPath;
 
-    const state = getStateFromPath(normalizedPath as RoutePath) as PartialState<NavigationState<RootNavigatorParamList>>;
+    const state = getStateFromPath(normalizedPath);
     if (shouldReplacePathInNestedState) {
-        replacePathInNestedState(state, normalizedPath);
+        const focusedRoute = findFocusedRoute(state);
+        if (focusedRoute) {
+            focusedRoute.path = normalizedPath;
+        }
     }
 
     if (state === undefined) {

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -1,8 +1,9 @@
 import Log from '@libs/Log';
 import {config, normalizedConfigs, screensWithOnyxTabNavigator} from '@libs/Navigation/linkingConfig/config';
 import type {State} from '@libs/Navigation/types';
+import {hasKey} from '@libs/ObjectUtils';
 
-import type {Screen} from '@src/SCREENS';
+import type {NavigationState, PartialState} from '@react-navigation/native';
 
 import {getPathFromState as RNGetPathFromState} from '@react-navigation/native';
 
@@ -10,10 +11,6 @@ import getDynamicRouteQueryParams from './dynamicRoutesUtils/getDynamicRouteQuer
 import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
 import splitPathAndQuery from './dynamicRoutesUtils/splitPathAndQuery';
 import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
-
-function isScreen(name: string): name is Screen {
-    return name in normalizedConfigs;
-}
 
 /**
  * Resolves a single path segment: if it's a `:param` placeholder, replaces it
@@ -80,6 +77,9 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
  *
  * @private - Internal helper. Do not export or use outside this file.
  */
+function popFocusedRoute(state: NavigationState): NavigationState | undefined;
+function popFocusedRoute(state: PartialState<NavigationState>): PartialState<NavigationState> | undefined;
+function popFocusedRoute(state: State): State | undefined;
 function popFocusedRoute(state: State): State | undefined {
     const index = state.index ?? state.routes.length - 1;
     const focusedRoute = state.routes[index];
@@ -92,21 +92,34 @@ function popFocusedRoute(state: State): State | undefined {
     // the focused route has nested state - try to pop from deeper levels first,
     // unless it hosts an OnyxTabNavigator (treat it as a leaf).
     if (focusedRoute.state && focusedRoute.name && !screensWithOnyxTabNavigator.has(focusedRoute.name)) {
-        const nestedResult = popFocusedRoute(focusedRoute.state as State);
-
-        // A deeper route was successfully popped - rebuild the current level with the updated nested state.
-        if (nestedResult) {
-            const newRoutes = [...state.routes] as typeof state.routes;
-            // @ts-expect-error -- we're rebuilding a structurally identical route with updated nested state
-            newRoutes[index] = {...focusedRoute, state: nestedResult};
-            return {...state, routes: newRoutes, index} as State;
+        // Rebuild from the narrowed state to preserve full and partial route categories.
+        if (state.stale === false) {
+            const nestedResult = popFocusedRoute(focusedRoute.state);
+            const fullFocusedRoute = state.routes.at(index);
+            if (nestedResult && fullFocusedRoute) {
+                const newRoutes = [...state.routes];
+                newRoutes[index] = {...fullFocusedRoute, state: nestedResult};
+                return {...state, routes: newRoutes, index};
+            }
+        } else {
+            const partialFocusedRoute = state.routes.at(index);
+            const nestedResult = partialFocusedRoute?.state ? popFocusedRoute(partialFocusedRoute.state) : undefined;
+            if (nestedResult && partialFocusedRoute) {
+                const newRoutes = [...state.routes];
+                newRoutes[index] = {...partialFocusedRoute, state: nestedResult};
+                return {...state, routes: newRoutes, index};
+            }
         }
     }
 
     // remove the focused route itself if siblings remain.
     if (state.routes.length > 1) {
+        if (state.stale === false) {
+            const newRoutes = state.routes.filter((_, i) => i !== index);
+            return {...state, routes: newRoutes, index: newRoutes.length - 1};
+        }
         const newRoutes = state.routes.filter((_, i) => i !== index);
-        return {...state, routes: newRoutes, index: newRoutes.length - 1} as State;
+        return {...state, routes: newRoutes, index: newRoutes.length - 1};
     }
 
     // Only one route at this level and nothing deeper to pop — signal the parent to remove this level entirely.
@@ -125,13 +138,13 @@ function popFocusedRoute(state: State): State | undefined {
 function getPathFromStateWithDynamicRoute(state: State): string {
     const focusedRoute = findFocusedRouteWithOnyxTabGuard(state);
     const screenName = focusedRoute?.name ?? '';
-    const suffixPattern = normalizedConfigs[screenName as Screen]?.path;
+    const suffixPattern = hasKey(normalizedConfigs, screenName) ? normalizedConfigs[screenName]?.path : undefined;
 
     if (!suffixPattern) {
         return RNGetPathFromState(state, config);
     }
 
-    let actualSuffix = buildSuffixFromPattern(suffixPattern, focusedRoute?.params as Record<string, unknown> | undefined);
+    let actualSuffix = buildSuffixFromPattern(suffixPattern, focusedRoute?.params ? {...focusedRoute.params} : undefined);
 
     // If this dynamic screen hosts a tab navigator, append the focused tab's path segment.
     if (screensWithOnyxTabNavigator.has(screenName)) {
@@ -139,7 +152,7 @@ function getPathFromStateWithDynamicRoute(state: State): string {
         if (tabState) {
             const tabIndex = tabState.index ?? tabState.routes.length - 1;
             const focusedTab = tabState.routes[tabIndex];
-            const tabPath = focusedTab && isScreen(focusedTab.name) ? normalizedConfigs[focusedTab.name]?.path : undefined;
+            const tabPath = focusedTab && hasKey(normalizedConfigs, focusedTab.name) ? normalizedConfigs[focusedTab.name]?.path : undefined;
             if (tabPath) {
                 const [suffixPathOnly, suffixQueryOnly] = splitPathAndQuery(actualSuffix);
                 actualSuffix = `${suffixPathOnly}/${tabPath}${suffixQueryOnly ? `?${suffixQueryOnly}` : ''}`;
@@ -184,7 +197,7 @@ function getPathFromState(state: State): string {
     const focusedRoute = findFocusedRouteWithOnyxTabGuard(state);
     const screenName = focusedRoute?.name ?? '';
 
-    return isDynamicRouteScreen(screenName as Screen) ? getPathFromStateWithDynamicRoute(state) : RNGetPathFromState(state, config);
+    return hasKey(normalizedConfigs, screenName) && isDynamicRouteScreen(screenName) ? getPathFromStateWithDynamicRoute(state) : RNGetPathFromState(state, config);
 }
 
 export default getPathFromState;

--- a/src/libs/Navigation/helpers/getStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getStateFromPath.ts
@@ -1,7 +1,6 @@
 import Log from '@libs/Log';
 import {linkingConfig} from '@libs/Navigation/linkingConfig';
 
-import type {Route} from '@src/ROUTES';
 import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
 import SCREENS from '@src/SCREENS';
@@ -20,7 +19,7 @@ import getMatchingNewRoute from './getMatchingNewRoute';
  * @param path - The path to parse
  * @returns - It's possible that there is no navigation action for the given path
  */
-function getStateFromPath(path: Route): PartialState<NavigationState> {
+function getStateFromPath(path: string): PartialState<NavigationState> {
     const normalizedPath = !path.startsWith('/') ? `/${path}` : path;
     const normalizedPathAfterRedirection = getMatchingNewRoute(normalizedPath) ?? normalizedPath;
 

--- a/src/libs/Navigation/helpers/linkTo/getMinimalAction.ts
+++ b/src/libs/Navigation/helpers/linkTo/getMinimalAction.ts
@@ -3,8 +3,6 @@ import type {State} from '@navigation/types';
 import type {NavigationAction, NavigationState} from '@react-navigation/native';
 import type {Writable} from 'type-fest';
 
-import type {ActionPayload} from './types';
-
 type MinimalAction = {
     action: Writable<NavigationAction>;
     targetState: State | undefined;
@@ -30,15 +28,15 @@ function getMinimalAction(action: NavigationAction, state: NavigationState): Min
         currentState = currentState?.routes[currentState.index ?? -1].state;
         currentTargetKey = currentState?.key;
 
-        const payload = currentAction.payload as ActionPayload;
+        const params = 'params' in currentAction.payload && typeof currentAction.payload.params === 'object' ? currentAction.payload.params : undefined;
 
         // Creating new smaller action
         currentAction = {
             type: currentAction.type,
             payload: {
-                name: payload?.params?.screen,
-                params: payload?.params?.params,
-                path: payload?.params?.path,
+                name: params && 'screen' in params ? params.screen : undefined,
+                params: params && 'params' in params ? params.params : undefined,
+                path: params && 'path' in params ? params.path : undefined,
             },
             target: currentTargetKey,
         };

--- a/src/libs/Navigation/helpers/linkTo/index.ts
+++ b/src/libs/Navigation/helpers/linkTo/index.ts
@@ -3,11 +3,10 @@ import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
 import normalizePath from '@libs/Navigation/helpers/normalizePath';
 import {getTabState} from '@libs/Navigation/helpers/tabNavigatorUtils';
 import {linkingConfig} from '@libs/Navigation/linkingConfig';
-import type {PlatformStackNavigationState} from '@libs/Navigation/PlatformStackNavigation/types';
 import {shallowCompare} from '@libs/ObjectUtils';
 
 import getMatchingNewRoute from '@navigation/helpers/getMatchingNewRoute';
-import type {NavigationPartialRoute, ReportsSplitNavigatorParamList, RootNavigatorParamList, StackNavigationAction} from '@navigation/types';
+import type {NavigationPartialRoute, NavigationRoute, RootNavigatorParamList, StackNavigationAction} from '@navigation/types';
 
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
@@ -19,9 +18,11 @@ import type {NavigationContainerRef, NavigationState, PartialState} from '@react
 import {getActionFromState} from '@react-navigation/core';
 import {CommonActions, findFocusedRoute} from '@react-navigation/native';
 
-import type {ActionPayloadParams, LinkToOptions} from './types';
+import type {LinkToOptions} from './types';
 
 import getMinimalAction from './getMinimalAction';
+
+type FullScreenRoute = Omit<NavigationPartialRoute, 'state'> & Pick<NavigationRoute, 'state'>;
 
 const defaultLinkToOptions: LinkToOptions = {
     forceReplace: false,
@@ -33,17 +34,17 @@ const defaultLinkToOptions: LinkToOptions = {
  */
 const ROOT_TAB_SCREENS = new Set<string>([SCREENS.HOME, SCREENS.INBOX, SCREENS.SEARCH.ROOT, SCREENS.SETTINGS.ROOT, SCREENS.WORKSPACES_LIST]);
 
-function areNamesAndParamsEqual(currentState: NavigationState<RootNavigatorParamList>, stateFromPath: PartialState<NavigationState<RootNavigatorParamList>>) {
+function areNamesAndParamsEqual(currentState: NavigationState, stateFromPath: PartialState<NavigationState>) {
     const currentFocusedRoute = findFocusedRoute(currentState);
     const targetFocusedRoute = findFocusedRoute(stateFromPath);
 
     const areNamesEqual = currentFocusedRoute?.name === targetFocusedRoute?.name;
-    const areParamsEqual = shallowCompare(currentFocusedRoute?.params as Record<string, unknown> | undefined, targetFocusedRoute?.params as Record<string, unknown> | undefined);
+    const areParamsEqual = shallowCompare(currentFocusedRoute?.params ? {...currentFocusedRoute.params} : undefined, targetFocusedRoute?.params ? {...targetFocusedRoute.params} : undefined);
 
     return areNamesEqual && areParamsEqual;
 }
 
-function arePathAndBackToEqual(stateFromPath: PartialState<NavigationState<RootNavigatorParamList>>) {
+function arePathAndBackToEqual(stateFromPath: PartialState<NavigationState>) {
     const focusedRouteFromPath = findFocusedRoute(stateFromPath);
     const params = focusedRouteFromPath?.params ?? {};
 
@@ -66,15 +67,22 @@ function isNavigatingToAttachmentScreen(focusedRouteName?: string) {
     return focusedRouteName === SCREENS.REPORT_ATTACHMENTS;
 }
 
+function getReportNavigationIDs(params: NavigationPartialRoute['params']) {
+    return {
+        reportID: params && 'reportID' in params ? params.reportID : undefined,
+        reportActionID: params && 'reportActionID' in params ? params.reportActionID : undefined,
+    };
+}
+
 function isNavigatingToReportWithSameReportID(currentRoute: NavigationPartialRoute, newRoute: NavigationPartialRoute) {
     if (currentRoute.name !== SCREENS.REPORT || newRoute.name !== SCREENS.REPORT) {
         return false;
     }
 
-    const currentParams = currentRoute.params as ReportsSplitNavigatorParamList[typeof SCREENS.REPORT];
-    const newParams = newRoute?.params as ReportsSplitNavigatorParamList[typeof SCREENS.REPORT];
+    const currentParams = getReportNavigationIDs(currentRoute.params);
+    const newParams = getReportNavigationIDs(newRoute.params);
 
-    return currentParams?.reportID === newParams?.reportID;
+    return currentParams.reportID === newParams.reportID;
 }
 
 function isNavigatingToReportActionWithinSameReport(currentRoute: NavigationPartialRoute, newRoute: NavigationPartialRoute) {
@@ -82,17 +90,17 @@ function isNavigatingToReportActionWithinSameReport(currentRoute: NavigationPart
         return false;
     }
 
-    const currentParams = currentRoute.params as ReportsSplitNavigatorParamList[typeof SCREENS.REPORT];
-    const newParams = newRoute?.params as ReportsSplitNavigatorParamList[typeof SCREENS.REPORT];
+    const currentParams = getReportNavigationIDs(currentRoute.params);
+    const newParams = getReportNavigationIDs(newRoute.params);
 
-    return currentParams?.reportID === newParams?.reportID && currentParams.reportActionID !== newParams.reportActionID;
+    return currentParams.reportID === newParams.reportID && currentParams.reportActionID !== newParams.reportActionID;
 }
 
 /**
  * Returns true when both current and target states are within TabNavigator (tab switching).
  * In this case we must keep NAVIGATE (not PUSH) because tab navigators use jumpTo/navigate.
  */
-function isSwitchingTabsWithinTabNavigator(currentState: NavigationState<RootNavigatorParamList>, stateFromPath: PartialState<NavigationState<RootNavigatorParamList>>) {
+function isSwitchingTabsWithinTabNavigator(currentState: NavigationState, stateFromPath: PartialState<NavigationState>) {
     const lastFullScreenRoute = currentState.routes.findLast((route) => isFullScreenName(route.name));
     const targetFullScreenRoute = stateFromPath.routes?.findLast((route) => isFullScreenName(route.name));
 
@@ -103,7 +111,7 @@ function isSwitchingTabsWithinTabNavigator(currentState: NavigationState<RootNav
  * For TAB_NAVIGATOR routes, returns the focused (active) tab screen name.
  * For other routes, returns the last nested route name (original behavior).
  */
-function getActiveScreenInRoute(route: NavigationPartialRoute): string | undefined {
+function getActiveScreenInRoute(route: FullScreenRoute): string | undefined {
     const tabState = getTabState(route);
     if (tabState) {
         const index = tabState.index ?? 0;
@@ -112,11 +120,7 @@ function getActiveScreenInRoute(route: NavigationPartialRoute): string | undefin
     return route.state?.routes?.at(-1)?.name;
 }
 
-function shouldChangeToMatchingFullScreen(
-    newFocusedRoute: ReturnType<typeof findFocusedRoute>,
-    matchingFullScreenRoute: NavigationPartialRoute,
-    lastFullScreenRoute: NavigationPartialRoute,
-) {
+function shouldChangeToMatchingFullScreen(newFocusedRoute: ReturnType<typeof findFocusedRoute>, matchingFullScreenRoute: FullScreenRoute, lastFullScreenRoute: FullScreenRoute) {
     if (matchingFullScreenRoute.name !== lastFullScreenRoute.name) {
         return true;
     }
@@ -138,9 +142,7 @@ function shouldChangeToMatchingFullScreen(
  * Preserves nested split state under `params.state`, where React Navigation expects it.
  * Omitting it rebuilds the workspace split without its policy-scoped route history.
  */
-function getMatchingFullScreenRouteParams(
-    matchingFullScreenRoute: NavigationPartialRoute,
-): NavigationPartialRoute['params'] | {screen: string; params: NavigationPartialRoute['params'] | undefined} {
+function getMatchingFullScreenRouteParams(matchingFullScreenRoute: FullScreenRoute): FullScreenRoute['params'] | {screen: string; params: FullScreenRoute['params'] | undefined} {
     const lastRoute = matchingFullScreenRoute.state?.routes?.at(-1);
     if (!lastRoute) {
         return matchingFullScreenRoute.params;
@@ -159,17 +161,16 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
         throw new Error("Couldn't find a navigation object. Is your component inside a screen in a navigator?");
     }
 
-    // We know that the options are always defined because we have default options.
-    const {forceReplace} = {...defaultLinkToOptions, ...options} as Required<LinkToOptions>;
+    const {forceReplace} = {...defaultLinkToOptions, ...options};
 
-    const normalizedPath = normalizePath(path) as Route;
-    const normalizedPathAfterRedirection = (getMatchingNewRoute(normalizedPath) ?? normalizedPath) as Route;
+    const normalizedPath = normalizePath(path);
+    const normalizedPathAfterRedirection = getMatchingNewRoute(normalizedPath) ?? normalizedPath;
 
     // This is the state generated with the default getStateFromPath function.
     // It won't include the whole state that will be generated for this path but the focused route will be correct.
     // It is necessary because getActionFromState will generate RESET action for whole state generated with our custom getStateFromPath function.
-    const stateFromPath = getStateFromPath(normalizedPathAfterRedirection) as PartialState<NavigationState<RootNavigatorParamList>>;
-    const currentState = navigation.getRootState() as PlatformStackNavigationState<RootNavigatorParamList>;
+    const stateFromPath = getStateFromPath(normalizedPathAfterRedirection);
+    const currentState = navigation.getRootState();
 
     const focusedRouteFromPath = findFocusedRoute(stateFromPath);
     const currentFocusedRoute = findFocusedRoute(currentState);
@@ -191,8 +192,6 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
     if (areNamesAndParamsEqual(currentState, stateFromPath) || arePathAndBackToEqual(stateFromPath)) {
         return;
     }
-
-    const typedPayload = (action as {payload: {name?: string; params?: ActionPayloadParams}}).payload;
 
     if (forceReplace) {
         action.type = CONST.NAVIGATION.ACTION_TYPE.REPLACE;
@@ -221,18 +220,18 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
     // When something other than TAB_NAVIGATOR is on top of the stack and we're navigating
     // to TAB_NAVIGATOR, PUSH a new instance above (e.g., above RHP).
     const currentTopRoute = currentState.routes[currentState.index];
-    if (currentTopRoute?.name !== NAVIGATORS.TAB_NAVIGATOR && typedPayload.name === NAVIGATORS.TAB_NAVIGATOR) {
-        (action as {type: string}).type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
+    if (currentTopRoute?.name !== NAVIGATORS.TAB_NAVIGATOR && 'payload' in action && action.payload && 'name' in action.payload && action.payload.name === NAVIGATORS.TAB_NAVIGATOR) {
+        action.type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
     }
 
     // Cross-tab navigation to a deep leaf (e.g. Settings → Concierge): PUSH a new TAB_NAVIGATOR so
     // swipe-back reveals the original tab. Skipped when the target is a tab root (plain tab switch).
-    const targetTopRoute = stateFromPath.routes?.at(-1) as NavigationPartialRoute | undefined;
-    const currentActiveScreen = currentTopRoute?.name === NAVIGATORS.TAB_NAVIGATOR ? getActiveScreenInRoute(currentTopRoute as NavigationPartialRoute) : undefined;
+    const targetTopRoute = stateFromPath.routes?.at(-1);
+    const currentActiveScreen = currentTopRoute?.name === NAVIGATORS.TAB_NAVIGATOR ? getActiveScreenInRoute(currentTopRoute) : undefined;
     const targetActiveScreen = targetTopRoute?.name === NAVIGATORS.TAB_NAVIGATOR ? getActiveScreenInRoute(targetTopRoute) : undefined;
     const isTargetAtTabRoot = ROOT_TAB_SCREENS.has(focusedRouteFromPath?.name ?? '');
     if (currentActiveScreen && targetActiveScreen && currentActiveScreen !== targetActiveScreen && !isTargetAtTabRoot) {
-        (action as {type: string}).type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
+        action.type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
         navigation.dispatch(action);
         return;
     }
@@ -247,12 +246,12 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
             // actual inner tab route (e.g. REPORTS_SPLIT_NAVIGATOR) at the correct index.
             const matchingTabNavigatorRoute = getMatchingFullScreenRoute(newFocusedRoute);
             const matchingTabState = matchingTabNavigatorRoute ? getTabState(matchingTabNavigatorRoute) : undefined;
-            const matchingFullScreenRoute = matchingTabState ? (matchingTabState.routes?.at(matchingTabState.index ?? 0) as NavigationPartialRoute | undefined) : undefined;
+            const matchingFullScreenRoute: FullScreenRoute | undefined = matchingTabState ? matchingTabState.routes?.at(matchingTabState.index ?? 0) : undefined;
             // Full-screen routes only exist inside TAB_NAVIGATOR, so look at the active tab directly.
             const tabRoute = currentState.routes.findLast((route) => route.name === NAVIGATORS.TAB_NAVIGATOR);
-            const tabState = tabRoute ? getTabState(tabRoute as NavigationPartialRoute) : undefined;
+            const tabState = tabRoute ? getTabState(tabRoute) : undefined;
             const tabNavigatorStateKey = tabRoute?.state?.key;
-            const lastFullScreenRoute = tabState?.routes?.at(tabState.index ?? 0) as NavigationPartialRoute | undefined;
+            const lastFullScreenRoute: FullScreenRoute | undefined = tabState?.routes?.at(tabState.index ?? 0);
             if (matchingFullScreenRoute && lastFullScreenRoute && shouldChangeToMatchingFullScreen(newFocusedRoute, matchingFullScreenRoute, lastFullScreenRoute)) {
                 const matchingFullScreenRouteInTabRootState = tabState?.routes?.find((route) => route.name === matchingFullScreenRoute.name);
                 if (matchingFullScreenRouteInTabRootState && matchingFullScreenRouteInTabRootState.state === undefined) {
@@ -283,11 +282,8 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
     }
 
     const {action: minimalAction} = getMinimalAction(action, navigation.getRootState());
-    if (
-        action.type === CONST.NAVIGATION.ACTION_TYPE.NAVIGATE &&
-        action.payload.name === NAVIGATORS.TAB_NAVIGATOR &&
-        !isFullScreenName((minimalAction.payload as {name?: string} | undefined)?.name)
-    ) {
+    const minimalActionName = minimalAction.payload && 'name' in minimalAction.payload && typeof minimalAction.payload.name === 'string' ? minimalAction.payload.name : undefined;
+    if (action.type === CONST.NAVIGATION.ACTION_TYPE.NAVIGATE && action.payload.name === NAVIGATORS.TAB_NAVIGATOR && !isFullScreenName(minimalActionName)) {
         minimalAction.type = CONST.NAVIGATION.ACTION_TYPE.PUSH;
     }
     navigation.dispatch(minimalAction);

--- a/src/setup/addUtilsToWindow.ts
+++ b/src/setup/addUtilsToWindow.ts
@@ -1,11 +1,12 @@
 import {isProduction as isProductionLib} from '@libs/Environment/Environment';
 import navigationRef from '@libs/Navigation/navigationRef';
+import {getOriginalMessage} from '@libs/ReportActionsUtils';
 
 import {setSupportAuthToken} from '@userActions/Session';
 
 import ONYXKEYS from '@src/ONYXKEYS';
 
-import type {CollectionKeyBase} from 'react-native-onyx/dist/types';
+import type {OnyxKey, OnyxValue} from 'react-native-onyx';
 
 import Onyx from 'react-native-onyx';
 
@@ -23,95 +24,106 @@ export default function addUtilsToWindow() {
             return;
         }
 
-        window.Onyx = Onyx as typeof Onyx & {
-            get: (key: CollectionKeyBase) => Promise<unknown>;
-            log: (key: CollectionKeyBase) => void;
-        };
-
         // We intentionally do not offer an Onyx.get API because we believe it will lead to code patterns we don't want to use in this repo, but we can offer a workaround for the sake of debugging
-        window.Onyx.get = function (key: CollectionKeyBase) {
+        function get<TKey extends OnyxKey>(key: TKey): Promise<OnyxValue<TKey>> {
             return new Promise((resolve) => {
+                const connectionReference: {current?: ReturnType<typeof Onyx.connectWithoutView>} = {};
+                let isResolved = false;
                 // We have opted for `connectWithoutView` here as this is a debugging utility and does not relate to any view.
                 const connection = Onyx.connectWithoutView({
                     key,
                     callback: (value) => {
-                        Onyx.disconnect(connection);
+                        if (isResolved) {
+                            return;
+                        }
+                        isResolved = true;
+                        if (connectionReference.current) {
+                            Onyx.disconnect(connectionReference.current);
+                        }
                         resolve(value);
                     },
                 });
+                if (isResolved) {
+                    Onyx.disconnect(connection);
+                } else {
+                    connectionReference.current = connection;
+                }
             });
-        };
+        }
 
-        window.Onyx.log = function (key: CollectionKeyBase) {
-            window.Onyx.get(key).then((value) => {
+        function log(key: OnyxKey): void {
+            get(key).then((value) => {
                 /* eslint-disable-next-line no-console */
                 console.log(value);
             });
-        };
+        }
+
+        const onyxWithDebugUtils = Object.assign(Onyx, {get, log});
+        window.Onyx = onyxWithDebugUtils;
 
         window.setSupportToken = setSupportAuthToken;
 
         // Helper to get current route params
-        const getRouteParams = () => {
-            return navigationRef.current?.getCurrentRoute()?.params as Record<string, string> | undefined;
-        };
+        function getRouteParams() {
+            return navigationRef.current?.getCurrentRoute()?.params;
+        }
 
         // Helper to get reportID from various sources
-        const getReportID = async (params: Record<string, string> | undefined) => {
-            if (params?.reportID) {
+        async function getReportID(params: ReturnType<typeof getRouteParams>): Promise<string | undefined> {
+            if (params && typeof params === 'object' && 'reportID' in params && typeof params.reportID === 'string' && params.reportID) {
                 return params.reportID;
             }
-            if (params?.transactionID) {
-                const transaction = await window.Onyx.get(`${ONYXKEYS.COLLECTION.TRANSACTION}${params.transactionID}` as CollectionKeyBase);
-                return (transaction as {reportID?: string} | undefined)?.reportID;
+            if (params && typeof params === 'object' && 'transactionID' in params && typeof params.transactionID === 'string' && params.transactionID) {
+                const transaction = await onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.TRANSACTION}${params.transactionID}`);
+                return transaction?.reportID;
             }
             return undefined;
-        };
+        }
 
         // Helper to get transactionID from one expense report
-        const getTransactionIDFromReport = async (reportID: string) => {
-            const report = await window.Onyx.get(`${ONYXKEYS.COLLECTION.REPORT}${reportID}` as CollectionKeyBase);
-            const typedReport = report as {parentReportID?: string; parentReportActionID?: string} | undefined;
+        async function getTransactionIDFromReport(reportID: string): Promise<string | undefined> {
+            const report = await onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
 
             // First try: Get from parent report action (for transaction thread reports)
-            if (typedReport?.parentReportID && typedReport?.parentReportActionID) {
-                const parentReportActions = await window.Onyx.get(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${typedReport.parentReportID}` as CollectionKeyBase);
-                const parentAction = (parentReportActions as Record<string, {originalMessage?: {IOUTransactionID?: string}}> | undefined)?.[typedReport.parentReportActionID];
-                if (parentAction?.originalMessage?.IOUTransactionID) {
-                    return parentAction.originalMessage.IOUTransactionID;
+            if (report?.parentReportID && report?.parentReportActionID) {
+                const parentReportActions = await onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.parentReportID}`);
+                const parentAction = parentReportActions?.[report.parentReportActionID];
+                // Debug lookups intentionally prefer the legacy message even when a modern message exists.
+                const parentMessage = parentAction ? getOriginalMessage({...parentAction, message: undefined}) : undefined;
+                if (parentMessage && 'IOUTransactionID' in parentMessage && parentMessage.IOUTransactionID) {
+                    return parentMessage.IOUTransactionID;
                 }
             }
 
             // Fallback: Search the report's own report actions (for expense reports with one transaction)
-            const reportActions = await window.Onyx.get(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}` as CollectionKeyBase);
-            const actions = reportActions as Record<string, {originalMessage?: {IOUTransactionID?: string}}> | undefined;
-            if (actions) {
-                for (const action of Object.values(actions)) {
-                    if (action?.originalMessage?.IOUTransactionID) {
-                        return action.originalMessage.IOUTransactionID;
+            const reportActions = await onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`);
+            if (reportActions) {
+                for (const action of Object.values(reportActions)) {
+                    const originalMessage = action ? getOriginalMessage({...action, message: undefined}) : undefined;
+                    if (originalMessage && 'IOUTransactionID' in originalMessage && originalMessage.IOUTransactionID) {
+                        return originalMessage.IOUTransactionID;
                     }
                 }
             }
 
             return undefined;
-        };
+        }
 
         // Helper to get policyID from report (checks parent report for one expense reports)
-        const getPolicyIDFromReport = async (reportID: string) => {
-            const report = await window.Onyx.get(`${ONYXKEYS.COLLECTION.REPORT}${reportID}` as CollectionKeyBase);
-            const typedReport = report as {policyID?: string; parentReportID?: string} | undefined;
+        async function getPolicyIDFromReport(reportID: string): Promise<string | undefined> {
+            const report = await onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
 
-            if (typedReport?.policyID) {
-                return typedReport.policyID;
+            if (report?.policyID) {
+                return report.policyID;
             }
 
-            if (typedReport?.parentReportID) {
-                const parentReport = await window.Onyx.get(`${ONYXKEYS.COLLECTION.REPORT}${typedReport.parentReportID}` as CollectionKeyBase);
-                return (parentReport as {policyID?: string} | undefined)?.policyID;
+            if (report?.parentReportID) {
+                const parentReport = await onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`);
+                return parentReport?.policyID;
             }
 
             return undefined;
-        };
+        }
 
         // Define lazy getters for debug data
         Object.defineProperties(window, {
@@ -120,15 +132,15 @@ export default function addUtilsToWindow() {
                 get: async () => {
                     const params = getRouteParams();
 
-                    if (params?.policyID) {
-                        return window.Onyx.get(`${ONYXKEYS.COLLECTION.POLICY}${params.policyID}` as CollectionKeyBase);
+                    if (params && typeof params === 'object' && 'policyID' in params && typeof params.policyID === 'string' && params.policyID) {
+                        return onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.POLICY}${params.policyID}`);
                     }
 
                     const reportID = await getReportID(params);
                     if (reportID) {
                         const policyID = await getPolicyIDFromReport(reportID);
                         if (policyID) {
-                            return window.Onyx.get(`${ONYXKEYS.COLLECTION.POLICY}${policyID}` as CollectionKeyBase);
+                            return onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
                         }
                     }
 
@@ -142,7 +154,7 @@ export default function addUtilsToWindow() {
                     const reportID = await getReportID(params);
 
                     if (reportID) {
-                        return window.Onyx.get(`${ONYXKEYS.COLLECTION.REPORT}${reportID}` as CollectionKeyBase);
+                        return onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
                     }
 
                     return undefined;
@@ -153,14 +165,14 @@ export default function addUtilsToWindow() {
                 get: async () => {
                     const params = getRouteParams();
 
-                    if (params?.transactionID) {
-                        return window.Onyx.get(`${ONYXKEYS.COLLECTION.TRANSACTION}${params.transactionID}` as CollectionKeyBase);
+                    if (params && typeof params === 'object' && 'transactionID' in params && typeof params.transactionID === 'string' && params.transactionID) {
+                        return onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.TRANSACTION}${params.transactionID}`);
                     }
 
-                    if (params?.reportID) {
+                    if (params && typeof params === 'object' && 'reportID' in params && typeof params.reportID === 'string' && params.reportID) {
                         const transactionID = await getTransactionIDFromReport(params.reportID);
                         if (transactionID) {
-                            return window.Onyx.get(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}` as CollectionKeyBase);
+                            return onyxWithDebugUtils.get(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`);
                         }
                     }
 
@@ -170,7 +182,7 @@ export default function addUtilsToWindow() {
             receipt: {
                 configurable: true,
                 get: async () => {
-                    const transaction = await (window as {transaction?: Promise<{receipt?: unknown}>}).transaction;
+                    const transaction = await window.transaction;
                     return transaction?.receipt;
                 },
             },


### PR DESCRIPTION
### Explanation of Change
Replace unsafe assertions in navigation and developer debugging helpers with producer-derived types, category-preserving state reconstruction and local field checks. The parser accepts the strings its callers already produce; debug reads retain legacy-message priority and intentionally add synchronous-callback support and duplicate-callback suppression.

Changed files:
- `src/libs/Navigation/helpers/getAdaptedStateFromPath.ts`
- `src/libs/Navigation/helpers/getPathFromState.ts`
- `src/libs/Navigation/helpers/getStateFromPath.ts`
- `src/libs/Navigation/helpers/linkTo/getMinimalAction.ts`
- `src/libs/Navigation/helpers/linkTo/index.ts`
- `src/setup/addUtilsToWindow.ts`

### Fixed Issues
$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Tests
Passed: 146 tests in 13 existing Jest suites, 34 runtime/falsifier groups, focused lint, formatting and spelling. Fork checks passed typecheck, lint, format, React Compiler and Jest. Local TypeScript was waived: zero changed-file diagnostics, but 43 imported-file diagnostics prevented complete coverage. Focused lint retains four existing support-file warnings.

Probes cover dispatch ordering, full/partial state metadata, strict report IDs, legacy lookups and callback timing. URL encoding and decoding retain delimiter collision handling and query precedence. Extracted probes do not establish Babel integration, browser history or native gestures; Jest coverage is bounded. No committed tests were added.

Local manual testing remains pending: follow QA steps below; on a nonproduction browser report screen, await window.report, window.transaction, window.policy and window.receipt. Verify matching available records and undefined for missing records; use Onyx.get/log with that report's stored key and verify the returned/logged value.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Pending: load a report and attachment online, disconnect, repeat cached navigation and back actions. Expect cached content and the same report context; verify again after reconnecting.

### QA Steps
Manual QA required. QA before review: shared navigation branches control deep links, tab backgrounds and history. Pending on staging, using desktop/mobile browsers and iOS/Android native:

1. From Inbox, open a report-action link and attachment; close it and use browser back/forward or native back/swipe. Expect the corresponding report/action and prior screen.
2. From Settings, open a report deep link; go back. Expect Settings restored. Open a workspace right-hand panel; expect the correct workspace background and nested history.
3. Open a public deep link signed out, then a report link signed in. Expect the corresponding accessible destination.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
Manual, offline, failure-flow, high-traffic and all-platform checks remain unperformed. No UI, copy, styles, assets, generic components or Storybook changes require conditional checks.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
Not captured; manual QA is pending.


<!-- seatbelt-v2:create:43192ddd-cb10-4b1f-b64a-c14669b9f8d6:s08-43192ddd-4541881-draft-create-1 -->