### PR TITLE
Remove unsafe assertions from card messages, DOM hooks, and reveal tokenization

### DIFF
--- a/src/components/ReportActionItem/IssueCardMessage.tsx
+++ b/src/components/ReportActionItem/IssueCardMessage.tsx
@@ -14,14 +14,13 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {ReportsSplitNavigatorParamList} from '@libs/Navigation/types';
 import {isPolicyAdmin} from '@libs/PolicyUtils';
-import {getCardIssuedMessage, getOriginalMessage, shouldShowActivateCard, shouldShowAddMissingDetails} from '@libs/ReportActionsUtils';
+import {getCardIssuedMessage, getOriginalMessage, isCardIssuedAction, shouldShowActivateCard, shouldShowAddMissingDetails} from '@libs/ReportActionsUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {ReportAction} from '@src/types/onyx';
-import type {IssueNewCardOriginalMessage} from '@src/types/onyx/OriginalMessage';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 import type {OnyxEntry} from 'react-native-onyx';
@@ -38,7 +37,8 @@ function IssueCardMessage({action, policyID}: IssueCardMessageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const session = useSession();
-    const assigneeAccountID = (getOriginalMessage(action) as IssueNewCardOriginalMessage)?.assigneeAccountID;
+    const cardIssuedActionOriginalMessage = isCardIssuedAction(action) ? getOriginalMessage(action) : undefined;
+    const assigneeAccountID = cardIssuedActionOriginalMessage?.assigneeAccountID;
     const expensifyCard = useGetExpensifyCardFromReportAction({
         reportAction: action,
         policyID,
@@ -48,7 +48,7 @@ function IssueCardMessage({action, policyID}: IssueCardMessageProps) {
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`);
     const shouldNavigateToCardDetails = isPolicyAdmin(policy);
     const [privatePersonalDetails] = useOnyx(ONYXKEYS.PRIVATE_PERSONAL_DETAILS);
-    const companyCard = cardList?.[(getOriginalMessage(action) as IssueNewCardOriginalMessage)?.cardID];
+    const companyCard = cardIssuedActionOriginalMessage?.cardID !== undefined ? cardList?.[cardIssuedActionOriginalMessage.cardID] : undefined;
     const shouldShowAddMissingDetailsButton =
         !!expensifyCard?.cardID && isAssigneeCurrentUser && shouldShowAddMissingDetails(action?.actionName, privatePersonalDetails, expensifyCard?.state);
     const shouldShowActivateButton = isAssigneeCurrentUser && shouldShowActivateCard(action?.actionName, expensifyCard, privatePersonalDetails);

--- a/src/components/ReportActionItem/receiptHoverUtils/index.ts
+++ b/src/components/ReportActionItem/receiptHoverUtils/index.ts
@@ -1,16 +1,22 @@
+import isHTMLElement from '@libs/isHTMLElement';
+
 import type {RefObject} from 'react';
 import type {View} from 'react-native';
 
 /** Reset stale button hover/tooltip when file picker opens (browsers don't fire mouseleave). */
 function resetButtonHoverState(addButtonRef: RefObject<View | null>) {
-    const buttonEl = addButtonRef.current as unknown as HTMLElement;
-    buttonEl?.dispatchEvent(new PointerEvent('pointerleave'));
-    buttonEl?.dispatchEvent(new MouseEvent('mouseout', {bubbles: true, relatedTarget: document.body}));
+    const buttonEl = addButtonRef.current;
+    if (!isHTMLElement(buttonEl)) {
+        return;
+    }
+    buttonEl.dispatchEvent(new PointerEvent('pointerleave'));
+    buttonEl.dispatchEvent(new MouseEvent('mouseout', {bubbles: true, relatedTarget: document.body}));
 }
 
 /** Check if cursor is over the element (web only). */
 function isElementHovered(ref: RefObject<View | null>): boolean {
-    return !!(ref.current as unknown as HTMLElement)?.matches?.(':hover');
+    const element = ref.current;
+    return isHTMLElement(element) && element.matches(':hover');
 }
 
 export {resetButtonHoverState, isElementHovered};

--- a/src/hooks/useTackInputFocus/index.ts
+++ b/src/hooks/useTackInputFocus/index.ts
@@ -1,6 +1,8 @@
 import useDebouncedState from '@hooks/useDebouncedState';
 import useSidePanelState from '@hooks/useSidePanelState';
 
+import isHTMLElement from '@libs/isHTMLElement';
+
 import CONST from '@src/CONST';
 
 import {useCallback, useEffect} from 'react';
@@ -14,7 +16,10 @@ export default function useTackInputFocus(enable = false): boolean {
 
     const handleFocusIn = useCallback(
         (event: FocusEvent) => {
-            const targetElement = event.target as HTMLElement;
+            const targetElement = event.target;
+            if (!isHTMLElement(targetElement)) {
+                return;
+            }
             if (targetElement.tagName === CONST.ELEMENT_NAME.INPUT || targetElement.tagName === CONST.ELEMENT_NAME.TEXTAREA) {
                 setIsInputFocus(true);
             }
@@ -24,7 +29,10 @@ export default function useTackInputFocus(enable = false): boolean {
 
     const handleFocusOut = useCallback(
         (event: FocusEvent) => {
-            const targetElement = event.target as HTMLElement;
+            const targetElement = event.target;
+            if (!isHTMLElement(targetElement)) {
+                return;
+            }
             if (targetElement.tagName === CONST.ELEMENT_NAME.INPUT || targetElement.tagName === CONST.ELEMENT_NAME.TEXTAREA) {
                 setIsInputFocus(false);
             }

--- a/src/hooks/useTextWithMiddleEllipsis.ts
+++ b/src/hooks/useTextWithMiddleEllipsis.ts
@@ -1,3 +1,5 @@
+import isHTMLElement from '@libs/isHTMLElement';
+
 import type {RefObject} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type {Text as RNText} from 'react-native';
@@ -85,13 +87,13 @@ function useTextWithMiddleEllipsis(props: TruncateProps): string {
 
     useEffect(() => {
         const element = ref.current;
-        if (!element) {
+        if (!isHTMLElement(element)) {
             return;
         }
 
         const measure = () => {
-            const style = window.getComputedStyle(element as unknown as Element);
-            const rect = (element as unknown as Element).getBoundingClientRect();
+            const style = window.getComputedStyle(element);
+            const rect = element.getBoundingClientRect();
             setFontStyle({
                 fontWeight: style.fontWeight,
                 fontStyle: style.fontStyle,

--- a/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
+++ b/src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts
@@ -1,4 +1,4 @@
-import type {AnyNode, Document, Element as DomElement} from 'domhandler';
+import type {AnyNode, Document} from 'domhandler';
 
 import render from 'dom-serializer';
 import {ElementType} from 'domelementtype';
@@ -78,17 +78,21 @@ function buildClippedNodes(doc: Document, anchor: Anchor): AnyNode[] {
         }
         if (isLeaf) {
             if (stopNode.type === ElementType.Text && anchor.textEndIdx !== undefined) {
-                const truncated = {...stopNode, data: stopNode.data.slice(0, anchor.textEndIdx)} as unknown as AnyNode;
+                const truncated = Object.assign(stopNode.cloneNode(false), stopNode);
+                truncated.data = stopNode.data.slice(0, anchor.textEndIdx);
                 return [...before, truncated];
             }
             return [...before, stopNode];
         }
-        const elem = stopNode as DomElement;
-        const innerChildren = clip(elem.children as AnyNode[], depth + 1);
-        const partialElem = {...elem, children: innerChildren} as unknown as AnyNode;
+        if (stopNode.type !== ElementType.Tag) {
+            return [...before, stopNode];
+        }
+        const innerChildren = clip(stopNode.children, depth + 1);
+        const partialElem = Object.assign(stopNode.cloneNode(false), stopNode);
+        partialElem.children = innerChildren;
         return [...before, partialElem];
     };
-    return clip(doc.children as AnyNode[], 0);
+    return clip(doc.children, 0);
 }
 
 /**

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -1516,18 +1516,6 @@ type OriginalMessageSettlementAccountLocked = {
 };
 
 /**
- * Original message for Expensify Card issue/replacement actions
- */
-type IssueNewCardOriginalMessage = OriginalMessage<
-    | typeof CONST.REPORT.ACTIONS.TYPE.CARD_MISSING_ADDRESS
-    | typeof CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED
-    | typeof CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL
-    | typeof CONST.REPORT.ACTIONS.TYPE.CARD_ASSIGNED
-    | typeof CONST.REPORT.ACTIONS.TYPE.CARD_REPLACED_VIRTUAL
-    | typeof CONST.REPORT.ACTIONS.TYPE.CARD_REPLACED
->;
-
-/**
  * Model of a HOME_ADDRESS_REQUIRED Concierge report action.
  */
 type OriginalMessageHomeAddressRequired = {
@@ -1706,7 +1694,6 @@ export type {
     JoinWorkspaceResolution,
     OriginalMessageModifiedExpense,
     OriginalMessageExportIntegration,
-    IssueNewCardOriginalMessage,
     OriginalMessageChangePolicy,
     OriginalMessageMovedTransaction,
     PolicyBudgetFrequency,


### PR DESCRIPTION
### Explanation of Change

Replace unsafe assertions with existing card/DOM guards and typed shallow node clones. Unsupported non-DOM values now safely skip browser operations; supported behavior retains card selection, hover/focus handling, and ellipsis measurement. Tokenizer comparisons preserve parser/serializer normalization and omission of non-anchor content, without promising arbitrary-input byte equality.

Changed files:

- `src/components/ReportActionItem/IssueCardMessage.tsx`
- `src/components/ReportActionItem/receiptHoverUtils/index.ts`
- `src/hooks/useTackInputFocus/index.ts`
- `src/hooks/useTextWithMiddleEllipsis.ts`
- `src/libs/ReportActionFollowupUtils/tokenizeForReveal.ts`

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Tests

CI passed full TypeScript, lint, formatting, React Compiler, and complete Jest selections for `tokenizeForRevealTest.ts`, `usePendingConciergeResponse.test.ts`, `MoneyRequestReceiptViewTest.tsx`, and `ReportActionItemTest.tsx`.

Local checks passed lint, formatting, spelling, compiler comparisons, 48 Jest tests, and tokenizer/DOM/card probes. Local card filtering skipped 200 tests. Local focused TypeScript remains waived, not passed: zero changed-root diagnostics, 43 imported-file diagnostics not proven pre-existing. Finite probes use controlled dependencies and jsdom; they do not establish arbitrary-HTML, real WebKit, font-engine, or complete navigation coverage.

For local manual testing, repeat QA steps below; none were performed.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not performed. On a loaded editable Room description screen, disconnect, focus/type/blur, and expect stable keyboard layout and retained draft text. Reconnect afterward.

### QA Steps

Manual QA required. QA before review: production guards, card selection, and node construction affect runtime consumers.

Using existing eligible data on staging:

1. Desktop Chrome, expense receipt: open Add additional receipt; cancel, then select a valid receipt. Expect no stuck tooltip and restored hover.
2. iOS Safari, editable Room description: focus, type, blur, and reopen keyboard; expect stable viewport and accessible controls.
3. Desktop Chrome, Docusign document-upload step: choose an allowed long-named file; narrow/widen the window. Expect middle truncation retaining both filename ends.
4. Web/native, existing card-issued chat: compare assignee/other-user buttons; open available activation/shipping actions. Expect the correct card destination.
5. Web/native, Concierge chat with progressive responses: observe formatted text and available atomic elements. Expect balanced reveal without an extra terminal stage.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

New-copy, CSS, asset, and layout-design conditions do not apply; no corresponding changes. Manual/platform, shared-consumer, markdown, deeplink, and Storybook acknowledgments remain unverified.

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

None captured.

<!-- seatbelt-v2:create:273bdc63-d42f-4322-a4e6-fe73fc2a288d:draft-273bdc63-501e9dc9-670f-4c28-9da4-9c6a3fa67239 -->