### PR TITLE
Support GL codes for dependent multi-level tags

### DIFF
--- a/src/libs/API/parameters/UpdatePolicyTagGLCodeParams.ts
+++ b/src/libs/API/parameters/UpdatePolicyTagGLCodeParams.ts
@@ -4,6 +4,7 @@ type UpdatePolicyTagGLCodeParams = {
     tagListIndex: number;
     tagName: string;
     glCode: string;
+    parentTagsFilter?: string;
 };
 
 export default UpdatePolicyTagGLCodeParams;

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/appendParentTagsFilter.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/appendParentTagsFilter.ts
@@ -1,0 +1,9 @@
+/**
+ * Appends the parentTagsFilter query param to a route when present.
+ * Used for dependent tag navigation where the filter disambiguates same-named tags.
+ */
+function appendParentTagsFilter(route: string, parentTagsFilter?: string): string {
+    return parentTagsFilter ? `${route}?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}` : route;
+}
+
+export default appendParentTagsFilter;

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -631,6 +631,7 @@ type SettingsNavigatorParamList = {
         policyID: string;
         orderWeight: number;
         tagName: string;
+        parentTagsFilter?: string;
     };
     [SCREENS.WORKSPACE.DYNAMIC_TAG_APPROVER]: {
         policyID: string;
@@ -646,6 +647,7 @@ type SettingsNavigatorParamList = {
         policyID: string;
         orderWeight: number;
         tagName: string;
+        parentTagsFilter?: string;
     };
     [SCREENS.SETTINGS.SUBSCRIPTION.SIZE]: {
         canChangeSize: 0 | 1;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -1156,6 +1156,36 @@ function findPolicyTagAtLevel(levelTags: PolicyTags, tagName: string, parentTagP
     return matchesTagAtLevel(directMatch) ? directMatch : Object.values(levelTags).find(matchesTagAtLevel);
 }
 
+/**
+ * Finds a policy tag record and its Onyx storage key within a tag list.
+ * Dependent tag lists can hold same-named child tags under different parents (stored under unique
+ * record keys), so a tag only matches by name when its parent filter also matches.
+ */
+function findPolicyTagEntryByParentFilter(tags: PolicyTags | undefined, tagName: string, parentTagsFilter?: string): {tag: ValueOf<PolicyTags>; tagKey: string} | undefined {
+    if (!tags) {
+        return undefined;
+    }
+
+    if (parentTagsFilter) {
+        const match = Object.entries(tags).find(([, tag]) => tag.name === tagName && (tag.rules?.parentTagsFilter ?? tag.parentTagsFilter) === parentTagsFilter);
+        if (match) {
+            return {tag: match[1], tagKey: match[0]};
+        }
+        return undefined;
+    }
+
+    if (tags[tagName]) {
+        return {tag: tags[tagName], tagKey: tagName};
+    }
+
+    const renamedTag = Object.entries(tags).find(([, tag]) => tag.previousTagName === tagName);
+    if (renamedTag) {
+        return {tag: renamedTag[1], tagKey: renamedTag[0]};
+    }
+
+    return undefined;
+}
+
 function isTagInPolicy(tagValue: string, policyTags: OnyxEntry<PolicyTagLists>): boolean {
     if (!policyTags) {
         return false;
@@ -3448,6 +3478,7 @@ export {
     hasTags,
     isTagInPolicy,
     findPolicyTagAtLevel,
+    findPolicyTagEntryByParentFilter,
     matchesParentTagPath,
     hasCustomCategories,
     hasConfiguredRules,

--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -1356,11 +1356,18 @@ type SetPolicyTagGLCodeProps = {
     tagListIndex: number;
     glCode: string;
     policyTags: OnyxEntry<PolicyTagLists>;
+    parentTagsFilter?: string;
 };
 
-function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags}: SetPolicyTagGLCodeProps) {
+function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags, parentTagsFilter}: SetPolicyTagGLCodeProps) {
     const tagListName = PolicyUtils.getTagListName(policyTags, tagListIndex);
-    const policyTagToUpdate = policyTags?.[tagListName]?.tags?.[tagName] ?? {};
+    const policyTagEntry = PolicyUtils.findPolicyTagEntryByParentFilter(policyTags?.[tagListName]?.tags, tagName, parentTagsFilter);
+
+    if (!policyTagEntry) {
+        return;
+    }
+
+    const {tag: policyTagToUpdate, tagKey} = policyTagEntry;
 
     const onyxData: OnyxData<typeof ONYXKEYS.COLLECTION.POLICY_TAGS> = {
         optimisticData: [
@@ -1370,7 +1377,7 @@ function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags
                 value: {
                     [tagListName]: {
                         tags: {
-                            [tagName]: {
+                            [tagKey]: {
                                 ...policyTagToUpdate,
                                 pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                                 pendingFields: {
@@ -1392,7 +1399,7 @@ function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags
                 value: {
                     [tagListName]: {
                         tags: {
-                            [tagName]: {
+                            [tagKey]: {
                                 errors: null,
                                 pendingAction: null,
                                 pendingFields: {
@@ -1412,7 +1419,7 @@ function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags
                 value: {
                     [tagListName]: {
                         tags: {
-                            [tagName]: {
+                            [tagKey]: {
                                 ...policyTagToUpdate,
                                 errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.tags.updateGLCodeFailureMessage'),
                             },
@@ -1425,10 +1432,11 @@ function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags
 
     const parameters: UpdatePolicyTagGLCodeParams = {
         policyID,
-        tagName,
+        tagName: policyTagToUpdate.name,
         tagListName,
         tagListIndex,
         glCode,
+        ...(parentTagsFilter ? {parentTagsFilter} : {}),
     };
 
     API.write(WRITE_COMMANDS.UPDATE_POLICY_TAG_GL_CODE, parameters, onyxData);

--- a/src/pages/workspace/tags/DynamicTagGLCodePage.tsx
+++ b/src/pages/workspace/tags/DynamicTagGLCodePage.tsx
@@ -14,10 +14,11 @@ import useThemeStyles from '@hooks/useThemeStyles';
 
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import {getTagListByOrderWeight, hasAccountingConnections} from '@libs/PolicyUtils';
+import {findPolicyTagEntryByParentFilter, getTagListByOrderWeight, hasAccountingConnections} from '@libs/PolicyUtils';
 
 import type {SettingsNavigatorParamList} from '@navigation/types';
 
+import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 
 import {setPolicyTagGLCode} from '@userActions/Policy/Tag';
@@ -43,15 +44,17 @@ function DynamicTagGLCodePage({route}: DynamicEditTagGLCodePageProps) {
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
 
     const tagName = route.params.tagName;
+    const parentTagsFilter = route.params.parentTagsFilter;
     const orderWeight = Number(route.params.orderWeight);
     const {tags} = getTagListByOrderWeight(policyTags, orderWeight);
-    const glCode = tags?.[route.params.tagName]?.['GL Code'];
+    const currentPolicyTagEntry = findPolicyTagEntryByParentFilter(tags, tagName, parentTagsFilter);
+    const glCode = currentPolicyTagEntry?.tag?.['GL Code'];
     const isQuickSettingsFlow = route.name === SCREENS.SETTINGS_TAGS.DYNAMIC_SETTINGS_TAG_GL_CODE;
     const backPath = useDynamicBackPath(isQuickSettingsFlow ? DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.path : DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path);
 
     const goBack = useCallback(() => {
-        Navigation.goBack(backPath);
-    }, [backPath]);
+        Navigation.goBack(isQuickSettingsFlow ? backPath : undefined);
+    }, [backPath, isQuickSettingsFlow]);
 
     const validate = useCallback(
         (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
@@ -71,12 +74,23 @@ function DynamicTagGLCodePage({route}: DynamicEditTagGLCodePageProps) {
         (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
             const newGLCode = values.glCode.trim();
             if (newGLCode !== glCode) {
-                setPolicyTagGLCode({policyID, tagName, tagListIndex: orderWeight, glCode: newGLCode, policyTags});
+                setPolicyTagGLCode({
+                    policyID,
+                    tagName,
+                    tagListIndex: orderWeight,
+                    glCode: newGLCode,
+                    policyTags,
+                    parentTagsFilter,
+                });
             }
             goBack();
         },
-        [glCode, goBack, policyID, tagName, orderWeight, policyTags],
+        [glCode, goBack, policyID, tagName, orderWeight, policyTags, parentTagsFilter],
     );
+
+    if (!currentPolicyTagEntry) {
+        return <NotFoundPage />;
+    }
 
     return (
         <AccessOrNotFoundWrapper

--- a/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
+++ b/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
@@ -27,6 +27,7 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import {isDisablingOrDeletingLastEnabledTag} from '@libs/OptionsListUtils';
 import {
     arePolicyRulesEnabled,
+    findPolicyTagEntryByParentFilter,
     getCleanedTagName,
     getTagApproverRule,
     getTagListByOrderWeight,
@@ -76,9 +77,8 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
     const tagApprover = getTagApproverRule(policy, route.params?.tagName)?.approver ?? '';
     const approverText = usePersonalDetailByLogin(tagApprover, (personalDetails) => formatPhoneNumber(personalDetails?.displayName ?? tagApprover));
     const hasDependentTags = hasDependentTagsPolicyUtils(policy, policyTags);
-    const currentPolicyTag = hasDependentTags
-        ? Object.values(policyTag.tags ?? {}).find((tag) => tag?.name === tagName && tag.rules?.parentTagsFilter === parentTagsFilter)
-        : (policyTag.tags[tagName] ?? Object.values(policyTag.tags ?? {}).find((tag) => tag.previousTagName === tagName));
+    const currentPolicyTagEntry = findPolicyTagEntryByParentFilter(policyTag.tags, tagName, parentTagsFilter);
+    const currentPolicyTag = currentPolicyTagEntry?.tag;
 
     const shouldPreventDisableOrDelete = isDisablingOrDeletingLastEnabledTag(policyTag, [currentPolicyTag]);
 
@@ -117,22 +117,23 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
     };
 
     const navigateToEditGlCode = () => {
+        const parentTagsFilterSuffix = parentTagsFilter ? `?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}` : '';
         if (!isControlPolicy(policy)) {
             Navigation.navigate(
                 ROUTES.WORKSPACE_UPGRADE.getRoute(
                     policyID,
                     CONST.UPGRADE_FEATURE_INTRO_MAPPING.glCodes.alias,
                     isQuickSettingsFlow
-                        ? createDynamicRoute(DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, tagName))
-                        : createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path),
+                        ? createDynamicRoute(`${DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, tagName)}${parentTagsFilterSuffix}`)
+                        : createDynamicRoute(`${DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path}${parentTagsFilterSuffix}`),
                 ),
             );
             return;
         }
         Navigation.navigate(
             isQuickSettingsFlow
-                ? createDynamicRoute(DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, currentPolicyTag.name))
-                : createDynamicRoute(DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path),
+                ? createDynamicRoute(`${DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, currentPolicyTag.name)}${parentTagsFilterSuffix}`)
+                : createDynamicRoute(`${DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path}${parentTagsFilterSuffix}`),
         );
     };
 
@@ -205,18 +206,16 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
                             value={cleanedTagName}
                         />
                     </OfflineWithFeedback>
-                    {(!hasDependentTags || !!currentPolicyTag?.['GL Code']) && (
-                        <OfflineWithFeedback pendingAction={currentPolicyTag.pendingFields?.['GL Code']}>
-                            <MenuItemWithTopDescription
-                                description={translate(`workspace.tags.glCode`)}
-                                title={currentPolicyTag?.['GL Code']}
-                                onPress={navigateToEditGlCode}
-                                iconRight={hasAccountingConnections ? expensifyIcons.Lock : undefined}
-                                interactive={canWriteTags && !hasAccountingConnections && !hasDependentTags}
-                                shouldShowRightIcon={canWriteTags && !hasDependentTags}
-                            />
-                        </OfflineWithFeedback>
-                    )}
+                    <OfflineWithFeedback pendingAction={currentPolicyTag.pendingFields?.['GL Code']}>
+                        <MenuItemWithTopDescription
+                            description={translate(`workspace.tags.glCode`)}
+                            title={currentPolicyTag?.['GL Code']}
+                            onPress={navigateToEditGlCode}
+                            iconRight={hasAccountingConnections ? expensifyIcons.Lock : undefined}
+                            interactive={canWriteTags && !hasAccountingConnections}
+                            shouldShowRightIcon={canWriteTags && !hasAccountingConnections}
+                        />
+                    </OfflineWithFeedback>
 
                     {arePolicyRulesEnabled(policy, policyData.categories, isRulesRevampEnabled) && !isMultiLevelTags && (
                         <>

--- a/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
+++ b/src/pages/workspace/tags/DynamicTagSettingsPage.tsx
@@ -21,6 +21,7 @@ import usePolicyFeatureWriteAccess from '@hooks/usePolicyFeatureWriteAccess';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {getLatestErrorMessageField} from '@libs/ErrorUtils';
+import appendParentTagsFilter from '@libs/Navigation/helpers/dynamicRoutesUtils/appendParentTagsFilter';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -117,24 +118,21 @@ function DynamicTagSettingsPage({route, navigation}: DynamicTagSettingsPageProps
     };
 
     const navigateToEditGlCode = () => {
-        const parentTagsFilterSuffix = parentTagsFilter ? `?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}` : '';
+        const workspaceGlCodeRoute = appendParentTagsFilter(DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path, parentTagsFilter);
+        const settingsGlCodeRoute = appendParentTagsFilter(DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, tagName), parentTagsFilter);
+        const settingsGlCodeRouteForCurrentTag = appendParentTagsFilter(DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, currentPolicyTag.name), parentTagsFilter);
+
         if (!isControlPolicy(policy)) {
             Navigation.navigate(
                 ROUTES.WORKSPACE_UPGRADE.getRoute(
                     policyID,
                     CONST.UPGRADE_FEATURE_INTRO_MAPPING.glCodes.alias,
-                    isQuickSettingsFlow
-                        ? createDynamicRoute(`${DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, tagName)}${parentTagsFilterSuffix}`)
-                        : createDynamicRoute(`${DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path}${parentTagsFilterSuffix}`),
+                    isQuickSettingsFlow ? createDynamicRoute(settingsGlCodeRoute) : createDynamicRoute(workspaceGlCodeRoute),
                 ),
             );
             return;
         }
-        Navigation.navigate(
-            isQuickSettingsFlow
-                ? createDynamicRoute(`${DYNAMIC_ROUTES.SETTINGS_TAG_GL_CODE.getRoute(orderWeight, currentPolicyTag.name)}${parentTagsFilterSuffix}`)
-                : createDynamicRoute(`${DYNAMIC_ROUTES.WORKSPACE_TAG_GL_CODE.path}${parentTagsFilterSuffix}`),
-        );
+        Navigation.navigate(isQuickSettingsFlow ? createDynamicRoute(settingsGlCodeRouteForCurrentTag) : createDynamicRoute(workspaceGlCodeRoute));
     };
 
     const navigateToEditTagApprover = () => {

--- a/src/pages/workspace/tags/DynamicWorkspaceViewTagsPage.tsx
+++ b/src/pages/workspace/tags/DynamicWorkspaceViewTagsPage.tsx
@@ -137,14 +137,15 @@ function DynamicWorkspaceViewTagsPage({route}: DynamicWorkspaceViewTagsProps) {
                 return;
             }
 
-            const parentTagsFilter = tag?.rules?.parentTagsFilter;
-            const workspaceTagSettingsSuffix = parentTagsFilter
+            const parentTagsFilter = tag?.rules?.parentTagsFilter ?? tag?.parentTagsFilter;
+            const tagSettingsSuffix = parentTagsFilter
                 ? `${DYNAMIC_ROUTES.WORKSPACE_TAG_SETTINGS.getRoute(orderWeight, tag.name)}?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}`
                 : DYNAMIC_ROUTES.WORKSPACE_TAG_SETTINGS.getRoute(orderWeight, tag.name);
+            const settingsTagSettingsSuffix = parentTagsFilter
+                ? `${DYNAMIC_ROUTES.SETTINGS_TAG_SETTINGS.getRoute(orderWeight, tag.name)}?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}`
+                : DYNAMIC_ROUTES.SETTINGS_TAG_SETTINGS.getRoute(orderWeight, tag.name);
 
-            Navigation.navigate(
-                isQuickSettingsFlow ? createDynamicRoute(DYNAMIC_ROUTES.SETTINGS_TAG_SETTINGS.getRoute(orderWeight, tag.name)) : createDynamicRoute(workspaceTagSettingsSuffix),
-            );
+            Navigation.navigate(isQuickSettingsFlow ? createDynamicRoute(settingsTagSettingsSuffix) : createDynamicRoute(tagSettingsSuffix));
         },
         [canWriteTags, isQuickSettingsFlow, orderWeight],
     );

--- a/src/pages/workspace/tags/DynamicWorkspaceViewTagsPage.tsx
+++ b/src/pages/workspace/tags/DynamicWorkspaceViewTagsPage.tsx
@@ -34,6 +34,7 @@ import {
     setPolicyTagsRequired,
     setWorkspaceTagEnabled,
 } from '@libs/actions/Policy/Tag';
+import appendParentTagsFilter from '@libs/Navigation/helpers/dynamicRoutesUtils/appendParentTagsFilter';
 import createDynamicRoute from '@libs/Navigation/helpers/dynamicRoutesUtils/createDynamicRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -138,12 +139,8 @@ function DynamicWorkspaceViewTagsPage({route}: DynamicWorkspaceViewTagsProps) {
             }
 
             const parentTagsFilter = tag?.rules?.parentTagsFilter ?? tag?.parentTagsFilter;
-            const tagSettingsSuffix = parentTagsFilter
-                ? `${DYNAMIC_ROUTES.WORKSPACE_TAG_SETTINGS.getRoute(orderWeight, tag.name)}?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}`
-                : DYNAMIC_ROUTES.WORKSPACE_TAG_SETTINGS.getRoute(orderWeight, tag.name);
-            const settingsTagSettingsSuffix = parentTagsFilter
-                ? `${DYNAMIC_ROUTES.SETTINGS_TAG_SETTINGS.getRoute(orderWeight, tag.name)}?parentTagsFilter=${encodeURIComponent(parentTagsFilter)}`
-                : DYNAMIC_ROUTES.SETTINGS_TAG_SETTINGS.getRoute(orderWeight, tag.name);
+            const tagSettingsSuffix = appendParentTagsFilter(DYNAMIC_ROUTES.WORKSPACE_TAG_SETTINGS.getRoute(orderWeight, tag.name), parentTagsFilter);
+            const settingsTagSettingsSuffix = appendParentTagsFilter(DYNAMIC_ROUTES.SETTINGS_TAG_SETTINGS.getRoute(orderWeight, tag.name), parentTagsFilter);
 
             Navigation.navigate(isQuickSettingsFlow ? createDynamicRoute(settingsTagSettingsSuffix) : createDynamicRoute(tagSettingsSuffix));
         },

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -2547,6 +2547,44 @@ describe('actions/Policy', () => {
                 expect(updatedPolicyTags[tagListName].tags[tagName].pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
             }
         });
+
+        it('should update GL code for a dependent tag stored under a unique record key', async () => {
+            const fakePolicy = createRandomPolicy(0);
+            const tagListName = 'Project';
+            const fakePolicyTags: PolicyTagLists = {
+                [tagListName]: {
+                    name: tagListName,
+                    orderWeight: 1,
+                    required: false,
+                    tags: {
+                        Roadshow: {name: 'Roadshow', enabled: true, rules: {parentTagsFilter: '^Marketing$'}},
+                        'Roadshow-1': {name: 'Roadshow', enabled: true, 'GL Code': '1111', rules: {parentTagsFilter: '^Engineering$'}},
+                    },
+                },
+            };
+            const newGLCode = 'NEW_GL_CODE_789';
+
+            mockFetch.pause();
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakePolicyTags);
+
+            setPolicyTagGLCode({
+                policyID: fakePolicy.id,
+                tagName: 'Roadshow',
+                tagListIndex: 1,
+                glCode: newGLCode,
+                policyTags: fakePolicyTags,
+                parentTagsFilter: '^Engineering$',
+            });
+            await waitForBatchedUpdates();
+
+            const updatedPolicyTags = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`);
+
+            expect(updatedPolicyTags?.[tagListName]?.tags['Roadshow-1']['GL Code']).toBe(newGLCode);
+            expect(updatedPolicyTags?.[tagListName]?.tags.Roadshow['GL Code']).toBeUndefined();
+
+            mockFetch.resume();
+            await waitForBatchedUpdates();
+        });
     });
 
     describe('createPolicyTag with onboarding task completion', () => {

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -27,7 +27,7 @@ import {
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {PolicyTagLists, PolicyTags, RecentlyUsedTags} from '@src/types/onyx';
+import type {PolicyTag, PolicyTagLists, PolicyTags, RecentlyUsedTags} from '@src/types/onyx';
 
 import Onyx from 'react-native-onyx';
 import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';
@@ -2562,7 +2562,7 @@ describe('actions/Policy', () => {
                     },
                 },
             };
-            const engineeringRoadshowTag = {
+            const engineeringRoadshowTag: PolicyTag = {
                 name: 'Roadshow',
                 enabled: true,
                 rules: {parentTagsFilter: '^Engineering$'},

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -2551,6 +2551,7 @@ describe('actions/Policy', () => {
         it('should update GL code for a dependent tag stored under a unique record key', async () => {
             const fakePolicy = createRandomPolicy(0);
             const tagListName = 'Project';
+            const engineeringRoadshowKey = 'Roadshow-1';
             const fakePolicyTags: PolicyTagLists = {
                 [tagListName]: {
                     name: tagListName,
@@ -2558,17 +2559,16 @@ describe('actions/Policy', () => {
                     required: false,
                     tags: {
                         Roadshow: {name: 'Roadshow', enabled: true, rules: {parentTagsFilter: '^Marketing$'}},
-                        // eslint-disable-next-line @typescript-eslint/naming-convention
-                        'Roadshow-1': {
-                            name: 'Roadshow',
-                            enabled: true,
-                            // eslint-disable-next-line @typescript-eslint/naming-convention
-                            'GL Code': '1111',
-                            rules: {parentTagsFilter: '^Engineering$'},
-                        },
                     },
                 },
             };
+            const engineeringRoadshowTag = {
+                name: 'Roadshow',
+                enabled: true,
+                rules: {parentTagsFilter: '^Engineering$'},
+            };
+            engineeringRoadshowTag['GL Code'] = '1111';
+            fakePolicyTags[tagListName].tags[engineeringRoadshowKey] = engineeringRoadshowTag;
             const newGLCode = 'NEW_GL_CODE_789';
 
             mockFetch.pause();

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -2558,7 +2558,14 @@ describe('actions/Policy', () => {
                     required: false,
                     tags: {
                         Roadshow: {name: 'Roadshow', enabled: true, rules: {parentTagsFilter: '^Marketing$'}},
-                        'Roadshow-1': {name: 'Roadshow', enabled: true, 'GL Code': '1111', rules: {parentTagsFilter: '^Engineering$'}},
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        'Roadshow-1': {
+                            name: 'Roadshow',
+                            enabled: true,
+                            // eslint-disable-next-line @typescript-eslint/naming-convention
+                            'GL Code': '1111',
+                            rules: {parentTagsFilter: '^Engineering$'},
+                        },
                     },
                 },
             };

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -47,6 +47,7 @@ import {
     getSubmitToEmail,
     getTagApproverRule,
     findPolicyTagAtLevel,
+    findPolicyTagEntryByParentFilter,
     getTagGLCode,
     isTagInPolicy,
     matchesParentTagPath,
@@ -1915,6 +1916,31 @@ describe('PolicyUtils', () => {
 
             expect(findPolicyTagAtLevel(escapedParentTags, 'Roadshow', 'Sales\\:EMEA')?.name).toBe('Roadshow');
             expect(findPolicyTagAtLevel(escapedParentTags, 'Roadshow', 'Sales')).toBeUndefined();
+        });
+    });
+
+    describe('findPolicyTagEntryByParentFilter', () => {
+        const dependentTags: PolicyTags = {
+            Roadshow: {name: 'Roadshow', enabled: true, rules: {parentTagsFilter: '^Marketing$'}},
+            'Roadshow-1': {name: 'Roadshow', enabled: true, 'GL Code': '2222', rules: {parentTagsFilter: '^Engineering$'}},
+        };
+
+        it('returns the tag and storage key when parentTagsFilter matches', () => {
+            expect(findPolicyTagEntryByParentFilter(dependentTags, 'Roadshow', '^Engineering$')).toEqual({
+                tag: dependentTags['Roadshow-1'],
+                tagKey: 'Roadshow-1',
+            });
+        });
+
+        it('returns the tag by name when parentTagsFilter is not provided', () => {
+            expect(findPolicyTagEntryByParentFilter(dependentTags, 'Roadshow')).toEqual({
+                tag: dependentTags.Roadshow,
+                tagKey: 'Roadshow',
+            });
+        });
+
+        it('returns undefined when parentTagsFilter does not match any tag', () => {
+            expect(findPolicyTagEntryByParentFilter(dependentTags, 'Roadshow', '^Sales$')).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Dependent multi-level tags can have GL codes at each level (same as independent tags), but the workspace tag settings flow could not resolve or update them correctly when duplicate display names exist under different parents.

This PR:
- Adds `findPolicyTagEntryByParentFilter` to resolve the correct tag record (and Onyx storage key) using `parentTagsFilter`
- Sends `parentTagsFilter` with `UpdatePolicyTagGLCode` so the backend updates the correct dependent tag
- Unblocks the GL code row in dependent tag settings (previously hidden when `hasDependentTags` was true)
- Passes `parentTagsFilter` through tag list → settings → GL code navigation
- Fixes post-save navigation for level 1+ tags (Region/City) by popping the stack on back instead of rebuilding the route, which was dropping `parentTagsFilter` and showing NotFound even though the GL code saved successfully

The **“Show GL codes when selecting a tag”** toggle in **Tags → More → Settings** remains visible and unchanged — dependent tags are expected to support GL codes when that setting is enabled.

### Fixed Issues
$ https://github.com/Expensify/App/issues/98488
PROPOSAL:

### Tests
1. Open a Control workspace with multi-level dependent tags imported using a CSV like State / Region / City with adjacent GL columns or simply use this file 
[multi-level-dependent-tags-with-gl-codes.csv](https://github.com/user-attachments/files/32076736/multi-level-dependent-tags-with-gl-codes.csv)
(see QA import settings below) 
2. Go to **Workspace → Tags → More → Settings** and confirm **“Show GL codes when selecting a tag”** is visible and can be toggled
3. Open the **State** tag list, select a tag (e.g. California), open **GL code**, edit the value, and tap **Save**
4. Confirm you return to tag settings (no NotFound page) and the updated GL code is shown
5. Open the **Region** tag list, select a tag (e.g. South), open **GL code**, tap **Save** without editing
6. Confirm you return to tag settings (no NotFound page) and the GL code is unchanged
7. Open the **City** tag list, select a tag (e.g. Austin), open **GL code**, edit the value, and tap **Save**
8. Confirm you return to tag settings (no NotFound page) and the updated GL code is shown
9. Create an expense, open the tag picker with **Show GL codes when selecting a tag** enabled, and confirm GL codes appear/search for dependent tags as expected
10. Repeat steps 3–8 on web and one native platform

- [ ] Verify that no errors appear in the JS console

### Offline tests
1. Go offline
2. Open a dependent tag at Region or City level → **GL code** → edit and tap **Save**
3. Confirm optimistic UI updates the GL code and navigation returns to tag settings without NotFound
4. Go back online and confirm the GL code persists after refresh

### QA Steps
**Import settings:**
- First row is the title for each tag list → **ON**
- These are independent tags → **OFF** (dependent)
- There is a GL code in the adjacent column → **ON**

Use a dependent multi-level CSV with GL columns (e.g. State / State GL / Region / Region GL / City / City GL) or simply use this file 
[multi-level-dependent-tags-with-gl-codes.csv](https://github.com/user-attachments/files/32076752/multi-level-dependent-tags-with-gl-codes.csv)


1. Import the CSV into a Control workspace
2. Go to **Workspace → Tags → More → Settings**
3. **Expected:** **“Show GL codes when selecting a tag”** toggle is visible
4. Enable **Show GL codes when selecting a tag** if it is off
5. Open the **State** list → select a tag → **GL code** → edit → **Save**
6. Confirm return to settings with updated GL code (no NotFound)
7. Open the **Region** list → select a tag → **GL code** → **Save** without editing
8. Confirm return to settings with no NotFound
9. Open the **City** list → select a tag → **GL code** → edit → **Save**
10. Confirm return to settings with updated GL code (no NotFound)
11. Create an expense and verify GL codes show in the dependent tag picker when the toggle is on
12. Repeat on all platforms

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open it as an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/3c3f1b60-5f77-4d2f-8e94-d3a86e97b0c6



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/67859f01-7e65-48c0-ada4-f02018cce221



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/48d6dca3-b742-4eed-896f-2461daad8420



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/c30d3713-3829-4e58-8722-70c3e50ced42



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/c474fd3c-e8a2-43aa-a92b-90263e02b4b6



</details>