### PR TITLE
Fix not-found page after clearing cache

### DIFF
--- a/src/libs/Navigation/guards/MigratedUserWelcomeModalGuard.ts
+++ b/src/libs/Navigation/guards/MigratedUserWelcomeModalGuard.ts
@@ -1,4 +1,5 @@
 import Log from '@libs/Log';
+import createScheduleOnce from '@libs/Navigation/helpers/createScheduleOnce';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import getValidDynamicRouteBasePath from '@libs/Navigation/helpers/getValidDynamicRouteBasePath';
 import Navigation from '@libs/Navigation/Navigation';
@@ -29,7 +30,6 @@ let session: OnyxEntry<Session>;
 let isLoadingApp = true;
 
 let hasRedirectedToMigratedUserModal = false;
-let isEvaluationScheduled = false;
 
 function getMigratedUserWelcomeModalRoute(basePath?: string): Route {
     return createDynamicRoute(
@@ -71,17 +71,7 @@ function navigateToMigratedUserWelcomeModalIfReady() {
 }
 
 /** Waits until the current Onyx update batch has populated every value used by the guard. */
-function scheduleMigratedUserWelcomeModalEvaluation() {
-    if (isEvaluationScheduled) {
-        return;
-    }
-
-    isEvaluationScheduled = true;
-    Promise.resolve().then(() => {
-        isEvaluationScheduled = false;
-        navigateToMigratedUserWelcomeModalIfReady();
-    });
-}
+const scheduleMigratedUserWelcomeModalEvaluation = createScheduleOnce(navigateToMigratedUserWelcomeModalIfReady);
 
 /**
  * Called by guards/index.ts when session or loading app state changes.

--- a/src/libs/Navigation/guards/MigratedUserWelcomeModalGuard.ts
+++ b/src/libs/Navigation/guards/MigratedUserWelcomeModalGuard.ts
@@ -1,5 +1,6 @@
 import Log from '@libs/Log';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
+import getValidDynamicRouteBasePath from '@libs/Navigation/helpers/getValidDynamicRouteBasePath';
 import Navigation from '@libs/Navigation/Navigation';
 import isProductTrainingElementDismissed from '@libs/TooltipUtils';
 
@@ -28,9 +29,17 @@ let session: OnyxEntry<Session>;
 let isLoadingApp = true;
 
 let hasRedirectedToMigratedUserModal = false;
+let isEvaluationScheduled = false;
 
 function getMigratedUserWelcomeModalRoute(basePath?: string): Route {
-    return createDynamicRoute(DYNAMIC_ROUTES.MIGRATED_USER_WELCOME.path, basePath ?? (Navigation.getActiveRoute() || ROUTES.HOME));
+    return createDynamicRoute(
+        DYNAMIC_ROUTES.MIGRATED_USER_WELCOME.path,
+        basePath ??
+            getValidDynamicRouteBasePath({
+                entryScreens: DYNAMIC_ROUTES.MIGRATED_USER_WELCOME.entryScreens,
+                fallbackPath: ROUTES.HOME,
+            }),
+    );
 }
 
 function resetSessionFlag() {
@@ -61,6 +70,19 @@ function navigateToMigratedUserWelcomeModalIfReady() {
     Navigation.navigate(getMigratedUserWelcomeModalRoute());
 }
 
+/** Waits until the current Onyx update batch has populated every value used by the guard. */
+function scheduleMigratedUserWelcomeModalEvaluation() {
+    if (isEvaluationScheduled) {
+        return;
+    }
+
+    isEvaluationScheduled = true;
+    Promise.resolve().then(() => {
+        isEvaluationScheduled = false;
+        navigateToMigratedUserWelcomeModalIfReady();
+    });
+}
+
 /**
  * Called by guards/index.ts when session or loading app state changes.
  * Reuses the shared Onyx subscriptions from guards/index.ts to avoid duplicate connections.
@@ -68,7 +90,7 @@ function navigateToMigratedUserWelcomeModalIfReady() {
 function onSessionOrLoadingAppChanged(sessionValue: OnyxEntry<Session>, isLoadingAppValue: boolean) {
     session = sessionValue;
     isLoadingApp = isLoadingAppValue;
-    navigateToMigratedUserWelcomeModalIfReady();
+    scheduleMigratedUserWelcomeModalEvaluation();
 }
 
 Onyx.connectWithoutView({
@@ -76,7 +98,7 @@ Onyx.connectWithoutView({
     callback: (value) => {
         const result = value ? tryNewDotOnyxSelector(value) : undefined;
         hasBeenAddedToNudgeMigration = result?.hasBeenAddedToNudgeMigration ?? false;
-        navigateToMigratedUserWelcomeModalIfReady();
+        scheduleMigratedUserWelcomeModalEvaluation();
     },
 });
 
@@ -88,7 +110,7 @@ Onyx.connectWithoutView({
         if (isProductTrainingElementDismissed('migratedUserWelcomeModal', value)) {
             hasRedirectedToMigratedUserModal = false;
         }
-        navigateToMigratedUserWelcomeModalIfReady();
+        scheduleMigratedUserWelcomeModalEvaluation();
     },
 });
 

--- a/src/libs/Navigation/guards/SubmitPlanWelcomeModalGuard.ts
+++ b/src/libs/Navigation/guards/SubmitPlanWelcomeModalGuard.ts
@@ -1,4 +1,5 @@
 import getUserSecurityGroup from '@libs/getUserSecurityGroup';
+import createScheduleOnce from '@libs/Navigation/helpers/createScheduleOnce';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import getValidDynamicRouteBasePath from '@libs/Navigation/helpers/getValidDynamicRouteBasePath';
 import Navigation from '@libs/Navigation/Navigation';
@@ -35,7 +36,6 @@ let isSubmitMigrationModalShownLoaded = false;
 let hasLoadedApp = false;
 
 let hasRedirectedToSubmitPlanModal = false;
-let isEvaluationScheduled = false;
 
 // An `intent=submit` deeplink delivers the same outcome as this modal without asking, so the modal must not open on
 // top of it. Recorded outside Onyx because the deeplink can only mark the modal shown from a React effect, which runs
@@ -126,16 +126,7 @@ function navigateToSubmitPlanWelcomeModalIfReady() {
  * pre-sign-in-stale IS_LOADING_APP) only flips true once this session's account data — including the shown-flag —
  * has loaded, covering the sign-in race where eligibility NVPs arrive before the shown-flag.
  */
-function scheduleSubmitPlanWelcomeModalEvaluation() {
-    if (isEvaluationScheduled) {
-        return;
-    }
-    isEvaluationScheduled = true;
-    Promise.resolve().then(() => {
-        isEvaluationScheduled = false;
-        navigateToSubmitPlanWelcomeModalIfReady();
-    });
-}
+const scheduleSubmitPlanWelcomeModalEvaluation = createScheduleOnce(navigateToSubmitPlanWelcomeModalIfReady);
 
 // Session/app-load state drive the one-shot proactive redirect: they are the boot-time signal by which point
 // every eligibility value below has already landed in the same OpenApp batch, so re-evaluating here is safe.

--- a/src/libs/Navigation/guards/SubmitPlanWelcomeModalGuard.ts
+++ b/src/libs/Navigation/guards/SubmitPlanWelcomeModalGuard.ts
@@ -1,8 +1,6 @@
 import getUserSecurityGroup from '@libs/getUserSecurityGroup';
-import Log from '@libs/Log';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
-import findFocusedRouteWithOnyxTabGuard from '@libs/Navigation/helpers/findFocusedRouteWithOnyxTabGuard';
-import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
+import getValidDynamicRouteBasePath from '@libs/Navigation/helpers/getValidDynamicRouteBasePath';
 import Navigation from '@libs/Navigation/Navigation';
 import {getGroupPoliciesWhereReportCanBeCreated} from '@libs/PolicyUtils';
 
@@ -54,37 +52,15 @@ function releaseWelcomeModalForSubmitDeeplink() {
     hasPendingSubmitDeeplink = false;
 }
 
-const SUBMIT_PLAN_WELCOME_ENTRY_SCREENS = new Set<string>(DYNAMIC_ROUTES.SUBMIT_PLAN_WELCOME.entryScreens);
-
-/**
- * The submit-plan-welcome modal is a dynamic route that can only attach to the screens listed in
- * DYNAMIC_ROUTES.SUBMIT_PLAN_WELCOME.entryScreens. When we proactively open the modal on app boot,
- * the active route can be any screen (e.g. `/settings/troubleshoot` after "Clear cache and restart"),
- * and stacking the suffix onto a non-entry screen resolves to NotFound. Fall back to HOME (a valid
- * entry screen) whenever the active route isn't an allowed base.
- */
-function getValidModalBasePath(): string {
-    const activeRoute = Navigation.getActiveRoute();
-    if (!activeRoute) {
-        return ROUTES.HOME;
-    }
-    try {
-        // getActiveRoute returns a plain string, while getStateFromPath expects a Route. Any string returned by
-        // getActiveRoute is a valid route path, and getStateFromPath safely handles paths it cannot parse.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        const focusedRouteName = findFocusedRouteWithOnyxTabGuard(getStateFromPath(activeRoute as Route) ?? {})?.name;
-        if (focusedRouteName && SUBMIT_PLAN_WELCOME_ENTRY_SCREENS.has(focusedRouteName)) {
-            return activeRoute;
-        }
-    } catch (error) {
-        // getStateFromPath can throw for paths it cannot parse; fall back to HOME below.
-        Log.warn('[SubmitPlanWelcomeModalGuard] Failed to resolve modal base path, falling back to HOME', {activeRoute, error});
-    }
-    return ROUTES.HOME;
-}
-
 function getSubmitPlanWelcomeModalRoute(basePath?: string): Route {
-    return createDynamicRoute(DYNAMIC_ROUTES.SUBMIT_PLAN_WELCOME.path, basePath ?? getValidModalBasePath());
+    return createDynamicRoute(
+        DYNAMIC_ROUTES.SUBMIT_PLAN_WELCOME.path,
+        basePath ??
+            getValidDynamicRouteBasePath({
+                entryScreens: DYNAMIC_ROUTES.SUBMIT_PLAN_WELCOME.entryScreens,
+                fallbackPath: ROUTES.HOME,
+            }),
+    );
 }
 
 function resetSessionFlag() {

--- a/src/libs/Navigation/helpers/createScheduleOnce.ts
+++ b/src/libs/Navigation/helpers/createScheduleOnce.ts
@@ -1,0 +1,20 @@
+/**
+ * Creates a scheduler that coalesces calls until the queued microtask runs.
+ */
+function createScheduleOnce(run: () => void): () => void {
+    let isScheduled = false;
+
+    return () => {
+        if (isScheduled) {
+            return;
+        }
+
+        isScheduled = true;
+        Promise.resolve().then(() => {
+            isScheduled = false;
+            run();
+        });
+    };
+}
+
+export default createScheduleOnce;

--- a/src/libs/Navigation/helpers/getValidDynamicRouteBasePath.ts
+++ b/src/libs/Navigation/helpers/getValidDynamicRouteBasePath.ts
@@ -1,0 +1,37 @@
+import Log from '@libs/Log';
+import Navigation from '@libs/Navigation/Navigation';
+
+import type {Route} from '@src/ROUTES';
+import type {Screen} from '@src/SCREENS';
+
+import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
+import getStateFromPath from './getStateFromPath';
+
+type GetValidDynamicRouteBasePathParams = {
+    entryScreens: ReadonlyArray<Screen | '*'>;
+    fallbackPath: Route;
+};
+
+/** Returns the active route when it can host a dynamic route, or a known-valid fallback. */
+function getValidDynamicRouteBasePath({entryScreens, fallbackPath}: GetValidDynamicRouteBasePathParams): Route {
+    const activeRoute = Navigation.getActiveRoute();
+    if (!activeRoute) {
+        return fallbackPath;
+    }
+
+    try {
+        // Navigation builds this path from the current navigation state, so it is a valid app route.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const activeRoutePath = activeRoute as Route;
+        const focusedRouteName = findFocusedRouteWithOnyxTabGuard(getStateFromPath(activeRoutePath) ?? {})?.name;
+        if (focusedRouteName && entryScreens.some((entryScreen) => entryScreen === '*' || entryScreen === focusedRouteName)) {
+            return activeRoutePath;
+        }
+    } catch (error) {
+        Log.warn('[Navigation] Failed to resolve a dynamic route base path', {activeRoute, error});
+    }
+
+    return fallbackPath;
+}
+
+export default getValidDynamicRouteBasePath;

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -956,7 +956,9 @@ function clearOnyxAndResetApp(shouldNavigateToHomepage?: boolean) {
     // Seed LAST_FULL_RECONNECT_TIME so subscribeToFullReconnect doesn't fire a duplicate
     // ReconnectApp once the openApp() below lands NVP_RECONNECT_APP_IF_FULL_RECONNECT_BEFORE.
     const resetPromise = clearWorkboxRecoveryCaches().then(() =>
-        clearOnyxAndSeedFullReconnect(KEYS_TO_PRESERVE)
+        // Mark the app as loading in the same transaction that clears account-scoped data. This prevents
+        // consumers from evaluating the transient post-clear state before OpenApp has started hydrating it.
+        clearOnyxAndSeedFullReconnect(KEYS_TO_PRESERVE, {[ONYXKEYS.IS_LOADING_APP]: true})
             .then(() => {
                 // Network key is preserved, so when exiting imported state, we should:
                 // 1. Stop forcing offline mode so the app can reconnect

--- a/tests/unit/Navigation/createScheduleOnceTest.ts
+++ b/tests/unit/Navigation/createScheduleOnceTest.ts
@@ -1,0 +1,22 @@
+import createScheduleOnce from '@libs/Navigation/helpers/createScheduleOnce';
+
+describe('createScheduleOnce', () => {
+    it('coalesces pending calls and can schedule again after the callback runs', async () => {
+        const run = jest.fn();
+        const schedule = createScheduleOnce(run);
+
+        schedule();
+        schedule();
+
+        expect(run).not.toHaveBeenCalled();
+
+        await Promise.resolve();
+
+        expect(run).toHaveBeenCalledTimes(1);
+
+        schedule();
+        await Promise.resolve();
+
+        expect(run).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/unit/Navigation/guards/MigratedUserWelcomeModalGuard.test.ts
+++ b/tests/unit/Navigation/guards/MigratedUserWelcomeModalGuard.test.ts
@@ -6,6 +6,7 @@ import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES, {DYNAMIC_ROUTES} from '@src/ROUTES';
+import type {Route} from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 
 import type {NavigationAction, NavigationState} from '@react-navigation/native';
@@ -17,11 +18,12 @@ import waitForBatchedUpdates from '../../../utils/waitForBatchedUpdates';
 const migratedUserWelcomeRoute = createDynamicRoute(DYNAMIC_ROUTES.MIGRATED_USER_WELCOME.path, ROUTES.HOME);
 
 const mockNavigate = jest.fn();
+let mockActiveRoute: Route = ROUTES.HOME;
 jest.mock('@libs/Navigation/Navigation', () => ({
     navigate: (...args: unknown[]) => {
         mockNavigate(...args);
     },
-    getActiveRoute: () => 'home',
+    getActiveRoute: () => mockActiveRoute,
 }));
 
 describe('MigratedUserWelcomeModalGuard', () => {
@@ -52,6 +54,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
         onSessionOrLoadingAppChanged(undefined, true);
         resetSessionFlag();
         mockNavigate.mockClear();
+        mockActiveRoute = ROUTES.HOME;
         await Onyx.clear();
         await waitForBatchedUpdates();
     });
@@ -402,8 +405,52 @@ describe('MigratedUserWelcomeModalGuard', () => {
 
             // Now signal that session is ready and app is done loading
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            await waitForBatchedUpdates();
 
             expect(mockNavigate).toHaveBeenCalledWith(migratedUserWelcomeRoute);
+        });
+
+        it('should use a valid base when the active route cannot host the modal', async () => {
+            mockActiveRoute = ROUTES.SETTINGS_TROUBLESHOOT;
+            await Onyx.merge(ONYXKEYS.NVP_TRY_NEW_DOT, {
+                nudgeMigration: {
+                    timestamp: new Date(),
+                    cohort: 'test',
+                },
+            });
+            await waitForBatchedUpdates();
+            mockNavigate.mockClear();
+
+            onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            await waitForBatchedUpdates();
+
+            expect(mockNavigate).toHaveBeenCalledWith(migratedUserWelcomeRoute);
+        });
+
+        it('should not navigate while cleared Onyx data is reloading', async () => {
+            mockActiveRoute = ROUTES.SETTINGS_TROUBLESHOOT;
+            await Onyx.merge(ONYXKEYS.NVP_TRY_NEW_DOT, {
+                nudgeMigration: {
+                    timestamp: new Date(),
+                    cohort: 'test',
+                },
+            });
+            await Onyx.merge(ONYXKEYS.NVP_DISMISSED_PRODUCT_TRAINING, {
+                migratedUserWelcomeModal: {
+                    timestamp: new Date().toISOString(),
+                    dismissedMethod: 'click',
+                },
+            });
+            await waitForBatchedUpdates();
+            onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            mockNavigate.mockClear();
+
+            // clearOnyxAndResetApp atomically sets IS_LOADING_APP before clearing account-scoped data.
+            onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, true);
+            await Onyx.clear([ONYXKEYS.NVP_TRY_NEW_DOT]);
+            await waitForBatchedUpdates();
+
+            expect(mockNavigate).not.toHaveBeenCalled();
         });
 
         it('should not navigate when app is still loading', async () => {
@@ -417,6 +464,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
             mockNavigate.mockClear();
 
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, true);
+            await waitForBatchedUpdates();
 
             expect(mockNavigate).not.toHaveBeenCalled();
         });
@@ -432,6 +480,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
             mockNavigate.mockClear();
 
             onSessionOrLoadingAppChanged(undefined, false);
+            await waitForBatchedUpdates();
 
             expect(mockNavigate).not.toHaveBeenCalled();
         });
@@ -444,6 +493,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
             mockNavigate.mockClear();
 
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            await waitForBatchedUpdates();
 
             expect(mockNavigate).not.toHaveBeenCalled();
         });
@@ -465,6 +515,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
             mockNavigate.mockClear();
 
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            await waitForBatchedUpdates();
 
             expect(mockNavigate).not.toHaveBeenCalled();
         });
@@ -481,6 +532,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
 
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            await waitForBatchedUpdates();
 
             expect(mockNavigate).toHaveBeenCalledTimes(1);
         });
@@ -488,6 +540,7 @@ describe('MigratedUserWelcomeModalGuard', () => {
         it('should navigate via Onyx NVP_DISMISSED_PRODUCT_TRAINING callback when session is already set', async () => {
             // Set session first
             onSessionOrLoadingAppChanged({authToken: 'test-token', accountID: 123}, false);
+            await waitForBatchedUpdates();
             mockNavigate.mockClear();
 
             // Set up nudge migration and dismissed product training (modal not dismissed)


### PR DESCRIPTION
Clearing Onyx through Account > Troubleshoot > Clear cache and restart could briefly expose partially cleared account state. The migrated-user welcome guard could then build a modal route on top of Troubleshoot, which resolves to the not-found page on every platform. This PR keeps the reset behind the existing app-loading gate and ensures dynamic welcome modals use a valid base route.

### Explanation of Change

`clearOnyxAndResetApp` now seeds `IS_LOADING_APP=true` in the same operation that clears account-scoped Onyx data. Consumers therefore cannot act on the transient state between the clear and the following OpenApp request, and the fix adds no new `Onyx.connect` or `Onyx.connectWithoutView` subscription.

The migrated-user and Submit-plan welcome guards now share a route helper that checks whether the active screen can host their dynamic modal. If it cannot, the helper falls back to Home instead of constructing an invalid route. The migrated-user guard tests cover the reset race and the invalid Troubleshoot base path.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100860
PROPOSAL: N/A

### Tests

1. Sign in with an account that is eligible for the migrated-user welcome flow and has already dismissed that welcome modal.
2. Go to Account > Troubleshoot.
3. Select Clear cache and restart, then confirm Reset and refresh.
4. Verify the app returns to Troubleshoot and does not show the migrated-user welcome modal or the "Hmm... it's not here" page.
5. Repeat the reset and verify the same result.
6. Verify that no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go to Account > Troubleshoot, then disconnect the device from the network.
2. Select Clear cache and restart, then confirm Reset and refresh.
3. Verify the app does not navigate to the "Hmm... it's not here" page while account data is unavailable.
4. Restore the network connection.
5. Verify the app finishes loading on Troubleshoot without showing the migrated-user welcome modal.

### QA Steps

Same as Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ea7cc3eb-d3fb-4ffe-bace-9f6b6f028302" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/3fde3c1e-c731-4dfa-8513-85483271e7c5" controls width="100%"></video> |

</details>

<details>
<summary>iOS: Native</summary>

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/6817e908-7ed7-4d8a-bc35-8029c20c3460" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/1d21bd15-1d74-47dc-a407-0a121dabbc6a" controls width="100%"></video> |

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/208ff47c-d1a7-4eb6-b417-4f3166212259" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/af1dd365-cc62-409e-aae5-34e266f9fb92" controls width="100%"></video> |

</details>
