### PR TITLE
[LegendList 2/7] fix: use list-aware message edit scrolling

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -50,7 +50,7 @@ import {useActionListContext, useActionListRef} from '@pages/inbox/ActionListCon
 import {useAgentZeroStatus} from '@pages/inbox/AgentZeroStatusContext';
 import {useConciergeDraft} from '@pages/inbox/ConciergeDraftContext';
 import FloatingMessageCounter from '@pages/inbox/report/FloatingMessageCounter';
-import ReportActionIndexContext from '@pages/inbox/report/ReportActionIndexContext';
+import ReportActionIndexContext, {ReportActionIsNewestContext, ReportActionScrollToNewestContext} from '@pages/inbox/report/ReportActionIndexContext';
 import ReportActionsListItemRenderer from '@pages/inbox/report/ReportActionsListItemRenderer';
 import {getUnreadMarkerReportAction} from '@pages/inbox/report/shouldDisplayNewMarkerOnReportAction';
 import useReportUnreadMessageScrollTracking from '@pages/inbox/report/useReportUnreadMessageScrollTracking';
@@ -636,26 +636,31 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
                 !isConsecutiveChronosAutomaticTimerAction(visibleReportActions, indexWithinReportActions, chatIncludesChronosWithID(reportAction?.reportID), isOffline) &&
                 hasNextActionMadeBySameActor(visibleReportActions, indexWithinReportActions, isOffline);
             const shouldDisableContextMenuForConciergeDraft = isDraftPendingCompletion && draftReportActionID === reportAction.reportActionID;
+            const isNewestReportAction = indexWithinReportActions === visibleReportActions.length - 1;
 
             return (
-                <ReportActionIndexContext.Provider value={indexWithinReportActions}>
-                    <ReportActionsListItemRenderer
-                        reportAction={reportAction}
-                        parentReportAction={parentReportAction}
-                        parentReportActionForTransactionThread={EmptyParentReportActionForTransactionThread}
-                        report={reportStable}
-                        transactionThreadReport={transactionThreadReport}
-                        chatReport={chatReport}
-                        displayAsGroup={displayAsGroup}
-                        shouldDisplayNewMarker={reportAction.reportActionID === unreadMarkerReportActionID}
-                        shouldDisplayReplyDivider={visibleReportActions.length > 1}
-                        isFirstVisibleReportAction={firstVisibleReportActionID === reportAction.reportActionID}
-                        shouldHideThreadDividerLine
-                        linkedReportActionID={linkedReportActionID}
-                        isHarvestCreatedExpenseReport={shouldShowHarvestCreatedAction}
-                        shouldDisableContextMenuForConciergeDraft={shouldDisableContextMenuForConciergeDraft}
-                    />
-                </ReportActionIndexContext.Provider>
+                <ReportActionScrollToNewestContext.Provider value={scrollToBottom}>
+                    <ReportActionIsNewestContext.Provider value={isNewestReportAction}>
+                        <ReportActionIndexContext.Provider value={indexWithinReportActions}>
+                            <ReportActionsListItemRenderer
+                                reportAction={reportAction}
+                                parentReportAction={parentReportAction}
+                                parentReportActionForTransactionThread={EmptyParentReportActionForTransactionThread}
+                                report={reportStable}
+                                transactionThreadReport={transactionThreadReport}
+                                chatReport={chatReport}
+                                displayAsGroup={displayAsGroup}
+                                shouldDisplayNewMarker={reportAction.reportActionID === unreadMarkerReportActionID}
+                                shouldDisplayReplyDivider={visibleReportActions.length > 1}
+                                isFirstVisibleReportAction={firstVisibleReportActionID === reportAction.reportActionID}
+                                shouldHideThreadDividerLine
+                                linkedReportActionID={linkedReportActionID}
+                                isHarvestCreatedExpenseReport={shouldShowHarvestCreatedAction}
+                                shouldDisableContextMenuForConciergeDraft={shouldDisableContextMenuForConciergeDraft}
+                            />
+                        </ReportActionIndexContext.Provider>
+                    </ReportActionIsNewestContext.Provider>
+                </ReportActionScrollToNewestContext.Provider>
             );
         },
         [
@@ -671,6 +676,7 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
             shouldShowHarvestCreatedAction,
             draftReportActionID,
             isDraftPendingCompletion,
+            scrollToBottom,
         ],
     );
 

--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -50,7 +50,7 @@ import {useActionListContext, useActionListRef} from '@pages/inbox/ActionListCon
 import {useAgentZeroStatus} from '@pages/inbox/AgentZeroStatusContext';
 import {useConciergeDraft} from '@pages/inbox/ConciergeDraftContext';
 import FloatingMessageCounter from '@pages/inbox/report/FloatingMessageCounter';
