### PR TITLE
[LegendList 3/7] fix: align report action loading skeletons

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
@@ -3,8 +3,7 @@ import MoneyReportHeader from '@components/MoneyReportHeader';
 import MoneyRequestHeader from '@components/MoneyRequestHeader';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import MoneyRequestReceiptView from '@components/ReportActionItem/MoneyRequestReceiptView';
-import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
-import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
+import ReportActionsSkeletonCover, {ReportActionsAnimatedSkeletonCover} from '@components/ReportActionsSkeletonCover';
 import ReportHeaderSkeletonView from '@components/ReportHeaderSkeletonView';
 
 import {useIsAppLoadPending, useIsReportLoadPending} from '@hooks/useInFlightRequests';
@@ -106,7 +105,7 @@ function InitialLoadingSkeleton({styles, onLayout}: {styles: ThemeStyles; onLayo
             <View style={[styles.appContentHeader, styles.borderBottom]}>
                 <ReportHeaderSkeletonView onBackButtonPress={() => {}} />
             </View>
-            <ReportActionsSkeletonCover />
+            <ReportActionsAnimatedSkeletonCover />
         </View>
     );
 }
@@ -218,11 +217,7 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
     }
 
     if (shouldShowEmptyActionsSkeleton) {
-        return (
-            <ReportActionsSkeletonCover>
-                <ReportActionsSkeletonView shouldAnimate={false} />
-            </ReportActionsSkeletonCover>
-        );
+        return <ReportActionsSkeletonCover />;
     }
 
     if (!report) {
@@ -233,7 +228,7 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
         return (
             <View style={styles.flex1}>
                 <ReportHeaderSkeletonView />
-                <ReportActionsSkeletonCover />
+                <ReportActionsAnimatedSkeletonCover />
                 {shouldDisplayReportFooter ? <ReportFooter /> : null}
             </View>
         );

--- a/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
@@ -3,6 +3,7 @@ import MoneyReportHeader from '@components/MoneyReportHeader';
 import MoneyRequestHeader from '@components/MoneyRequestHeader';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import MoneyRequestReceiptView from '@components/ReportActionItem/MoneyRequestReceiptView';
+import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 import ReportHeaderSkeletonView from '@components/ReportHeaderSkeletonView';
 
@@ -105,7 +106,7 @@ function InitialLoadingSkeleton({styles, onLayout}: {styles: ThemeStyles; onLayo
             <View style={[styles.appContentHeader, styles.borderBottom]}>
                 <ReportHeaderSkeletonView onBackButtonPress={() => {}} />
             </View>
-            <ReportActionsSkeletonView />
+            <ReportActionsSkeletonCover />
         </View>
     );
 }
@@ -217,7 +218,11 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
     }
 
     if (shouldShowEmptyActionsSkeleton) {
-        return <ReportActionsSkeletonView shouldAnimate={false} />;
+        return (
+            <ReportActionsSkeletonCover>
+                <ReportActionsSkeletonView shouldAnimate={false} />
+            </ReportActionsSkeletonCover>
+        );
     }
 
     if (!report) {
@@ -228,7 +233,7 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
         return (
             <View style={styles.flex1}>
                 <ReportHeaderSkeletonView />
-                <ReportActionsSkeletonView />
+                <ReportActionsSkeletonCover />
                 {shouldDisplayReportFooter ? <ReportFooter /> : null}
             </View>
         );

--- a/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportView.tsx
@@ -44,7 +44,7 @@ import type {LayoutChangeEvent} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 
 import {PortalHost} from '@gorhom/portal';
-import React, {useCallback, useEffect, useMemo} from 'react';
+import {useEffect} from 'react';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
@@ -126,34 +126,23 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
 
     const {reportActions: unfilteredReportActions} = usePaginatedReportActions(reportID);
 
-    const reportActions = useMemo(() => {
-        return getFilteredReportActionsForReportView(unfilteredReportActions);
-    }, [unfilteredReportActions]);
+    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
 
     const reportTransactions = useReportTransactionsCollection(reportID);
-    const transactions = useMemo(() => getAllNonDeletedTransactions(reportTransactions, reportActions, isOffline, true), [reportTransactions, reportActions, isOffline]);
+    const transactions = getAllNonDeletedTransactions(reportTransactions, reportActions, isOffline, true);
 
-    const visibleTransactions = useMemo(() => {
-        if (isOffline) {
-            return transactions;
-        }
-
-        // When there are no pending delete transactions, which is most of the time, we can return the same transactions keeping the same reference avoiding extra work
-        const hasPendingDelete = transactions.some((transaction) => transaction.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-        if (!hasPendingDelete) {
-            return transactions;
-        }
-
-        return transactions.filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-    }, [transactions, isOffline]);
+    // When there are no pending delete transactions, which is most of the time, return the same transactions to keep the same reference and avoid extra work.
+    const hasPendingDelete = transactions.some((transaction) => transaction.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+    const visibleTransactions =
+        isOffline || !hasPendingDelete ? transactions : transactions.filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
     const reportErrors = visibleTransactions.length === 1 && visibleTransactions.at(0)?.errors ? undefined : allReportErrors;
     const reportTransactionIDs = visibleTransactions.map((transaction) => transaction.transactionID);
     const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
 
     const isReportLoadPending = useIsReportLoadPending(reportID);
-    const dismissReportCreationError = useCallback(() => {
+    const dismissReportCreationError = () => {
         goBackFromSearchMoneyRequest({afterTransition: () => removeFailedReport(reportID)});
-    }, [reportID]);
+    };
 
     // Special case handling a report that is a transaction thread
     // If true we will use the standard `ReportActionsList` to display report data and a special header, anything else is handled via `MoneyRequestReportActionsList`
@@ -171,33 +160,29 @@ function MoneyRequestReportView({report, reportIDFromRoute, reportLoadingState, 
     const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`);
     const shouldShowWideRHPReceipt = visibleTransactions.length === 1 && !isSmallScreenWidth && !!transactionThreadReport;
 
-    const reportHeaderView = useMemo(
-        () =>
-            isTransactionThreadView ? (
-                <MoneyRequestHeader
-                    reportID={report?.reportID}
-                    onBackButtonPress={() => {
-                        if (!backToRoute) {
-                            goBackFromSearchMoneyRequest();
-                            return;
-                        }
-                        Navigation.goBack(backToRoute);
-                    }}
-                />
-            ) : (
-                <MoneyReportHeader
-                    reportID={report?.reportID}
-                    shouldDisplayBackButton
-                    onBackButtonPress={() => {
-                        if (!backToRoute) {
-                            goBackFromSearchMoneyRequest();
-                            return;
-                        }
-                        Navigation.goBack(backToRoute);
-                    }}
-                />
-            ),
-        [backToRoute, isTransactionThreadView, report?.reportID],
+    const reportHeaderView = isTransactionThreadView ? (
+        <MoneyRequestHeader
+            reportID={report?.reportID}
+            onBackButtonPress={() => {
+                if (!backToRoute) {
+                    goBackFromSearchMoneyRequest();
+                    return;
+                }
+                Navigation.goBack(backToRoute);
+            }}
+        />
+    ) : (
+        <MoneyReportHeader
+            reportID={report?.reportID}
+            shouldDisplayBackButton
+            onBackButtonPress={() => {
+                if (!backToRoute) {
+                    goBackFromSearchMoneyRequest();
+                    return;
+                }
+                Navigation.goBack(backToRoute);
+            }}
+        />
     );
 
     // We need to cancel telemetry span when user leaves the screen before full report data is loaded

--- a/src/components/ReportActionsSkeletonCover.tsx
+++ b/src/components/ReportActionsSkeletonCover.tsx
@@ -7,13 +7,30 @@ import {View} from 'react-native';
 
 import ReportActionsSkeletonView from './ReportActionsSkeletonView';
 
-type ReportActionsSkeletonCoverProps = {
+type ReportActionsSkeletonContainerProps = {
     /** The skeleton content to place at the bottom of the report viewport */
-    children?: ReactNode;
+    children: ReactNode;
 };
 
-/** Fills the report-actions viewport with a consistently positioned loading skeleton. */
-function ReportActionsSkeletonCover({children}: ReportActionsSkeletonCoverProps) {
+/** Fills the report-actions viewport with a consistently positioned static loading skeleton. */
+function ReportActionsSkeletonCover() {
+    return (
+        <ReportActionsSkeletonContainer>
+            <ReportActionsSkeletonView shouldAnimate={false} />
+        </ReportActionsSkeletonContainer>
+    );
+}
+
+/** Fills the report-actions viewport with a consistently positioned animated loading skeleton. */
+function ReportActionsAnimatedSkeletonCover() {
+    return (
+        <ReportActionsSkeletonContainer>
+            <ReportActionsSkeletonView shouldAnimate />
+        </ReportActionsSkeletonContainer>
+    );
+}
+
+function ReportActionsSkeletonContainer({children}: ReportActionsSkeletonContainerProps) {
     const styles = useThemeStyles();
 
     return (
@@ -22,9 +39,10 @@ function ReportActionsSkeletonCover({children}: ReportActionsSkeletonCoverProps)
             testID="ReportActionsSkeletonCover"
             style={[styles.flex1, styles.appBG, styles.overflowHidden, styles.justifyContentEnd, styles.pb4]}
         >
-            {children ?? <ReportActionsSkeletonView />}
+            {children}
         </View>
     );
 }
 
+export {ReportActionsAnimatedSkeletonCover};
 export default ReportActionsSkeletonCover;

--- a/src/components/ReportActionsSkeletonCover.tsx
+++ b/src/components/ReportActionsSkeletonCover.tsx
@@ -1,0 +1,30 @@
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {ReactNode} from 'react';
+
+import React from 'react';
+import {View} from 'react-native';
+
+import ReportActionsSkeletonView from './ReportActionsSkeletonView';
+
+type ReportActionsSkeletonCoverProps = {
+    /** The skeleton content to place at the bottom of the report viewport */
+    children?: ReactNode;
+};
+
+/** Fills the report-actions viewport with a consistently positioned loading skeleton. */
+function ReportActionsSkeletonCover({children}: ReportActionsSkeletonCoverProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <View
+            pointerEvents="none"
+            testID="ReportActionsSkeletonCover"
+            style={[styles.flex1, styles.appBG, styles.overflowHidden, styles.justifyContentEnd, styles.pb4]}
+        >
+            {children ?? <ReportActionsSkeletonView />}
+        </View>
+    );
+}
+
+export default ReportActionsSkeletonCover;

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -1,6 +1,7 @@
 import {renderScrollComponent as renderActionSheetAwareScrollView} from '@components/ActionSheetAwareScrollView';
 import InvertedFlashList from '@components/FlashList/InvertedFlashList';
 import MerchantRuleSuggestionBanner from '@components/MerchantRuleSuggestionBanner';
+import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
 import useConciergeSessionStartTime from '@hooks/useConciergeSessionStartTime';
@@ -449,7 +450,7 @@ function ReportActionsListContent({reportID, conciergeChat, onLayout}: ReportAct
     // It narrows `report` to non-undefined for the render below and stays a safe fallback if the report
     // is cleared mid-session while the latch keeps the content mounted.
     if (!report) {
-        return <ReportActionsSkeletonView />;
+        return <ReportActionsSkeletonCover />;
     }
 
     return (

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -1,7 +1,7 @@
 import {renderScrollComponent as renderActionSheetAwareScrollView} from '@components/ActionSheetAwareScrollView';
 import InvertedFlashList from '@components/FlashList/InvertedFlashList';
 import MerchantRuleSuggestionBanner from '@components/MerchantRuleSuggestionBanner';
-import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
+import {ReportActionsAnimatedSkeletonCover} from '@components/ReportActionsSkeletonCover';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
 import useConciergeSessionStartTime from '@hooks/useConciergeSessionStartTime';
@@ -450,7 +450,7 @@ function ReportActionsListContent({reportID, conciergeChat, onLayout}: ReportAct
     // It narrows `report` to non-undefined for the render below and stays a safe fallback if the report
     // is cleared mid-session while the latch keeps the content mounted.
     if (!report) {
-        return <ReportActionsSkeletonCover />;
+        return <ReportActionsAnimatedSkeletonCover />;
     }
 
     return (

--- a/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
+++ b/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
@@ -1,3 +1,4 @@
+import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
 import useCancelSendMessageSpanOnSkeleton from '@hooks/useCancelSendMessageSpanOnSkeleton';
@@ -28,7 +29,11 @@ type ReportActionsLoadingSkeletonProps = {
 function ReportActionsLoadingSkeleton({reportID, skeletonName, shouldAnimate = true, shouldMarkOpenReportEnd = true}: ReportActionsLoadingSkeletonProps) {
     useCancelSendMessageSpanOnSkeleton(reportID, skeletonName);
     useMarkOpenReportEndOnSkeleton(reportID, shouldMarkOpenReportEnd);
-    return <ReportActionsSkeletonView shouldAnimate={shouldAnimate} />;
+    return (
+        <ReportActionsSkeletonCover>
+            <ReportActionsSkeletonView shouldAnimate={shouldAnimate} />
+        </ReportActionsSkeletonCover>
+    );
 }
 
 ReportActionsLoadingSkeleton.displayName = 'ReportActionsLoadingSkeleton';

--- a/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
+++ b/src/pages/inbox/report/ReportActionsLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
-import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
-import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
+import ReportActionsSkeletonCover, {ReportActionsAnimatedSkeletonCover} from '@components/ReportActionsSkeletonCover';
 
 import useCancelSendMessageSpanOnSkeleton from '@hooks/useCancelSendMessageSpanOnSkeleton';
 import type {SkeletonName} from '@hooks/useCancelSendMessageSpanOnSkeleton';
@@ -29,11 +28,9 @@ type ReportActionsLoadingSkeletonProps = {
 function ReportActionsLoadingSkeleton({reportID, skeletonName, shouldAnimate = true, shouldMarkOpenReportEnd = true}: ReportActionsLoadingSkeletonProps) {
     useCancelSendMessageSpanOnSkeleton(reportID, skeletonName);
     useMarkOpenReportEndOnSkeleton(reportID, shouldMarkOpenReportEnd);
-    return (
-        <ReportActionsSkeletonCover>
-            <ReportActionsSkeletonView shouldAnimate={shouldAnimate} />
-        </ReportActionsSkeletonCover>
-    );
+    const SkeletonCover = shouldAnimate ? ReportActionsAnimatedSkeletonCover : ReportActionsSkeletonCover;
+
+    return <SkeletonCover />;
 }
 
 ReportActionsLoadingSkeleton.displayName = 'ReportActionsLoadingSkeleton';

--- a/tests/ui/MoneyRequestReportViewTest.tsx
+++ b/tests/ui/MoneyRequestReportViewTest.tsx
@@ -195,6 +195,7 @@ describe('MoneyRequestReportView', () => {
         renderMoneyRequestReportView(jest.fn());
 
         expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
+        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: true}));
         expect(mockReportActionsListBody).not.toHaveBeenCalled();
         expect(mockMoneyRequestReportActionsList).not.toHaveBeenCalled();
     });
@@ -216,6 +217,7 @@ describe('MoneyRequestReportView', () => {
         renderMoneyRequestReportView(jest.fn());
 
         expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
+        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: true}));
         expect(mockReportActionsListBody).not.toHaveBeenCalled();
         expect(mockMoneyRequestReportActionsList).not.toHaveBeenCalled();
     });

--- a/tests/ui/MoneyRequestReportViewTest.tsx
+++ b/tests/ui/MoneyRequestReportViewTest.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
-import {render} from '@testing-library/react-native';
+import {render, screen} from '@testing-library/react-native';
 
 import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/MoneyRequestReportActionsList';
 import MoneyRequestReportView from '@components/MoneyRequestReportView/MoneyRequestReportView';
+import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
+import {useIsAppLoadPending, useIsReportLoadPending} from '@hooks/useInFlightRequests';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
@@ -34,6 +36,10 @@ jest.mock('@hooks/useOnyx', () => jest.fn());
 jest.mock('@hooks/useResponsiveLayout', () => jest.fn());
 jest.mock('@hooks/usePaginatedReportActions', () => jest.fn());
 jest.mock('@hooks/useReportTransactionsCollection', () => jest.fn());
+jest.mock('@hooks/useInFlightRequests', () => ({
+    useIsAppLoadPending: jest.fn(),
+    useIsReportLoadPending: jest.fn(),
+}));
 
 // useThemeStyles throws without a <ThemeStylesProvider>; return a proxy that yields an empty style object
 // for any key so the (mostly-mocked) tree renders without wiring up the full provider stack.
@@ -54,6 +60,8 @@ jest.mock('@components/MoneyReportHeader', () => jest.fn(() => null));
 jest.mock('@components/MoneyRequestHeader', () => jest.fn(() => null));
 jest.mock('@components/CollapsibleHeaderOnKeyboard', () => jest.fn(() => null));
 jest.mock('@components/ReportActionItem/MoneyRequestReceiptView', () => jest.fn(() => null));
+jest.mock('@components/ReportActionsSkeletonView', () => jest.fn(() => null));
+jest.mock('@components/ReportHeaderSkeletonView', () => jest.fn(() => null));
 jest.mock('@pages/inbox/report/ReportFooter', () => jest.fn(() => null));
 jest.mock('@components/OfflineWithFeedback', () => {
     const reactModule = jest.requireActual<typeof React>('react');
@@ -61,12 +69,15 @@ jest.mock('@components/OfflineWithFeedback', () => {
 });
 
 const mockUseNetwork = useNetwork as jest.MockedFunction<typeof useNetwork>;
+const mockUseIsAppLoadPending = jest.mocked(useIsAppLoadPending);
+const mockUseIsReportLoadPending = jest.mocked(useIsReportLoadPending);
 const mockUseOnyx = useOnyx as jest.MockedFunction<typeof useOnyx>;
 const mockUseResponsiveLayout = useResponsiveLayout as jest.MockedFunction<typeof useResponsiveLayout>;
 const mockUsePaginatedReportActions = usePaginatedReportActions as jest.MockedFunction<typeof usePaginatedReportActions>;
 const mockUseReportTransactionsCollection = useReportTransactionsCollection as jest.MockedFunction<typeof useReportTransactionsCollection>;
 const mockMoneyRequestReportActionsList = MoneyRequestReportActionsList as jest.MockedFunction<typeof MoneyRequestReportActionsList>;
 const mockReportActionsListBody = ReportActionsList as jest.MockedFunction<typeof ReportActionsList>;
+const mockReportActionsSkeletonView = jest.mocked(ReportActionsSkeletonView);
 const mockUserTypingEventListener = UserTypingEventListener as jest.MockedFunction<typeof UserTypingEventListener>;
 
 const defaultPaginatedReportActionsResult: ReturnType<typeof usePaginatedReportActions> = {
@@ -134,6 +145,8 @@ describe('MoneyRequestReportView', () => {
         jest.clearAllMocks();
 
         mockUseNetwork.mockReturnValue({isOffline: false});
+        mockUseIsAppLoadPending.mockReturnValue(false);
+        mockUseIsReportLoadPending.mockReturnValue(false);
         mockUsePaginatedReportActions.mockReturnValue(defaultPaginatedReportActionsResult);
         mockUseReportTransactionsCollection.mockReturnValue({});
         mockUseResponsiveLayout.mockReturnValue({
@@ -174,6 +187,37 @@ describe('MoneyRequestReportView', () => {
         renderMoneyRequestReportView(jest.fn());
 
         expect(MoneyRequestReportUtils.shouldWaitForTransactions).toHaveBeenLastCalledWith(mockReport, [], mockReportLoadingState, false, false);
+    });
+
+    it('uses the bottom-padded cover while the report is waiting for transactions', () => {
+        jest.spyOn(MoneyRequestReportUtils, 'shouldWaitForTransactions').mockReturnValue(true);
+
+        renderMoneyRequestReportView(jest.fn());
+
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
+        expect(mockReportActionsListBody).not.toHaveBeenCalled();
+        expect(mockMoneyRequestReportActionsList).not.toHaveBeenCalled();
+    });
+
+    it('uses a static bottom-padded cover while report actions are empty', () => {
+        jest.spyOn(ReportActionsUtils, 'getFilteredReportActionsForReportView').mockReturnValue([]);
+
+        renderMoneyRequestReportView(jest.fn());
+
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
+        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: false}));
+        expect(mockReportActionsListBody).not.toHaveBeenCalled();
+        expect(mockMoneyRequestReportActionsList).not.toHaveBeenCalled();
+    });
+
+    it('uses the bottom-padded cover while the app is loading', () => {
+        mockUseIsAppLoadPending.mockReturnValue(true);
+
+        renderMoneyRequestReportView(jest.fn());
+
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
+        expect(mockReportActionsListBody).not.toHaveBeenCalled();
+        expect(mockMoneyRequestReportActionsList).not.toHaveBeenCalled();
     });
 
     it('mounts the chat list body and the typing listener (not the table view) for a transaction-thread report', () => {

--- a/tests/ui/ReportActionsTest.tsx
+++ b/tests/ui/ReportActionsTest.tsx
@@ -149,6 +149,7 @@ describe('ReportActions (orchestrator)', () => {
 
         render(<ReportActions />);
 
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
         expect(screen.getByTestId('ReportActionsSkeletonView')).toBeTruthy();
         expect(mockReportActionsListBody).not.toHaveBeenCalled();
         expect(mockMoneyRequestList).not.toHaveBeenCalled();
@@ -159,6 +160,7 @@ describe('ReportActions (orchestrator)', () => {
 
         render(<ReportActions />);
 
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
         expect(screen.getByTestId('ReportActionsSkeletonView')).toBeTruthy();
         expect(mockReportActionsListBody).not.toHaveBeenCalled();
         expect(mockMoneyRequestList).not.toHaveBeenCalled();

--- a/tests/unit/ReportActionsSkeletonCoverTest.tsx
+++ b/tests/unit/ReportActionsSkeletonCoverTest.tsx
@@ -1,0 +1,38 @@
+import {render, screen} from '@testing-library/react-native';
+
+import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
+import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
+
+import React from 'react';
+
+jest.mock('@components/ReportActionsSkeletonView', () => jest.fn(() => null));
+
+const mockReportActionsSkeletonView = jest.mocked(ReportActionsSkeletonView);
+
+describe('ReportActionsSkeletonCover', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('fills, clips, and bottom-aligns the default report-actions skeleton', () => {
+        render(<ReportActionsSkeletonCover />);
+
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toHaveStyle({
+            flex: 1,
+            overflow: 'hidden',
+            justifyContent: 'flex-end',
+            paddingBottom: 16,
+        });
+        expect(mockReportActionsSkeletonView).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts a static report-actions skeleton as its content', () => {
+        render(
+            <ReportActionsSkeletonCover>
+                <ReportActionsSkeletonView shouldAnimate={false} />
+            </ReportActionsSkeletonCover>,
+        );
+
+        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: false}));
+    });
+});

--- a/tests/unit/ReportActionsSkeletonCoverTest.tsx
+++ b/tests/unit/ReportActionsSkeletonCoverTest.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react-native';
 
-import ReportActionsSkeletonCover from '@components/ReportActionsSkeletonCover';
+import ReportActionsSkeletonCover, {ReportActionsAnimatedSkeletonCover} from '@components/ReportActionsSkeletonCover';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 
 import React from 'react';
@@ -14,7 +14,7 @@ describe('ReportActionsSkeletonCover', () => {
         jest.clearAllMocks();
     });
 
-    it('fills, clips, and bottom-aligns the default report-actions skeleton', () => {
+    it('fills, clips, and bottom-aligns the static report-actions skeleton', () => {
         render(<ReportActionsSkeletonCover />);
 
         expect(screen.getByTestId('ReportActionsSkeletonCover')).toHaveStyle({
@@ -24,15 +24,14 @@ describe('ReportActionsSkeletonCover', () => {
             paddingBottom: 16,
         });
         expect(mockReportActionsSkeletonView).toHaveBeenCalledTimes(1);
+        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: false}));
     });
 
-    it('accepts a static report-actions skeleton as its content', () => {
-        render(
-            <ReportActionsSkeletonCover>
-                <ReportActionsSkeletonView shouldAnimate={false} />
-            </ReportActionsSkeletonCover>,
-        );
+    it('fills the report-actions viewport with an animated skeleton', () => {
+        render(<ReportActionsAnimatedSkeletonCover />);
 
-        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: false}));
+        expect(screen.getByTestId('ReportActionsSkeletonCover')).toBeTruthy();
+        expect(mockReportActionsSkeletonView).toHaveBeenCalledTimes(1);
+        expect(mockReportActionsSkeletonView.mock.calls.at(-1)?.at(0)).toEqual(expect.objectContaining({shouldAnimate: true}));
     });
 });


### PR DESCRIPTION
Expense reports can display loading skeletons with different vertical positions while report data becomes available. That creates visible jumps before the report actions render and makes the transitional UI depend on which loading path fired. This WIP extraction gives report action loading states one consistent bottom-padded cover without changing LegendList hydration logic.

@roryabraham @dmkt9 

### Explanation of Change

The new `ReportActionsSkeletonCover` centralizes the background, overflow, bottom alignment, and bottom padding used while report actions load. The expense report view, the configured report loading state, and the defensive missing-report fallback now use that cover. The offline and pagination skeletons that intentionally live inside the list remain unchanged.

This is layer 3 of the seven-part LegendList series and is held on #100883. Review order is #100732 → #100883 → this PR → #100733 → #100740 → #100734 → #100736. The focused layer is available in the [Margelo branch comparison](https://github.com/margelo/Expensify/compare/@chrispader/fix/report-action-edit-scroll...@chrispader/fix/report-actions-loading-skeleton). The branches are maintained with GH Stacks in the Margelo fork; because GitHub does not support linking cross-fork heads into an upstream Stack, each upstream PR targets `Expensify/App:main`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98994
PROPOSAL:

No approved proposal is linked.

### Tests

1. Open an expense report from a cold app state.
2. Verify the report uses one bottom-aligned loading skeleton with consistent bottom padding until the report actions are ready.
3. Open an expense report while its transactions are still loading and verify the same skeleton placement is used.
4. Open an expense report with no actions and verify the non-animated placeholder uses the same placement.
5. Verify the report actions replace the skeleton without showing intermediate skeleton positions.
6. Verify that no errors appear in the JS console.

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Open a cached expense report, then go offline.
2. Reopen the report and verify its loading placeholder is bottom-aligned with the same padding.
3. Verify an offline skeleton rendered inside an already-mounted list remains unchanged.
4. Return online and verify the report actions replace the placeholder normally.

### QA Steps

Same as Tests and Offline tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos