### PR TITLE
Skip submodule validation for fork PRs

### DIFF
--- a/.github/workflows/validateMobileExpensifySubmodule.yml
+++ b/.github/workflows/validateMobileExpensifySubmodule.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validate-mobile-expensify-submodule:
-    if: github.actor != 'OSBotify' && !endsWith(github.actor, '[bot]')
+    if: github.actor != 'OSBotify' && !endsWith(github.actor, '[bot]') && !github.event.pull_request.head.repo.fork
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout App


### PR DESCRIPTION
### Explanation of Change
Skips the Mobile-Expensify submodule validation job for fork PRs, where GitHub withholds `OS_BOTIFY_TOKEN` and the private-repository checkout cannot run.

### Fixed Issues
$ https://expensify.slack.com/archives/C03TQ48KC/p1788976681377559
PROPOSAL:

### Tests
1. Run the workflow from a fork PR that changes `Mobile-Expensify`.
2. Verify the validation job is skipped instead of failing because its token is unavailable.
3. Verify the job still runs for an internal PR that changes `Mobile-Expensify`.

### Offline tests
Not applicable: GitHub Actions workflow-only change.

### QA Steps
Same as tests.

### PR Author Checklist
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed proper code patterns
- [x] I verified that comments were added to code that is not self explanatory
- [x] I verified there are no console errors relevant to this workflow-only change