-import ReportActionIndexContext, {ReportActionIsNewestContext, ReportActionScrollToNewestContext} from '@pages/inbox/report/ReportActionIndexContext';
+import {ReportActionPositionContextProvider, ReportActionScrollToNewestContext} from '@pages/inbox/report/ReportActionIndexContext';
 import ReportActionsListItemRenderer from '@pages/inbox/report/ReportActionsListItemRenderer';
 import {getUnreadMarkerReportAction} from '@pages/inbox/report/shouldDisplayNewMarkerOnReportAction';
 import useReportUnreadMessageScrollTracking from '@pages/inbox/report/useReportUnreadMessageScrollTracking';
@@ -640,26 +640,27 @@ function MoneyRequestReportActionsList({onLayout}: MoneyRequestReportListProps) 
 
             return (
                 <ReportActionScrollToNewestContext.Provider value={scrollToBottom}>
-                    <ReportActionIsNewestContext.Provider value={isNewestReportAction}>
-                        <ReportActionIndexContext.Provider value={indexWithinReportActions}>
-                            <ReportActionsListItemRenderer
-                                reportAction={reportAction}
-                                parentReportAction={parentReportAction}
-                                parentReportActionForTransactionThread={EmptyParentReportActionForTransactionThread}
-                                report={reportStable}
-                                transactionThreadReport={transactionThreadReport}
-                                chatReport={chatReport}
-                                displayAsGroup={displayAsGroup}
-                                shouldDisplayNewMarker={reportAction.reportActionID === unreadMarkerReportActionID}
-                                shouldDisplayReplyDivider={visibleReportActions.length > 1}
-                                isFirstVisibleReportAction={firstVisibleReportActionID === reportAction.reportActionID}
-                                shouldHideThreadDividerLine
-                                linkedReportActionID={linkedReportActionID}
-                                isHarvestCreatedExpenseReport={shouldShowHarvestCreatedAction}
-                                shouldDisableContextMenuForConciergeDraft={shouldDisableContextMenuForConciergeDraft}
-                            />
-                        </ReportActionIndexContext.Provider>
-                    </ReportActionIsNewestContext.Provider>
+                    <ReportActionPositionContextProvider
+                        index={indexWithinReportActions}
+                        isNewest={isNewestReportAction}
+                    >
+                        <ReportActionsListItemRenderer
+                            reportAction={reportAction}
+                            parentReportAction={parentReportAction}
+                            parentReportActionForTransactionThread={EmptyParentReportActionForTransactionThread}
+                            report={reportStable}
+                            transactionThreadReport={transactionThreadReport}
+                            chatReport={chatReport}
+                            displayAsGroup={displayAsGroup}
+                            shouldDisplayNewMarker={reportAction.reportActionID === unreadMarkerReportActionID}
+                            shouldDisplayReplyDivider={visibleReportActions.length > 1}
+                            isFirstVisibleReportAction={firstVisibleReportActionID === reportAction.reportActionID}
+                            shouldHideThreadDividerLine
+                            linkedReportActionID={linkedReportActionID}
+                            isHarvestCreatedExpenseReport={shouldShowHarvestCreatedAction}
+                            shouldDisableContextMenuForConciergeDraft={shouldDisableContextMenuForConciergeDraft}
+                        />
+                    </ReportActionPositionContextProvider>
                 </ReportActionScrollToNewestContext.Provider>
             );
         },

--- a/src/pages/inbox/report/ReportActionCompose/useEditMessage.ts
+++ b/src/pages/inbox/report/ReportActionCompose/useEditMessage.ts
@@ -23,6 +23,7 @@ type UseEditMessageProps = {
     originalReportID: string | undefined;
     reportAction: OnyxTypes.ReportAction | null | undefined;
     shouldScrollToLastMessage?: boolean;
+    scrollToLastMessage?: () => void;
     debouncedCommentMaxLengthValidation: DebouncedFuncLeading<(value: string) => boolean>;
     composerRef: React.RefObject<ComposerRef | null>;
 };
