### PR TITLE
fix: Show Approver row on invite confirmation for Dynamic External Workflow policies

### DIFF
--- a/src/pages/workspace/members/WorkspaceInviteMessageComponent.tsx
+++ b/src/pages/workspace/members/WorkspaceInviteMessageComponent.tsx
@@ -31,8 +31,10 @@ import {
     getDefaultApprover,
     getMemberAccountIDsForWorkspace,
     goBackFromInvalidPolicy,
+    hasDynamicExternalWorkflow,
     isControlPolicy,
     isSubmitPolicy,
+    shouldHideDynamicExternalWorkflowPeople,
     tryNavigateToSubmitWorkspaceUpgrade,
 } from '@libs/PolicyUtils';
 import {getAllPolicyExpenseChatReportActions} from '@libs/ReportUtils';
@@ -118,7 +120,10 @@ function WorkspaceInviteMessageComponent({
     const approverDetails = usePersonalDetailByLogin(workspaceInviteApproverDraft);
 
     const isControl = isControlPolicy(policy);
-    const shouldShowApproverRow = isControl && policy?.approvalMode === CONST.POLICY.APPROVAL_MODE.ADVANCED && policy?.areWorkflowsEnabled;
+    const isSupportedApprovalMode =
+        policy?.approvalMode === CONST.POLICY.APPROVAL_MODE.ADVANCED ||
+        policy?.approvalMode === CONST.POLICY.APPROVAL_MODE.DYNAMICEXTERNAL;
+    const shouldShowApproverRow = isControl && isSupportedApprovalMode && policy?.areWorkflowsEnabled && !shouldHideDynamicExternalWorkflowPeople(policy);
 
     const isApproverValid = !!workspaceInviteApproverDraft && workspaceInviteApproverDraft in (policy?.employeeList ?? {});
     const validatedApprover = isApproverValid ? workspaceInviteApproverDraft : undefined;

--- a/src/pages/workspace/members/WorkspaceInviteMessageComponent.tsx
+++ b/src/pages/workspace/members/WorkspaceInviteMessageComponent.tsx
@@ -31,7 +31,6 @@ import {
     getDefaultApprover,
     getMemberAccountIDsForWorkspace,
     goBackFromInvalidPolicy,
-    hasDynamicExternalWorkflow,
     isControlPolicy,
     isSubmitPolicy,
     shouldHideDynamicExternalWorkflowPeople,


### PR DESCRIPTION
### Details
$ #100728

### Fixed Issues
$250 (https://github.com/Expensify/App/issues/100728)

### Tests
1. Create a Control workspace with `approvalMode: dynamic_external` and Workflows enabled
2. Go to Members > Invite member, select a member, continue to confirmation page
3. Verify the Approver row appears
4. Select an approver and complete the invite
5. Verify the approver is applied

### PR Review Checklist (partial)
- [x] I have read the Expensify contributing guidelines
- [x] I have verified this does not break existing functionality
- [x] Only changed the necessary file

### Explanation of Change
The Approver row was gated on `approvalMode === ADVANCED` only. Dynamic External Workflow (DEW) policies use `DYNAMICEXTERNAL` mode, so the row was skipped.

Fix:
- Added `DYNAMICEXTERNAL` to the supported approval modes
- Kept the row hidden when `shouldHideDynamicExternalWorkflowPeople(policy)` is true (matching #98491)
- The same boolean gates the `validatedApprover` payload, so DEW workspaces now also submit the approver correctly

#### Before
```ts
const shouldShowApproverRow = isControl && policy?.approvalMode === CONST.POLICY.APPROVAL_MODE.ADVANCED && policy?.areWorkflowsEnabled;
```

#### After
```ts
const isSupportedApprovalMode =
    policy?.approvalMode === CONST.POLICY.APPROVAL_MODE.ADVANCED ||
    policy?.approvalMode === CONST.POLICY.APPROVAL_MODE.DYNAMICEXTERNAL;
const shouldShowApproverRow = isControl && isSupportedApprovalMode && policy?.areWorkflowsEnabled && !shouldHideDynamicExternalWorkflowPeople(policy);
```

### Related Issues
- #99749 - Approver row depends on upgrade path
- #98491 - Hide approval workflow UI when DEW hide people is set

cc: @thesahindia
