### PR TITLE
[CP Staging] Fix Concierge prompt box bugs on the HomePage

### DIFF
--- a/src/components/AutoCompleteSuggestions/index.tsx
+++ b/src/components/AutoCompleteSuggestions/index.tsx
@@ -13,6 +13,7 @@ import React, {useEffect} from 'react';
 import type {AutoCompleteSuggestionsProps, MeasureParentContainerAndCursor} from './types';
 
 import AutoCompleteSuggestionsPortal from './AutoCompleteSuggestionsPortal';
+import getBottomSuggestionPadding from './AutoCompleteSuggestionsPortal/getBottomSuggestionPadding';
 import getLeftOffset from './getSuggestionsLeftOffset';
 import getSuggestionsViewportBottom from './getSuggestionsViewportBottom';
 
@@ -43,11 +44,13 @@ function isSuggestionMenuRenderedAbove(isEnoughSpaceAboveForBigMenu: boolean, is
 }
 
 type IsEnoughSpaceToRenderMenuAboveCursor = Pick<MeasureParentContainerAndCursor, 'y' | 'cursorCoordinates' | 'scrollValue'> & {
-    contentHeight: number;
+    menuHeight: number;
     topInset: number;
 };
-function isEnoughSpaceToRenderMenuAboveCursor({y, cursorCoordinates, scrollValue, contentHeight, topInset}: IsEnoughSpaceToRenderMenuAboveCursor): boolean {
-    return y + (cursorCoordinates.y - scrollValue) > contentHeight + topInset + CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTION_BOX_MAX_SAFE_DISTANCE;
+function isEnoughSpaceToRenderMenuAboveCursor({y, cursorCoordinates, scrollValue, menuHeight, topInset}: IsEnoughSpaceToRenderMenuAboveCursor): boolean {
+    const gapAboveCursor = Math.max(CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTION_BOX_MAX_SAFE_DISTANCE, getBottomSuggestionPadding(true));
+
+    return y + (cursorCoordinates.y - scrollValue) > menuHeight + gapAboveCursor + topInset;
 }
 
 const initialContainerState = {
@@ -123,7 +126,7 @@ function AutoCompleteSuggestions<TSuggestion>({measureParentContainerAndReportCu
                 y,
                 cursorCoordinates,
                 scrollValue,
-                contentHeight: contentMaxHeight,
+                menuHeight: StyleUtils.getAutoCompleteSuggestionContainerHeight(contentMaxHeight),
                 topInset,
             });
 
@@ -134,7 +137,7 @@ function AutoCompleteSuggestions<TSuggestion>({measureParentContainerAndReportCu
                     y,
                     cursorCoordinates,
                     scrollValue,
-                    contentHeight: contentMinHeight,
+                    menuHeight: StyleUtils.getAutoCompleteSuggestionContainerHeight(contentMinHeight),
                     topInset,
                 });
 
@@ -186,6 +189,7 @@ function AutoCompleteSuggestions<TSuggestion>({measureParentContainerAndReportCu
         isKeyboardAnimatingRef,
         isInLandscapeMode,
         insets,
+        StyleUtils,
     ]);
 
     // Prevent rendering if container dimensions are not set or if we have no suggestions

--- a/src/components/DragAndDrop/Provider/index.tsx
+++ b/src/components/DragAndDrop/Provider/index.tsx
@@ -1,6 +1,8 @@
 import useDragAndDrop from '@hooks/useDragAndDrop';
 import useThemeStyles from '@hooks/useThemeStyles';
 
+import {shouldAcceptDrop} from '@libs/DragAndDropUtils';
+
 import htmlDivElementRef from '@src/types/utils/htmlDivElementRef';
 import viewRef from '@src/types/utils/viewRef';
 
@@ -12,10 +14,6 @@ import {View} from 'react-native';
 import type {DragAndDropActionsContextType, DragAndDropProviderProps, DragAndDropStateContextType, SetOnDropHandlerCallback} from './types';
 
 import {DragAndDropActionsContext, DragAndDropStateContext} from './DragAndDropContext';
-
-function shouldAcceptDrop(event: DragEvent): boolean {
-    return !!event.dataTransfer?.types.some((type) => type === 'Files');
-}
 
 function DragAndDropProvider({children, isDisabled = false, setIsDraggingOver = () => {}}: DragAndDropProviderProps) {
     const styles = useThemeStyles();

--- a/src/components/DropZone/DropZoneWrapper.tsx
+++ b/src/components/DropZone/DropZoneWrapper.tsx
@@ -1,6 +1,8 @@
 import useDragAndDrop from '@hooks/useDragAndDrop';
 import useThemeStyles from '@hooks/useThemeStyles';
 
+import {shouldAcceptDrop} from '@libs/DragAndDropUtils';
+
 import htmlDivElementRef from '@src/types/utils/htmlDivElementRef';
 import viewRef from '@src/types/utils/viewRef';
 
@@ -21,7 +23,7 @@ function DropZoneWrapper({onDrop, children}: DropZoneWrapperProps) {
     const dropZone = useRef<HTMLDivElement | View>(null);
 
     const {isDraggingOver} = useDragAndDrop({
-        shouldAcceptDrop: (event) => !!event.dataTransfer?.types.some((type) => type === 'Files'),
+        shouldAcceptDrop,
         onDrop,
         shouldStopPropagation: false,
         shouldHandleDragEvent: false,

--- a/src/components/ReceiptScanDropZone/ReceiptScanDropTarget.tsx
+++ b/src/components/ReceiptScanDropZone/ReceiptScanDropTarget.tsx
@@ -1,0 +1,75 @@
+import DropZoneUI from '@components/DropZone/DropZoneUI';
+
+import useDragAndDrop from '@hooks/useDragAndDrop';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useReceiptScanDrop from '@hooks/useReceiptScanDrop';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import htmlDivElementRef from '@src/types/utils/htmlDivElementRef';
+
+import type {StyleProp, View, ViewStyle} from 'react-native';
+
+import React, {useEffect} from 'react';
+import {View as RNView} from 'react-native';
+
+type ReceiptScanDropTargetProps = {
+    /** Ref to the element the drag events are bound to */
+    targetRef: React.RefObject<View | HTMLDivElement | null>;
+
+    dropWrapperStyle?: StyleProp<ViewStyle>;
+
+    /** Reports the drag-over state back to the drop zone, which publishes it through DragAndDropStateContext */
+    onDraggingOverChange: (isDraggingOver: boolean) => void;
+};
+
+function shouldAcceptDrop(event: DragEvent): boolean {
+    return !!event.dataTransfer?.types.some((type) => type === 'Files');
+}
+
+/**
+ * Owns the receipt scan drag-and-drop logic and the drop overlay.
+ */
+function ReceiptScanDropTarget({targetRef, dropWrapperStyle, onDraggingOverChange}: ReceiptScanDropTargetProps) {
+    const styles = useThemeStyles();
+    const theme = useTheme();
+    const {translate} = useLocalize();
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['SmartScan']);
+    const {initScanRequest, auxiliaryUI, isDragDisabled} = useReceiptScanDrop();
+
+    const {isDraggingOver} = useDragAndDrop({
+        dropZone: htmlDivElementRef(targetRef),
+        onDrop: initScanRequest,
+        shouldAcceptDrop,
+        isDisabled: isDragDisabled,
+    });
+
+    useEffect(() => {
+        onDraggingOverChange(isDraggingOver);
+        return () => onDraggingOverChange(false);
+    }, [isDraggingOver, onDraggingOverChange]);
+
+    return (
+        <>
+            {isDraggingOver && (
+                <RNView
+                    pointerEvents="none"
+                    style={[styles.fullScreen, styles.pAbsolute, styles.invisibleOverlay]}
+                >
+                    <DropZoneUI
+                        icon={expensifyIcons.SmartScan}
+                        dropTitle={translate('dropzone.scanReceipts')}
+                        dropStyles={styles.receiptDropOverlay(true)}
+                        dropTextStyles={styles.receiptDropText}
+                        dropWrapperStyles={dropWrapperStyle}
+                        dashedBorderStyles={[styles.dropzoneArea, styles.easeInOpacityTransition, styles.activeDropzoneDashedBorder(theme.receiptDropBorderColorActive, true)]}
+                    />
+                </RNView>
+            )}
+            {auxiliaryUI}
+        </>
+    );
+}
+
+export default ReceiptScanDropTarget;

--- a/src/components/ReceiptScanDropZone/ReceiptScanDropTarget.tsx
+++ b/src/components/ReceiptScanDropZone/ReceiptScanDropTarget.tsx
@@ -7,6 +7,8 @@ import useReceiptScanDrop from '@hooks/useReceiptScanDrop';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 
+import {shouldAcceptDrop} from '@libs/DragAndDropUtils';
+
 import htmlDivElementRef from '@src/types/utils/htmlDivElementRef';
 
 import type {StyleProp, View, ViewStyle} from 'react-native';
@@ -23,10 +25,6 @@ type ReceiptScanDropTargetProps = {
     /** Reports the drag-over state back to the drop zone, which publishes it through DragAndDropStateContext */
     onDraggingOverChange: (isDraggingOver: boolean) => void;
 };
-
-function shouldAcceptDrop(event: DragEvent): boolean {
-    return !!event.dataTransfer?.types.some((type) => type === 'Files');
-}
 
 /**
  * Owns the receipt scan drag-and-drop logic and the drop overlay.

--- a/src/components/ReceiptScanDropZone/index.tsx
+++ b/src/components/ReceiptScanDropZone/index.tsx
@@ -1,61 +1,44 @@
-import DropZoneUI from '@components/DropZone/DropZoneUI';
+import {DragAndDropStateContext} from '@components/DragAndDrop/Provider/DragAndDropContext';
 
-import useDragAndDrop from '@hooks/useDragAndDrop';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
-import useLocalize from '@hooks/useLocalize';
-import useReceiptScanDrop from '@hooks/useReceiptScanDrop';
-import useTheme from '@hooks/useTheme';
-import useThemeStyles from '@hooks/useThemeStyles';
-
-import htmlDivElementRef from '@src/types/utils/htmlDivElementRef';
-
+import type {ReactNode, RefObject} from 'react';
 import type {StyleProp, View, ViewStyle} from 'react-native';
 
-import React from 'react';
-import {View as RNView} from 'react-native';
+import React, {useState} from 'react';
+
+import ReceiptScanDropTarget from './ReceiptScanDropTarget';
 
 type ReceiptScanDropZoneProps = {
-    targetRef: React.RefObject<View | HTMLDivElement | null>;
+    /** The page content that receipts can be dropped onto */
+    children: ReactNode;
+
+    /** Ref to the container receipts are dropped onto */
+    dropZoneRef: RefObject<View | HTMLDivElement | null>;
+
+    /** Whether the drop zone is disabled, keeping the scan logic unmounted */
+    isDisabled?: boolean;
+
     dropWrapperStyle?: StyleProp<ViewStyle>;
 };
 
-function shouldAcceptDrop(event: DragEvent): boolean {
-    return !!event.dataTransfer?.types.some((type) => type === 'Files');
-}
-
-function ReceiptScanDropZone({targetRef, dropWrapperStyle}: ReceiptScanDropZoneProps) {
-    const styles = useThemeStyles();
-    const theme = useTheme();
-    const {translate} = useLocalize();
-    const expensifyIcons = useMemoizedLazyExpensifyIcons(['SmartScan']);
-    const {initScanRequest, auxiliaryUI, isDragDisabled} = useReceiptScanDrop();
-
-    const {isDraggingOver} = useDragAndDrop({
-        dropZone: htmlDivElementRef(targetRef),
-        onDrop: initScanRequest,
-        shouldAcceptDrop,
-        isDisabled: isDragDisabled,
-    });
+/**
+ * Turns the page into a receipt scan drop zone and publishes the drag state to it, so components inside can react to a
+ * file being dragged over the page.
+ */
+function ReceiptScanDropZone({children, dropZoneRef, isDisabled = false, dropWrapperStyle}: ReceiptScanDropZoneProps) {
+    const [isDraggingOver, setIsDraggingOver] = useState(false);
 
     return (
-        <>
-            {isDraggingOver && (
-                <RNView
-                    pointerEvents="none"
-                    style={[styles.fullScreen, styles.pAbsolute, styles.invisibleOverlay]}
-                >
-                    <DropZoneUI
-                        icon={expensifyIcons.SmartScan}
-                        dropTitle={translate('dropzone.scanReceipts')}
-                        dropStyles={styles.receiptDropOverlay(true)}
-                        dropTextStyles={styles.receiptDropText}
-                        dropWrapperStyles={dropWrapperStyle}
-                        dashedBorderStyles={[styles.dropzoneArea, styles.easeInOpacityTransition, styles.activeDropzoneDashedBorder(theme.receiptDropBorderColorActive, true)]}
-                    />
-                </RNView>
+        // eslint-disable-next-line react/jsx-no-constructed-context-values
+        <DragAndDropStateContext.Provider value={{isDraggingOver, dropZoneID: ''}}>
+            {children}
+            {!isDisabled && (
+                <ReceiptScanDropTarget
+                    targetRef={dropZoneRef}
+                    dropWrapperStyle={dropWrapperStyle}
+                    onDraggingOverChange={setIsDraggingOver}
+                />
             )}
-            {auxiliaryUI}
-        </>
+        </DragAndDropStateContext.Provider>
     );
 }
 

--- a/src/libs/DragAndDropUtils.ts
+++ b/src/libs/DragAndDropUtils.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether the dragged content contains files, which is the only payload our drop zones handle.
+ */
+function shouldAcceptDrop(event: DragEvent): boolean {
+    return !!event.dataTransfer?.types.some((type) => type === 'Files');
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export {shouldAcceptDrop};

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -237,140 +237,140 @@ function SearchPageNarrow({
             ref={receiptDropTargetRef}
             style={styles.flex1}
         >
-            <ScreenWrapper
-                testID="SearchPageNarrow"
-                shouldEnableMaxHeight
-                offlineIndicatorStyle={styles.mtAuto}
-                shouldShowOfflineIndicator={!!searchResults}
-                bottomContent={tabBarContent}
-                bottomContentStyle={styles.overflowVisible}
+            <ReceiptScanDropZone
+                dropZoneRef={receiptDropTargetRef}
+                isDisabled={useStaticRendering && !isHeaderInteractive}
+                dropWrapperStyle={{marginBottom: variables.bottomTabHeight}}
             >
-                <View style={[styles.flex1, styles.overflowHidden]}>
-                    {!isMobileSelectionModeEnabled ? (
-                        <View style={[StyleUtils.getSearchPageNarrowHeaderStyles(), styles.mh100]}>
-                            <View style={[styles.zIndex10, styles.appBG]}>
+                <ScreenWrapper
+                    testID="SearchPageNarrow"
+                    shouldEnableMaxHeight
+                    offlineIndicatorStyle={styles.mtAuto}
+                    shouldShowOfflineIndicator={!!searchResults}
+                    bottomContent={tabBarContent}
+                    bottomContentStyle={styles.overflowVisible}
+                >
+                    <View style={[styles.flex1, styles.overflowHidden]}>
+                        {!isMobileSelectionModeEnabled ? (
+                            <View style={[StyleUtils.getSearchPageNarrowHeaderStyles(), styles.mh100]}>
+                                <View style={[styles.zIndex10, styles.appBG]}>
+                                    <SearchPageHeaderNarrow
+                                        queryJSON={queryJSON}
+                                        shouldShowLoadingBar={shouldShowLoadingState || shouldShowLoadingBarForReports}
+                                        isMobileSelectionModeEnabled={false}
+                                    />
+                                </View>
+                                <View style={[styles.flex1]}>
+                                    <Animated.View style={[topBarAnimatedStyle, styles.narrowSearchRouterInactiveStyle, styles.flex1, styles.appBG, styles.searchTopBarZIndexStyle]}>
+                                        <PulsingView
+                                            shouldPulse={!isHeaderInteractive}
+                                            style={styles.flex1}
+                                            wrapperStyle={[styles.flex1, styles.appBG]}
+                                        >
+                                            <SearchTypeMenuSwitch
+                                                showStatic={!isHeaderInteractive}
+                                                queryJSON={queryJSON}
+                                            />
+                                            <View style={[styles.flex1, styles.flexRow, styles.pt1, styles.mh5, styles.mb4, styles.gap3]}>
+                                                <SearchPageInputSwitch
+                                                    showStatic={!isHeaderInteractive}
+                                                    queryJSON={queryJSON}
+                                                    onFocus={() => topBarOffset.set(StyleUtils.searchHeaderDefaultOffset)}
+                                                />
+                                                <SearchActionsBarSwitch
+                                                    showStatic={!isHeaderInteractive}
+                                                    queryJSON={queryJSON}
+                                                    searchResults={searchResults}
+                                                    onSort={onSortPressedCallback}
+                                                />
+                                            </View>
+                                            <SearchFiltersBarSwitch
+                                                showStatic={!isHeaderInteractive}
+                                                queryJSON={queryJSON}
+                                            />
+                                        </PulsingView>
+                                    </Animated.View>
+                                </View>
+                            </View>
+                        ) : (
+                            <>
+                                <HeaderWithBackButton
+                                    title={translate('common.selectMultiple')}
+                                    onBackButtonPress={() => {
+                                        topBarOffset.set(StyleUtils.searchHeaderDefaultOffset);
+                                        clearSelectedTransactions();
+                                        turnOffMobileSelectionMode();
+                                    }}
+                                />
                                 <SearchPageHeaderNarrow
                                     queryJSON={queryJSON}
-                                    shouldShowLoadingBar={shouldShowLoadingState || shouldShowLoadingBarForReports}
-                                    isMobileSelectionModeEnabled={false}
+                                    shouldShowLoadingBar={false}
+                                    isMobileSelectionModeEnabled
                                 />
-                            </View>
-                            <View style={[styles.flex1]}>
-                                <Animated.View style={[topBarAnimatedStyle, styles.narrowSearchRouterInactiveStyle, styles.flex1, styles.appBG, styles.searchTopBarZIndexStyle]}>
-                                    <PulsingView
-                                        shouldPulse={!isHeaderInteractive}
-                                        style={styles.flex1}
-                                        wrapperStyle={[styles.flex1, styles.appBG]}
-                                    >
-                                        <SearchTypeMenuSwitch
-                                            showStatic={!isHeaderInteractive}
+                            </>
+                        )}
+                        <View style={[styles.flex1]}>
+                            {useStaticRendering && (
+                                <>
+                                    {isInteractive && (
+                                        <Search
+                                            searchResults={searchResults}
                                             queryJSON={queryJSON}
+                                            key={queryJSON.hash}
+                                            contentContainerStyle={contentContainerStyle}
+                                            handleSearch={handleSearchAction}
+                                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                                            onSearchListScroll={scrollHandler}
+                                            onDestinationVisible={endSubmitNavigationSpans}
+                                            onContentReady={onSearchContentReady}
+                                            hasFilterBars={hasFilterBars}
                                         />
-                                        <View style={[styles.flex1, styles.flexRow, styles.pt1, styles.mh5, styles.mb4, styles.gap3]}>
-                                            <SearchPageInputSwitch
-                                                showStatic={!isHeaderInteractive}
-                                                queryJSON={queryJSON}
-                                                onFocus={() => topBarOffset.set(StyleUtils.searchHeaderDefaultOffset)}
-                                            />
-                                            <SearchActionsBarSwitch
-                                                showStatic={!isHeaderInteractive}
-                                                queryJSON={queryJSON}
-                                                searchResults={searchResults}
-                                                onSort={onSortPressedCallback}
-                                            />
+                                    )}
+                                    {shouldRenderLayoutProbe && <View onLayout={onSearchLayout} />}
+                                    {!!searchOverlayContent && (
+                                        <View
+                                            style={[StyleSheet.absoluteFill, styles.appBG]}
+                                            onLayout={onSearchLayout}
+                                        >
+                                            {searchOverlayContent}
                                         </View>
-                                        <SearchFiltersBarSwitch
-                                            showStatic={!isHeaderInteractive}
+                                    )}
+                                </>
+                            )}
+                            {!useStaticRendering && (
+                                <>
+                                    {shouldShowLoadingSkeleton ? (
+                                        <SearchLoadingSkeleton containerStyle={styles.searchListContentContainerStyles(hasFilterBars)} />
+                                    ) : (
+                                        <SearchWithNavigationDeferredMount
+                                            searchResults={searchResults}
                                             queryJSON={queryJSON}
+                                            key={queryJSON.hash}
+                                            onSearchListScroll={scrollHandler}
+                                            contentContainerStyle={contentContainerStyle}
+                                            handleSearch={handleSearchAction}
+                                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                                            onDestinationVisible={endSubmitNavigationSpans}
+                                            onContentReady={onSearchContentReady}
+                                            hasFilterBars={hasFilterBars}
                                         />
-                                    </PulsingView>
-                                </Animated.View>
-                            </View>
+                                    )}
+                                    {shouldRenderLayoutProbe && <View onLayout={onSearchLayout} />}
+                                    {!!searchOverlayContent && (
+                                        <View
+                                            style={[StyleSheet.absoluteFill, styles.appBG]}
+                                            onLayout={onSearchLayout}
+                                        >
+                                            {searchOverlayContent}
+                                        </View>
+                                    )}
+                                </>
+                            )}
                         </View>
-                    ) : (
-                        <>
-                            <HeaderWithBackButton
-                                title={translate('common.selectMultiple')}
-                                onBackButtonPress={() => {
-                                    topBarOffset.set(StyleUtils.searchHeaderDefaultOffset);
-                                    clearSelectedTransactions();
-                                    turnOffMobileSelectionMode();
-                                }}
-                            />
-                            <SearchPageHeaderNarrow
-                                queryJSON={queryJSON}
-                                shouldShowLoadingBar={false}
-                                isMobileSelectionModeEnabled
-                            />
-                        </>
-                    )}
-                    <View style={[styles.flex1]}>
-                        {useStaticRendering && (
-                            <>
-                                {isInteractive && (
-                                    <Search
-                                        searchResults={searchResults}
-                                        queryJSON={queryJSON}
-                                        key={queryJSON.hash}
-                                        contentContainerStyle={contentContainerStyle}
-                                        handleSearch={handleSearchAction}
-                                        isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                                        onSearchListScroll={scrollHandler}
-                                        onDestinationVisible={endSubmitNavigationSpans}
-                                        onContentReady={onSearchContentReady}
-                                        hasFilterBars={hasFilterBars}
-                                    />
-                                )}
-                                {shouldRenderLayoutProbe && <View onLayout={onSearchLayout} />}
-                                {!!searchOverlayContent && (
-                                    <View
-                                        style={[StyleSheet.absoluteFill, styles.appBG]}
-                                        onLayout={onSearchLayout}
-                                    >
-                                        {searchOverlayContent}
-                                    </View>
-                                )}
-                            </>
-                        )}
-                        {!useStaticRendering && (
-                            <>
-                                {shouldShowLoadingSkeleton ? (
-                                    <SearchLoadingSkeleton containerStyle={styles.searchListContentContainerStyles(hasFilterBars)} />
-                                ) : (
-                                    <SearchWithNavigationDeferredMount
-                                        searchResults={searchResults}
-                                        queryJSON={queryJSON}
-                                        key={queryJSON.hash}
-                                        onSearchListScroll={scrollHandler}
-                                        contentContainerStyle={contentContainerStyle}
-                                        handleSearch={handleSearchAction}
-                                        isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                                        onDestinationVisible={endSubmitNavigationSpans}
-                                        onContentReady={onSearchContentReady}
-                                        hasFilterBars={hasFilterBars}
-                                    />
-                                )}
-                                {shouldRenderLayoutProbe && <View onLayout={onSearchLayout} />}
-                                {!!searchOverlayContent && (
-                                    <View
-                                        style={[StyleSheet.absoluteFill, styles.appBG]}
-                                        onLayout={onSearchLayout}
-                                    >
-                                        {searchOverlayContent}
-                                    </View>
-                                )}
-                            </>
-                        )}
+                        <SearchSelectionFooter searchResults={searchResults} />
                     </View>
-                    <SearchSelectionFooter searchResults={searchResults} />
-                </View>
-            </ScreenWrapper>
-            {(!useStaticRendering || isHeaderInteractive) && (
-                <ReceiptScanDropZone
-                    targetRef={receiptDropTargetRef}
-                    dropWrapperStyle={{marginBottom: variables.bottomTabHeight}}
-                />
-            )}
+                </ScreenWrapper>
+            </ReceiptScanDropZone>
         </View>
     );
 }

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -260,7 +260,7 @@ function SearchPageNarrow({
                                         isMobileSelectionModeEnabled={false}
                                     />
                                 </View>
-                                <View style={[styles.flex1]}>
+                                <View style={styles.flex1}>
                                     <Animated.View style={[topBarAnimatedStyle, styles.narrowSearchRouterInactiveStyle, styles.flex1, styles.appBG, styles.searchTopBarZIndexStyle]}>
                                         <PulsingView
                                             shouldPulse={!isHeaderInteractive}
@@ -309,7 +309,7 @@ function SearchPageNarrow({
                                 />
                             </>
                         )}
-                        <View style={[styles.flex1]}>
+                        <View style={styles.flex1}>
                             {useStaticRendering && (
                                 <>
                                     {isInteractive && (

--- a/src/pages/Search/SearchPageWide.tsx
+++ b/src/pages/Search/SearchPageWide.tsx
@@ -69,7 +69,6 @@ function SearchPageWide({
     const shouldAllowFooterTotals = useSearchShouldCalculateTotals(currentSearchKey, true);
     const shouldReserveFooterSpace = hasSelectedTransactions || (shouldAllowFooterTotals && !!searchResults?.search?.count);
     const {saveScrollOffset} = useContext(ScrollOffsetContext);
-    const receiptDropTargetRef = useRef<View>(null);
 
     const endSubmitNavigationSpans = useEndSubmitNavigationSpans({requireLayout: false});
 
@@ -94,56 +93,61 @@ function SearchPageWide({
 
     const handleOnBackButtonPress = () => Navigation.goBack(ROUTES.SEARCH_ROOT.getRoute({query: buildCannedSearchQuery()}));
     const splitContainerAnimatedStyle = useSearchSidebarContentOffsetStyle();
+    const receiptDropTargetRef = useRef<View>(null);
 
     return (
         <Animated.View
             ref={receiptDropTargetRef}
             style={[styles.searchSplitContainer, splitContainerAnimatedStyle]}
         >
-            <ScreenWrapper
-                testID="Search"
-                shouldEnableMaxHeight
-                shouldShowOfflineIndicatorInWideScreen={!!searchResults}
-                offlineIndicatorStyle={offlineIndicatorStyle}
+            <ReceiptScanDropZone
+                dropZoneRef={receiptDropTargetRef}
+                isDisabled={!queryJSON}
             >
-                <FullPageNotFoundView
-                    shouldForceFullScreen
-                    shouldShow={!queryJSON}
-                    onBackButtonPress={handleOnBackButtonPress}
-                    shouldShowLink={false}
+                <ScreenWrapper
+                    testID="Search"
+                    shouldEnableMaxHeight
+                    shouldShowOfflineIndicatorInWideScreen={!!searchResults}
+                    offlineIndicatorStyle={offlineIndicatorStyle}
                 >
-                    {!!queryJSON && (
-                        <>
-                            <SearchPageHeaderWide queryJSON={queryJSON} />
-                            <SearchActionsBarWide
-                                queryJSON={queryJSON}
-                                searchResults={searchResults}
-                                onSort={onSortPressedCallback}
-                            />
-                            <View style={styles.flex1}>
-                                {shouldShowLoadingSkeleton ? (
-                                    <SearchLoadingSkeleton />
-                                ) : (
-                                    <SearchWithNavigationDeferredMount
-                                        key={queryJSON.hash}
-                                        queryJSON={queryJSON}
-                                        searchResults={searchResults}
-                                        handleSearch={handleSearchAction}
-                                        isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                                        onSearchListScroll={scrollHandler}
-                                        onSortPressedCallback={onSortPressedCallback}
-                                        onDestinationVisible={endSubmitNavigationSpans}
-                                        onContentReady={onSearchContentReady}
-                                    />
-                                )}
-                                {!!searchOverlayContent && <View style={[StyleSheet.absoluteFill, styles.appBG]}>{searchOverlayContent}</View>}
-                            </View>
-                            <SearchSelectionFooter searchResults={searchResults} />
-                        </>
-                    )}
-                </FullPageNotFoundView>
-            </ScreenWrapper>
-            {!!queryJSON && <ReceiptScanDropZone targetRef={receiptDropTargetRef} />}
+                    <FullPageNotFoundView
+                        shouldForceFullScreen
+                        shouldShow={!queryJSON}
+                        onBackButtonPress={handleOnBackButtonPress}
+                        shouldShowLink={false}
+                    >
+                        {!!queryJSON && (
+                            <>
+                                <SearchPageHeaderWide queryJSON={queryJSON} />
+                                <SearchActionsBarWide
+                                    queryJSON={queryJSON}
+                                    searchResults={searchResults}
+                                    onSort={onSortPressedCallback}
+                                />
+                                <View style={styles.flex1}>
+                                    {shouldShowLoadingSkeleton ? (
+                                        <SearchLoadingSkeleton />
+                                    ) : (
+                                        <SearchWithNavigationDeferredMount
+                                            key={queryJSON.hash}
+                                            queryJSON={queryJSON}
+                                            searchResults={searchResults}
+                                            handleSearch={handleSearchAction}
+                                            isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                                            onSearchListScroll={scrollHandler}
+                                            onSortPressedCallback={onSortPressedCallback}
+                                            onDestinationVisible={endSubmitNavigationSpans}
+                                            onContentReady={onSearchContentReady}
+                                        />
+                                    )}
+                                    {!!searchOverlayContent && <View style={[StyleSheet.absoluteFill, styles.appBG]}>{searchOverlayContent}</View>}
+                                </View>
+                                <SearchSelectionFooter searchResults={searchResults} />
+                            </>
+                        )}
+                    </FullPageNotFoundView>
+                </ScreenWrapper>
+            </ReceiptScanDropZone>
         </Animated.View>
     );
 }

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -47,10 +47,13 @@ function HomePage() {
     const [isConciergeMenuVisible, setIsConciergeMenuVisible] = useState(false);
 
     return (
-        <View style={styles.flex1}>
-            <View
-                ref={receiptDropTargetRef}
-                style={styles.flex1}
+        <View
+            ref={receiptDropTargetRef}
+            style={styles.flex1}
+        >
+            <ReceiptScanDropZone
+                dropZoneRef={receiptDropTargetRef}
+                dropWrapperStyle={shouldUseNarrowLayout ? {marginBottom: variables.bottomTabHeight} : undefined}
             >
                 <ScreenWrapper
                     shouldEnablePickerAvoiding={false}
@@ -120,11 +123,7 @@ function HomePage() {
                     </ScrollView>
                     <PortalHost name="suggestions" />
                 </ScreenWrapper>
-            </View>
-            <ReceiptScanDropZone
-                targetRef={receiptDropTargetRef}
-                dropWrapperStyle={shouldUseNarrowLayout ? {marginBottom: variables.bottomTabHeight} : undefined}
-            />
+            </ReceiptScanDropZone>
         </View>
     );
 }

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1041,19 +1041,23 @@ function getBaseAutoCompleteSuggestionContainerStyle({left, bottom, width}: GetB
 
 const shouldPreventScroll = shouldPreventScrollOnAutoCompleteSuggestion();
 
+const suggestionContainerBorderWidth = 2;
+const suggestionContainerChromeHeight = 2 * CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTER_INNER_PADDING + (shouldPreventScroll ? suggestionContainerBorderWidth : 0);
+
 /**
  * Gets the correct position for auto complete suggestion container
  */
 function getAutoCompleteSuggestionContainerStyle(itemsHeight: number): ViewStyle {
     'worklet';
 
-    const borderWidth = 2;
-    const height = itemsHeight + 2 * CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTER_INNER_PADDING + (shouldPreventScroll ? borderWidth : 0);
-
     return {
-        height,
+        height: itemsHeight + suggestionContainerChromeHeight,
         minHeight: CONST.AUTO_COMPLETE_SUGGESTER.SUGGESTION_ROW_HEIGHT,
     };
+}
+
+function getAutoCompleteSuggestionContainerHeight(itemsHeight: number): number {
+    return itemsHeight + suggestionContainerChromeHeight;
 }
 
 function getEmojiReactionBubbleTextStyle(isContextMenu = false): TextStyle {
@@ -1413,6 +1417,7 @@ const staticStyleUtils = {
     displayIfTrue,
     getAmountFontSizeAndLineHeight,
     getAmountInputFontSize,
+    getAutoCompleteSuggestionContainerHeight,
     getAutoCompleteSuggestionContainerStyle,
     getAvatarBorderRadius,
     getAvatarBorderStyle,

--- a/tests/unit/pages/HomePage.test.tsx
+++ b/tests/unit/pages/HomePage.test.tsx
@@ -80,8 +80,9 @@ jest.mock('@gorhom/portal', () => {
 });
 
 jest.mock('@components/ReceiptScanDropZone', () => {
-    function MockReceiptScanDropZone() {
-        return null;
+    // The drop zone wraps the page content, so the mock has to keep rendering its children.
+    function MockReceiptScanDropZone({children}: {children: React.ReactNode}) {
+        return children;
     }
     return MockReceiptScanDropZone;
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

`ReceiptScanDropZone` now wraps page content and publishes its drag state via `DragAndDropStateContext`, so the composer's `Suggestions` list closes when a file is dragged over the page. Drag logic and overlay moved into a new `ReceiptScanDropTarget`, unmounted while disabled. `HomePage`, `SearchPageWide` and `SearchPageNarrow` updated to the wrapper API.

`isEnoughSpaceToRenderMenuAboveCursor` now also takes into consideration suggestion list chrome height (borders, paddings) and correct gap between the caret and the list in the native app

### Fixed Issues

$ https://github.com/Expensify/App/issues/100915
$ https://github.com/Expensify/App/issues/100934
PROPOSAL: N/A


<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

T1:

1. Open the web app on Home page.
2. Focus the Concierge prompt box (composer) and type `:smi` so the emoji suggestion list opens.
3. Drag an image file from your file system over the Home page (do not drop yet).
4. Verify that the emoji suggestion list closes as soon as the file is dragged over the page, and the "Scan receipts" drop overlay appears.
5. Drag the file outside of the window to cancel the drag.
6. Verify that the drop overlay disappears and the page returns to its normal state.
7. Repeat steps 2-3, then drop the file on the page.
8. Verify that the receipt scan flow starts with the dropped file.
9. Repeat steps 1-8 with a mention suggestion (type `@` + a few letters) and verify the mention suggestion list also closes while dragging.

10. Go to Spend on a wide layout.
11. Drag an image file over the page and verify the "Scan receipts" drop overlay appears; drop it and verify the receipt scan flow starts.

12. Resize the window to a narrow layout  and open Spend again.
13. Verify the page renders correctly (header, search input, filters bar, list, bottom tab bar) and that scrolling/collapsing the header still works.
14. Drag an image file over the page and verify the drop overlay appears above the bottom tab bar, then drop it and verify the receipt scan flow starts.

T2:

1. Open the native app on iOS/Android on the home page
2. Focus the Concierge prompt box and trigger the suggestion list (type in `@` or `:smi`)
3. Verify that the list is displayed correctly and not cut off by the dynamic island/camera notch when displayed above the box
4. Repeat steps 2.-3. after scrolling down/up a bit to test cases


- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/35f4c5f2-a605-4466-8445-fb1611ebbb88


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/e76fc008-18e0-487d-960a-79ae2598165a


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/24c3a2a8-2ede-4c50-9968-98fb674ec038


https://github.com/user-attachments/assets/13f73781-5168-45e9-8e8a-cfa1df31f1ad


<!-- add screenshots or videos here -->

</details>