@@ -30,7 +31,15 @@ type UseEditMessageProps = {
 /**
  * Delete the draft of the comment being edited. This will take the comment out of "edit mode" with the old content.
  */
-function useEditMessage({reportID, originalReportID, reportAction, shouldScrollToLastMessage = false, debouncedCommentMaxLengthValidation, composerRef}: UseEditMessageProps) {
+function useEditMessage({
+    reportID,
+    originalReportID,
+    reportAction,
+    shouldScrollToLastMessage = false,
+    scrollToLastMessage,
+    debouncedCommentMaxLengthValidation,
+    composerRef,
+}: UseEditMessageProps) {
     const reportScrollManager = useReportScrollManager();
 
     const {email} = useCurrentUserPersonalDetails();
@@ -51,9 +60,16 @@ function useEditMessage({reportID, originalReportID, reportAction, shouldScrollT
         clearAllReportActionDrafts();
 
         // Scroll to the last comment after editing to make sure the whole comment is clearly visible in the report.
-        if (shouldScrollToLastMessage) {
-            reportScrollManager.scrollToIndex(0);
+        if (!shouldScrollToLastMessage) {
+            return;
         }
+
+        if (scrollToLastMessage) {
+            scrollToLastMessage();
+            return;
+        }
+
+        reportScrollManager.scrollToIndex(0);
     }
 
     /**

--- a/src/pages/inbox/report/ReportActionIndexContext.tsx
+++ b/src/pages/inbox/report/ReportActionIndexContext.tsx
@@ -1,20 +1,30 @@
-import {createContext} from 'react';
+import type {PropsWithChildren} from 'react';
+
+import {createContext, useMemo} from 'react';
+
+type ReportActionPosition = {
+    index: number;
+    isNewest: boolean;
+};
 
 /**
- * Carries an action item's position index from the list renderer down to the rare consumers that
- * actually need it (e.g. `ReportActionItemMessageEdit` for scroll-to-index during edit mode).
+ * Carries an action item's position from the list renderer down to the rare consumers that
+ * actually need it (e.g. `ReportActionItemMessageEdit` for scrolling during edit mode).
  *
- * Using context keeps `index` out of the prop signatures of every intermediate component, so a
- * position shift caused by a new message arriving doesn't cascade re-renders through items that
- * never read it. Only components that `useContext(ReportActionIndexContext)` re-render on change.
+ * Using context keeps position data out of the prop signatures of every intermediate component, so
+ * a shift caused by a new message arriving doesn't cascade re-renders through items that never read
+ * it. Only components that `useContext(ReportActionIndexContext)` re-render on change.
  */
-const ReportActionIndexContext = createContext<number>(0);
-
-/** Lets shared list implementations identify their newest report action without assuming an ordering direction. */
-const ReportActionIsNewestContext = createContext<boolean | undefined>(undefined);
+const ReportActionIndexContext = createContext<ReportActionPosition>({index: 0, isNewest: true});
 
 /** Lets shared list implementations provide their own reliable way to reach the newest action. */
 const ReportActionScrollToNewestContext = createContext<(() => void) | undefined>(undefined);
 
-export {ReportActionIsNewestContext, ReportActionScrollToNewestContext};
+function ReportActionPositionContextProvider({children, index, isNewest}: PropsWithChildren<ReportActionPosition>) {
+    const value = useMemo(() => ({index, isNewest}), [index, isNewest]);
+
+    return <ReportActionIndexContext.Provider value={value}>{children}</ReportActionIndexContext.Provider>;
+}
+
+export {ReportActionPositionContextProvider, ReportActionScrollToNewestContext};
 export default ReportActionIndexContext;

--- a/src/pages/inbox/report/ReportActionIndexContext.tsx
+++ b/src/pages/inbox/report/ReportActionIndexContext.tsx
@@ -1,6 +1,6 @@
 import type {PropsWithChildren} from 'react';
 
-import {createContext, useMemo} from 'react';
+import {createContext} from 'react';
 
 type ReportActionPosition = {
     index: number;
@@ -21,9 +21,7 @@ const ReportActionIndexContext = createContext<ReportActionPosition>({index: 0, 
 const ReportActionScrollToNewestContext = createContext<(() => void) | undefined>(undefined);
 
 function ReportActionPositionContextProvider({children, index, isNewest}: PropsWithChildren<ReportActionPosition>) {
-    const value = useMemo(() => ({index, isNewest}), [index, isNewest]);
-
-    return <ReportActionIndexContext.Provider value={value}>{children}</ReportActionIndexContext.Provider>;
+    return <ReportActionIndexContext.Provider value={{index, isNewest}}>{children}</ReportActionIndexContext.Provider>;
 }
 
 export {ReportActionPositionContextProvider, ReportActionScrollToNewestContext};

--- a/src/pages/inbox/report/ReportActionIndexContext.tsx
+++ b/src/pages/inbox/report/ReportActionIndexContext.tsx
@@ -10,4 +10,11 @@ import {createContext} from 'react';
  */
 const ReportActionIndexContext = createContext<number>(0);
 
+/** Lets shared list implementations identify their newest report action without assuming an ordering direction. */
+const ReportActionIsNewestContext = createContext<boolean | undefined>(undefined);
+
+/** Lets shared list implementations provide their own reliable way to reach the newest action. */
+const ReportActionScrollToNewestContext = createContext<(() => void) | undefined>(undefined);
+
+export {ReportActionIsNewestContext, ReportActionScrollToNewestContext};
 export default ReportActionIndexContext;

--- a/src/pages/inbox/report/ReportActionItemMessageEdit.tsx
+++ b/src/pages/inbox/report/ReportActionItemMessageEdit.tsx
@@ -49,7 +49,7 @@ import useComposerSuggestions from './ReportActionCompose/useComposerSuggestions
 import useDebouncedCommentMaxLengthValidation from './ReportActionCompose/useDebouncedCommentMaxLengthValidation';
 import useEditMessage from './ReportActionCompose/useEditMessage';
 import {useReportActionActiveEdit, useReportActionActiveEditActions} from './ReportActionEditMessageContext';
-import ReportActionIndexContext from './ReportActionIndexContext';
+import ReportActionIndexContext, {ReportActionIsNewestContext, ReportActionScrollToNewestContext} from './ReportActionIndexContext';
 import shouldUseEmojiPickerSelection from './shouldUseEmojiPickerSelection';
 import useDebouncedSaveDraft from './useDebouncedSaveDraft';
 import useDraftMessageVideoAttributeCache from './useDraftMessageVideoAttributeCache';
@@ -78,6 +78,8 @@ const DEFAULT_MODAL_VALUE = {
 
 function ReportActionItemMessageEdit({action, reportID, originalReportID, policyID, ref}: ReportActionItemMessageEditProps) {
     const index = useContext(ReportActionIndexContext);
+    const isNewestOverride = useContext(ReportActionIsNewestContext);
+    const scrollToNewestAction = useContext(ReportActionScrollToNewestContext);
     const [preferredSkinTone = CONST.EMOJI_DEFAULT_SKIN_TONE] = useOnyx(ONYXKEYS.PREFERRED_EMOJI_SKIN_TONE);
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
     const [reportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getNonEmptyStringOnyxID(reportID)}`);
@@ -249,7 +251,8 @@ function ReportActionItemMessageEdit({action, reportID, originalReportID, policy
         reportID,
         originalReportID,
         reportAction: action,
-        shouldScrollToLastMessage: index === 0,
+        shouldScrollToLastMessage: isNewestOverride ?? index === 0,
+        scrollToLastMessage: scrollToNewestAction,
         debouncedCommentMaxLengthValidation,
         composerRef,
     });

--- a/src/pages/inbox/report/ReportActionItemMessageEdit.tsx
+++ b/src/pages/inbox/report/ReportActionItemMessageEdit.tsx
@@ -49,7 +49,7 @@ import useComposerSuggestions from './ReportActionCompose/useComposerSuggestions
 import useDebouncedCommentMaxLengthValidation from './ReportActionCompose/useDebouncedCommentMaxLengthValidation';
 import useEditMessage from './ReportActionCompose/useEditMessage';
 import {useReportActionActiveEdit, useReportActionActiveEditActions} from './ReportActionEditMessageContext';
-import ReportActionIndexContext, {ReportActionIsNewestContext, ReportActionScrollToNewestContext} from './ReportActionIndexContext';
+import ReportActionIndexContext, {ReportActionScrollToNewestContext} from './ReportActionIndexContext';
 import shouldUseEmojiPickerSelection from './shouldUseEmojiPickerSelection';
 import useDebouncedSaveDraft from './useDebouncedSaveDraft';
 import useDraftMessageVideoAttributeCache from './useDraftMessageVideoAttributeCache';
@@ -77,8 +77,7 @@ const DEFAULT_MODAL_VALUE = {
 };
 
 function ReportActionItemMessageEdit({action, reportID, originalReportID, policyID, ref}: ReportActionItemMessageEditProps) {
-    const index = useContext(ReportActionIndexContext);
-    const isNewestOverride = useContext(ReportActionIsNewestContext);
+    const {index, isNewest} = useContext(ReportActionIndexContext);
     const scrollToNewestAction = useContext(ReportActionScrollToNewestContext);
     const [preferredSkinTone = CONST.EMOJI_DEFAULT_SKIN_TONE] = useOnyx(ONYXKEYS.PREFERRED_EMOJI_SKIN_TONE);
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
@@ -251,7 +250,7 @@ function ReportActionItemMessageEdit({action, reportID, originalReportID, policy
         reportID,
         originalReportID,
         reportAction: action,
-        shouldScrollToLastMessage: isNewestOverride ?? index === 0,
+        shouldScrollToLastMessage: isNewest,
         scrollToLastMessage: scrollToNewestAction,
         debouncedCommentMaxLengthValidation,
         composerRef,

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -66,7 +66,7 @@ import {isTrackIntentUserSelector} from '@selectors/Onboarding';
 import React, {useEffect, useRef, useState} from 'react';
 
 import FloatingMessageCounter from './FloatingMessageCounter';
-import ReportActionIndexContext from './ReportActionIndexContext';
+import {ReportActionPositionContextProvider} from './ReportActionIndexContext';
 import {useReportActionsListActions, useReportActionsListState} from './ReportActionsListContext';
 import ReportActionsListHeader from './ReportActionsListHeader';
 import ReportActionsListItemRenderer from './ReportActionsListItemRenderer';
@@ -366,7 +366,10 @@ function ReportActionsListContent({reportID, conciergeChat, onLayout}: ReportAct
         const shouldDisableContextMenuForConciergeDraft = isDraftPendingCompletion && draftReportActionID === reportAction.reportActionID;
 
         return (
-            <ReportActionIndexContext.Provider value={index}>
+            <ReportActionPositionContextProvider
+                index={index}
+                isNewest={index === 0}
+            >
                 <ReportActionsListItemRenderer
                     reportAction={reportAction}
                     parentReportAction={parentReportAction}
@@ -396,7 +399,7 @@ function ReportActionsListContent({reportID, conciergeChat, onLayout}: ReportAct
                         onPress={onShowPreviousMessages}
                     />
                 )}
-            </ReportActionIndexContext.Provider>
+            </ReportActionPositionContextProvider>
         );
     };
 

--- a/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
+++ b/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
@@ -11,6 +11,9 @@ import {useIsReportLoadPending} from '@hooks/useInFlightRequests';
 import type * as InFlightRequests from '@hooks/useInFlightRequests';
 import useNetwork from '@hooks/useNetwork';
 
+import {ActionListContextProvider} from '@pages/inbox/ActionListContext';
+import type * as ReportActionIndexContexts from '@pages/inbox/report/ReportActionIndexContext';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
@@ -31,6 +34,12 @@ const FAKE_POLICY_ID = 'FAKE_POLICY_001';
 const FAKE_ACCOUNT_ID = 15593135;
 const FAKE_TRANSACTION_ID = 'FAKE_TXN_001';
 const FAKE_EMAIL = 'testuser@example.com';
+const MOCK_UNIFIED_LAST_ITEM_INDEX = 37;
+const mockScrollToIndex = jest.fn();
+const mockScrollToEnd = jest.fn();
+const mockScrollToOffset = jest.fn();
+let mockIsNewestReportAction: boolean | undefined;
+let mockScrollToNewestAction: (() => void) | undefined;
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual<typeof NativeNavigation>('@react-navigation/native'),
@@ -80,12 +89,38 @@ jest.mock('@libs/Navigation/Navigation', () => ({
 jest.mock('@components/MoneyRequestReportView/MoneyRequestReportTransactionList', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const {View} = require('react-native');
-    return ({listFooterComponent, isLoadingInitialActions}: {listFooterComponent?: React.ReactElement; isLoadingInitialActions: boolean}) => (
-        <View testID="MockMoneyRequestReportTransactionList">
-            {isLoadingInitialActions ? <View testID="MockInitialReportActionsSkeleton" /> : null}
-            {listFooterComponent}
-        </View>
-    );
+    const ReactActual = jest.requireActual<typeof React>('react');
+    return ({
+        listFooterComponent,
+        isLoadingInitialActions,
+        listRef,
+        onLastItemIndexChange,
+        visibleReportActions,
+        renderReportAction,
+    }: {
+        listFooterComponent?: React.ReactElement;
+        isLoadingInitialActions: boolean;
+        listRef: React.Ref<{
+            scrollToIndex: typeof mockScrollToIndex;
+            scrollToEnd: typeof mockScrollToEnd;
+            scrollToOffset: typeof mockScrollToOffset;
+        }>;
+        onLastItemIndexChange?: (index: number) => void;
+        visibleReportActions: ReportAction[];
+        renderReportAction: (reportAction: ReportAction, index: number) => React.ReactElement;
+    }) => {
+        ReactActual.useImperativeHandle(listRef, () => ({scrollToIndex: mockScrollToIndex, scrollToEnd: mockScrollToEnd, scrollToOffset: mockScrollToOffset}));
+        ReactActual.useLayoutEffect(() => onLastItemIndexChange?.(MOCK_UNIFIED_LAST_ITEM_INDEX), [onLastItemIndexChange]);
+        const newestAction = visibleReportActions.at(-1);
+
+        return (
+            <View testID="MockMoneyRequestReportTransactionList">
+                {isLoadingInitialActions ? <View testID="MockInitialReportActionsSkeleton" /> : null}
+                {newestAction ? renderReportAction(newestAction, visibleReportActions.length - 1) : null}
+                {listFooterComponent}
+            </View>
+        );
+    };
 });
 
 jest.mock('@components/MoneyRequestReportView/SearchMoneyRequestReportEmptyState', () => {
@@ -159,7 +194,17 @@ jest.mock('@hooks/useMobileSelectionMode', () => jest.fn(() => true));
 jest.mock('@hooks/useResponsiveLayoutOnWideRHP', () => jest.fn(() => ({shouldUseNarrowLayout: true})));
 jest.mock('@hooks/useFilterSelectedTransactions', () => jest.fn());
 jest.mock('@hooks/useLoadReportActions', () => jest.fn(() => ({loadOlderChats: jest.fn(), loadNewerChats: jest.fn()})));
-jest.mock('@pages/inbox/report/ReportActionsListItemRenderer', () => jest.fn(() => null));
+jest.mock('@pages/inbox/report/ReportActionsListItemRenderer', () => {
+    const ReactActual = jest.requireActual<typeof React>('react');
+    const {ReportActionIsNewestContext: ReportActionIsNewestContextActual, ReportActionScrollToNewestContext: ReportActionScrollToNewestContextActual} =
+        jest.requireActual<typeof ReportActionIndexContexts>('@pages/inbox/report/ReportActionIndexContext');
+
+    return jest.fn(() => {
+        mockIsNewestReportAction = ReactActual.useContext(ReportActionIsNewestContextActual);
+        mockScrollToNewestAction = ReactActual.useContext(ReportActionScrollToNewestContextActual);
+        return null;
+    });
+});
 jest.mock('@hooks/useParentReportAction', () => jest.fn(() => undefined));
 jest.mock('@navigation/helpers/isSearchTopmostFullScreenRoute', () => jest.fn(() => false));
 
@@ -223,9 +268,23 @@ const mockReportAction = createMock<ReportAction<typeof CONST.REPORT.ACTIONS.TYP
     childReportID: 'CHILD_001',
 });
 
+const mockCommentReportAction: ReportAction = {
+    reportActionID: 'ACTION_002',
+    reportID: FAKE_REPORT_ID,
+    actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+    created: '2025-01-02 00:00:00',
+    actorAccountID: FAKE_ACCOUNT_ID,
+    message: [{type: 'COMMENT', html: 'comment', text: 'comment'}],
+    originalMessage: {},
+    shouldShow: true,
+    person: [{type: 'TEXT', style: 'strong', text: 'Test User'}],
+    pendingAction: null,
+    errors: {},
+};
+
 const renderComponent = () => {
     return render(
-        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+        <ComposeProviders components={[ActionListContextProvider, OnyxListItemProvider, LocaleContextProvider]}>
             <SearchContextProvider>
                 <ScreenWrapper testID="test">
                     <MoneyRequestReportActionsList />
@@ -250,6 +309,8 @@ describe('MoneyRequestReportActionsList - Reject Educational Modal', () => {
 
     beforeEach(async () => {
         jest.clearAllMocks();
+        mockIsNewestReportAction = undefined;
+        mockScrollToNewestAction = undefined;
         jest.spyOn(NativeNavigation, 'useIsFocused').mockReturnValue(true);
         mockUseIsReportLoadPending.mockReturnValue(false);
         mockUseNetwork.mockReturnValue({isOffline: false});
@@ -257,6 +318,30 @@ describe('MoneyRequestReportActionsList - Reject Educational Modal', () => {
             await Onyx.clear();
             await waitForBatchedUpdatesWithAct();
         });
+    });
+
+    it('should use the unified list index when the newest action requests a bottom scroll', async () => {
+        await act(async () => {
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.REPORT}${FAKE_REPORT_ID}` as const]: mockReport,
+                [`${ONYXKEYS.COLLECTION.POLICY}${FAKE_POLICY_ID}` as const]: mockPolicy,
+                [`${ONYXKEYS.COLLECTION.TRANSACTION}${FAKE_TRANSACTION_ID}` as const]: mockTransaction,
+                [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${FAKE_REPORT_ID}` as const]: {
+                    [mockReportAction.reportActionID]: mockReportAction,
+                    [mockCommentReportAction.reportActionID]: mockCommentReportAction,
+                },
+                [`${ONYXKEYS.COLLECTION.RAM_ONLY_REPORT_LOADING_STATE}${FAKE_REPORT_ID}` as const]: {isLoadingInitialReportActions: false, hasOnceLoadedReportActions: true},
+                [ONYXKEYS.SESSION]: {accountID: FAKE_ACCOUNT_ID, email: FAKE_EMAIL} as Session,
+            });
+        });
+
+        renderComponent();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockIsNewestReportAction).toBe(true);
+        act(() => mockScrollToNewestAction?.());
+        expect(mockScrollToIndex).toHaveBeenCalledWith({index: MOCK_UNIFIED_LAST_ITEM_INDEX, animated: false, viewPosition: 1});
+        expect(mockScrollToEnd).not.toHaveBeenCalled();
     });
 
     it('should show reject educational modal when reject option is selected and explanation has NOT been dismissed', async () => {

--- a/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
+++ b/tests/ui/MoneyRequestReportActionsListRejectModalTest.tsx
@@ -196,11 +196,11 @@ jest.mock('@hooks/useFilterSelectedTransactions', () => jest.fn());
 jest.mock('@hooks/useLoadReportActions', () => jest.fn(() => ({loadOlderChats: jest.fn(), loadNewerChats: jest.fn()})));
 jest.mock('@pages/inbox/report/ReportActionsListItemRenderer', () => {
     const ReactActual = jest.requireActual<typeof React>('react');
-    const {ReportActionIsNewestContext: ReportActionIsNewestContextActual, ReportActionScrollToNewestContext: ReportActionScrollToNewestContextActual} =
+    const {default: ReportActionIndexContextActual, ReportActionScrollToNewestContext: ReportActionScrollToNewestContextActual} =
         jest.requireActual<typeof ReportActionIndexContexts>('@pages/inbox/report/ReportActionIndexContext');
 
     return jest.fn(() => {
-        mockIsNewestReportAction = ReactActual.useContext(ReportActionIsNewestContextActual);
+        mockIsNewestReportAction = ReactActual.useContext(ReportActionIndexContextActual).isNewest;
         mockScrollToNewestAction = ReactActual.useContext(ReportActionScrollToNewestContextActual);
         return null;
     });

--- a/tests/ui/ReportActionItemMessageEditTest.tsx
+++ b/tests/ui/ReportActionItemMessageEditTest.tsx
@@ -9,6 +9,7 @@ import {editReportComment} from '@libs/actions/Report';
 
 import * as ReportActionContextMenu from '@pages/inbox/report/ContextMenu/ReportActionContextMenu';
 import {ReportActionEditMessageContextProvider} from '@pages/inbox/report/ReportActionEditMessageContext';
+import ReportActionIndexContext, {ReportActionIsNewestContext, ReportActionScrollToNewestContext} from '@pages/inbox/report/ReportActionIndexContext';
 import type {ReportActionItemMessageEditProps} from '@pages/inbox/report/ReportActionItemMessageEdit';
 import ReportActionItemMessageEdit from '@pages/inbox/report/ReportActionItemMessageEdit';
 import {draftMessageVideoAttributeCache} from '@pages/inbox/report/useDraftMessageVideoAttributeCache';
@@ -86,13 +87,19 @@ function ReportScreenProviders({children}: PropsWithChildren) {
     return <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, KeyboardStateProvider, ReportActionEditMessageContextProviderForReport]}>{children}</ComposeProviders>;
 }
 
-const renderReportActionItemMessageEdit = (props?: Partial<ReportActionItemMessageEditProps>) => {
+const renderReportActionItemMessageEdit = (props?: Partial<ReportActionItemMessageEditProps>, listContext?: {index: number; isNewest: boolean; scrollToNewestAction?: () => void}) => {
     return render(
         <ReportScreenProviders>
-            <ReportActionItemMessageEdit
-                {...defaultProps}
-                {...props}
-            />
+            <ReportActionScrollToNewestContext.Provider value={listContext?.scrollToNewestAction}>
+                <ReportActionIsNewestContext.Provider value={listContext?.isNewest}>
+                    <ReportActionIndexContext.Provider value={listContext?.index ?? 0}>
+                        <ReportActionItemMessageEdit
+                            {...defaultProps}
+                            {...props}
+                        />
+                    </ReportActionIndexContext.Provider>
+                </ReportActionIsNewestContext.Provider>
+            </ReportActionScrollToNewestContext.Provider>
         </ReportScreenProviders>,
     );
 };
@@ -209,6 +216,26 @@ describe('ReportActionCompose Integration Tests', () => {
             expect(videoAttributeCache?.[videoSource]).toContain('data-name');
             expect(videoAttributeCache?.[videoSource]).toContain('data-expensify-height');
             expect(videoAttributeCache?.[videoSource]).toContain('data-expensify-width');
+        });
+
+        it('should use the list-specific scroll after saving the newest message', () => {
+            const scrollToNewestAction = jest.fn();
+            renderReportActionItemMessageEdit(undefined, {index: 9, isNewest: true, scrollToNewestAction});
+
+            fireEvent.changeText(screen.getByTestId('composer'), 'Edited message');
+            fireEvent.press(screen.getByLabelText('common.saveChanges'));
+
+            expect(scrollToNewestAction).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not scroll after saving a non-newest message at index zero', () => {
+            const scrollToNewestAction = jest.fn();
+            renderReportActionItemMessageEdit(undefined, {index: 0, isNewest: false, scrollToNewestAction});
+
+            fireEvent.changeText(screen.getByTestId('composer'), 'Edited message');
+            fireEvent.press(screen.getByLabelText('common.saveChanges'));
+
+            expect(scrollToNewestAction).not.toHaveBeenCalled();
         });
     });
 });

--- a/tests/ui/ReportActionItemMessageEditTest.tsx
+++ b/tests/ui/ReportActionItemMessageEditTest.tsx
@@ -9,7 +9,7 @@ import {editReportComment} from '@libs/actions/Report';
 
 import * as ReportActionContextMenu from '@pages/inbox/report/ContextMenu/ReportActionContextMenu';
 import {ReportActionEditMessageContextProvider} from '@pages/inbox/report/ReportActionEditMessageContext';
-import ReportActionIndexContext, {ReportActionIsNewestContext, ReportActionScrollToNewestContext} from '@pages/inbox/report/ReportActionIndexContext';
+import {ReportActionPositionContextProvider, ReportActionScrollToNewestContext} from '@pages/inbox/report/ReportActionIndexContext';
 import type {ReportActionItemMessageEditProps} from '@pages/inbox/report/ReportActionItemMessageEdit';
 import ReportActionItemMessageEdit from '@pages/inbox/report/ReportActionItemMessageEdit';
 import {draftMessageVideoAttributeCache} from '@pages/inbox/report/useDraftMessageVideoAttributeCache';
@@ -91,14 +91,15 @@ const renderReportActionItemMessageEdit = (props?: Partial<ReportActionItemMessa
     return render(
         <ReportScreenProviders>
             <ReportActionScrollToNewestContext.Provider value={listContext?.scrollToNewestAction}>
-                <ReportActionIsNewestContext.Provider value={listContext?.isNewest}>
-                    <ReportActionIndexContext.Provider value={listContext?.index ?? 0}>
-                        <ReportActionItemMessageEdit
-                            {...defaultProps}
-                            {...props}
-                        />
-                    </ReportActionIndexContext.Provider>
-                </ReportActionIsNewestContext.Provider>
+                <ReportActionPositionContextProvider
+                    index={listContext?.index ?? 0}
+                    isNewest={listContext?.isNewest ?? true}
+                >
+                    <ReportActionItemMessageEdit
+                        {...defaultProps}
+                        {...props}
+                    />
+                </ReportActionPositionContextProvider>
             </ReportActionScrollToNewestContext.Provider>
         </ReportScreenProviders>,
     );

--- a/tests/unit/hooks/useEditMessage.test.ts
+++ b/tests/unit/hooks/useEditMessage.test.ts
@@ -58,9 +58,10 @@ jest.mock('@hooks/useReportIsArchived', () => ({
     default: () => false,
 }));
 
+const mockScrollToIndex = jest.fn();
 jest.mock('@hooks/useReportScrollManager', () => ({
     __esModule: true,
-    default: () => ({scrollToIndex: jest.fn()}),
+    default: () => ({scrollToIndex: mockScrollToIndex}),
 }));
 
 jest.mock('@libs/ReportUtils', () => {
@@ -141,5 +142,45 @@ describe('useEditMessage', () => {
 
         const args = mockShowDeleteModal.mock.calls.at(0);
         expect(args?.[1]?.reportActionID).toBe(props.reportAction?.reportActionID);
+    });
+
+    it('scrolls to index zero after deleting the newest message draft without a list-specific callback', () => {
+        const {hook} = renderUseEditMessage({shouldScrollToLastMessage: true});
+
+        act(() => {
+            hook.result.current.publishDraft('   ');
+        });
+        act(() => {
+            mockShowDeleteModal.mock.calls.at(0)?.[3]?.();
+        });
+
+        expect(mockScrollToIndex).toHaveBeenCalledWith(0);
+    });
+
+    it('uses the list-specific scroll after deleting the newest message draft', () => {
+        const scrollToLastMessage = jest.fn();
+        const {hook} = renderUseEditMessage({shouldScrollToLastMessage: true, scrollToLastMessage});
+
+        act(() => {
+            hook.result.current.publishDraft('   ');
+        });
+        act(() => {
+            mockShowDeleteModal.mock.calls.at(0)?.[3]?.();
+        });
+
+        expect(scrollToLastMessage).toHaveBeenCalledTimes(1);
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
+    });
+
+    it('does not scroll after deleting a non-newest message draft', () => {
+        const scrollToLastMessage = jest.fn();
+        const {hook} = renderUseEditMessage({shouldScrollToLastMessage: false, scrollToLastMessage});
+
+        act(() => {
+            hook.result.current.deleteDraft();
+        });
+
+        expect(scrollToLastMessage).not.toHaveBeenCalled();
+        expect(mockScrollToIndex).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
In expense views, message-edit scrolling currently assumes the main report action list is inverted. `MoneyRequestReportActionsList` orders items chronologically, so editing its newest message can ask the wrong list position to stay visible. This WIP extraction makes message-edit scrolling list-aware while preserving existing report behavior.

@roryabraham @dmkt9
### Explanation of Change

The existing report action position context now carries both the action index and whether the action is newest, so each list declares its own ordering semantics. `MoneyRequestReportActionsList` also provides a separate list-level callback that scrolls to its newest position, while the inverted main report list keeps the existing report scroll manager fallback.

This is layer 2 of the seven-part LegendList series. Review order is #100732 → this PR → #100884 → #100733 → #100740 → #100734 → #100736. The branches are maintained with GH Stacks in the Margelo fork; because GitHub does not support linking cross-fork heads into an upstream Stack, each upstream PR targets `Expensify/App:main` and records the dependency order here.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98994
PROPOSAL:

No approved proposal is linked.

### Tests

1. Open an expense report with several report actions.
2. Edit and save the newest comment.
3. Verify the edited comment remains visible and the list stays at its newest position.
4. Edit an older comment and verify the list does not jump to its newest position.
5. Repeat the newest- and older-comment checks in a regular chat and verify its existing scroll behavior is unchanged.
6. Verify that no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Open a cached expense report, then go offline.
2. Edit the newest comment and verify it remains visible after saving.
3. Edit an older comment and verify the list does not jump to its newest position.
4. Return online and verify the pending edit synchronizes without changing the scroll position unexpectedly.

### QA Steps

Same as Tests and Offline tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f6eeff56-5a2f-449f-afb8-104d855122b0




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/9548b05d-e483-4cb2-8ee2-ce32dfad48ea



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/0325372a-8ba2-433f-95ea-5e6937774342



</details>


