### PR TITLE
Gate the "Create a rule" offer on the expense it would create a rule for

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -700,6 +700,7 @@ function MoneyRequestView({
         }
         updateMoneyRequestBillable({
             transactionID: transaction.transactionID,
+            transaction,
             transactionThreadReport,
             parentReport,
             iouReportOwnerLogin,
@@ -727,6 +728,7 @@ function MoneyRequestView({
         }
         updateMoneyRequestReimbursable({
             transactionID: transaction.transactionID,
+            transaction,
             transactionThreadReport,
             parentReport,
             iouReportOwnerLogin,
@@ -868,6 +870,7 @@ function MoneyRequestView({
 
             updateMoneyRequestTaxRate({
                 transactionID: transaction?.transactionID,
+                transaction,
                 transactionThreadReport,
                 parentReport,
                 iouReportOwnerLogin,
@@ -908,6 +911,7 @@ function MoneyRequestView({
 
             updateMoneyRequestCategory({
                 transactionID,
+                transaction,
                 transactionThreadReport,
                 parentReport,
                 iouReportOwnerLogin,
@@ -949,6 +953,7 @@ function MoneyRequestView({
             const updatedTag = insertTagIntoTransactionTagsString(transactionTag ?? '', '', tagListIndex, policy?.hasMultipleTagLists ?? false);
             updateMoneyRequestTag({
                 transactionID,
+                transaction,
                 transactionThreadReport,
                 parentReport,
                 iouReportOwnerLogin,

--- a/src/libs/actions/IOU/UpdateMoneyRequest.ts
+++ b/src/libs/actions/IOU/UpdateMoneyRequest.ts
@@ -373,6 +373,7 @@ function addMerchantRuleSuggestionRollback(
 /** Updates the billable field of an expense */
 function updateMoneyRequestBillable({
     transactionID,
+    transaction,
     transactionThreadReport,
     parentReport,
     iouReportOwnerLogin,
@@ -392,6 +393,7 @@ function updateMoneyRequestBillable({
     rules,
 }: {
     transactionID: string | undefined;
+    transaction?: OnyxEntry<OnyxTypes.Transaction>;
     transactionThreadReport: OnyxEntry<OnyxTypes.Report>;
     parentReport: OnyxEntry<OnyxTypes.Report>;
     iouReportOwnerLogin: string | undefined;
@@ -438,11 +440,20 @@ function updateMoneyRequestBillable({
     });
     addMerchantRuleSuggestionRollback(onyxData, transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.BILLABLE);
     API.write(WRITE_COMMANDS.UPDATE_MONEY_REQUEST_BILLABLE, params, onyxData);
-    trackMerchantRuleSuggestion(transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.BILLABLE, transactionThreadReport.reportID, policy, policyCategories);
+    trackMerchantRuleSuggestion({
+        transactionID,
+        field: CONST.MERCHANT_RULE_SUGGESTION_FIELDS.BILLABLE,
+        reportID: transactionThreadReport.reportID,
+        policy,
+        policyCategories,
+        transaction,
+        parentReport,
+    });
 }
 
 function updateMoneyRequestReimbursable({
     transactionID,
+    transaction,
     transactionThreadReport,
     parentReport,
     iouReportOwnerLogin,
@@ -463,6 +474,7 @@ function updateMoneyRequestReimbursable({
     rules,
 }: {
     transactionID: string | undefined;
+    transaction?: OnyxEntry<OnyxTypes.Transaction>;
     transactionThreadReport: OnyxEntry<OnyxTypes.Report>;
     parentReport: OnyxEntry<OnyxTypes.Report>;
     iouReportOwnerLogin: string | undefined;
@@ -511,7 +523,15 @@ function updateMoneyRequestReimbursable({
     });
     addMerchantRuleSuggestionRollback(onyxData, transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.REIMBURSABLE);
     API.write(WRITE_COMMANDS.UPDATE_MONEY_REQUEST_REIMBURSABLE, params, onyxData);
-    trackMerchantRuleSuggestion(transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.REIMBURSABLE, transactionThreadReport.reportID, policy, policyCategories);
+    trackMerchantRuleSuggestion({
+        transactionID,
+        field: CONST.MERCHANT_RULE_SUGGESTION_FIELDS.REIMBURSABLE,
+        reportID: transactionThreadReport.reportID,
+        policy,
+        policyCategories,
+        transaction,
+        parentReport,
+    });
 }
 
 /** Updates the merchant field of an expense */
@@ -869,6 +889,8 @@ type UpdateMoneyRequestTagParams = {
     tag: string;
     /** Which level of a multi-level tag was edited, so the "Create a rule" callout can seed that level alone */
     tagListIndex?: number;
+    /** Whether the edit came from a list of expenses, where the "Create a rule" callout has nowhere to appear */
+    isEditedFromExpenseList?: boolean;
     policy: OnyxEntry<OnyxTypes.Policy>;
     policyTagList: OnyxEntry<OnyxTypes.PolicyTagLists>;
     policyRecentlyUsedTags: OnyxEntry<RecentlyUsedTags>;
@@ -896,6 +918,7 @@ function updateMoneyRequestTag({
     iouReportOwnerLogin,
     tag,
     tagListIndex,
+    isEditedFromExpenseList,
     policy,
     policyTagList,
     policyRecentlyUsedTags,
@@ -951,7 +974,17 @@ function updateMoneyRequestTag({
     }
     addMerchantRuleSuggestionRollback(onyxData, transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.TAG, editedTagLevels);
     API.write(WRITE_COMMANDS.UPDATE_MONEY_REQUEST_TAG, params, onyxData);
-    trackMerchantRuleSuggestion(transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.TAG, transactionThreadReport?.reportID, policy, policyCategories, editedTagLevels);
+    trackMerchantRuleSuggestion({
+        transactionID,
+        field: CONST.MERCHANT_RULE_SUGGESTION_FIELDS.TAG,
+        reportID: transactionThreadReport?.reportID,
+        policy,
+        policyCategories,
+        transaction,
+        parentReport,
+        editedTagLevels,
+        isEditedFromExpenseList,
+    });
 }
 
 /** Updates the created tax amount of an expense */
@@ -1019,6 +1052,7 @@ function updateMoneyRequestTaxAmount({
 
 type UpdateMoneyRequestTaxRateParams = {
     transactionID: string | undefined;
+    transaction?: OnyxEntry<OnyxTypes.Transaction>;
     transactionThreadReport: OnyxEntry<OnyxTypes.Report>;
     parentReport: OnyxEntry<OnyxTypes.Report>;
     iouReportOwnerLogin: string | undefined;
@@ -1043,6 +1077,7 @@ type UpdateMoneyRequestTaxRateParams = {
 /** Updates the created tax rate of an expense */
 function updateMoneyRequestTaxRate({
     transactionID,
+    transaction,
     transactionThreadReport,
     parentReport,
     iouReportOwnerLogin,
@@ -1091,7 +1126,15 @@ function updateMoneyRequestTaxRate({
 
     addMerchantRuleSuggestionRollback(onyxData, transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.TAX);
     API.write(WRITE_COMMANDS.UPDATE_MONEY_REQUEST_TAX_RATE, params, onyxData);
-    trackMerchantRuleSuggestion(transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.TAX, transactionThreadReport?.reportID, policy, policyCategories);
+    trackMerchantRuleSuggestion({
+        transactionID,
+        field: CONST.MERCHANT_RULE_SUGGESTION_FIELDS.TAX,
+        reportID: transactionThreadReport?.reportID,
+        policy,
+        policyCategories,
+        transaction,
+        parentReport,
+    });
 }
 
 type UpdateMoneyRequestDistanceParams = {
@@ -1273,6 +1316,7 @@ function updateMoneyRequestCategory({
     parentReport,
     iouReportOwnerLogin,
     category,
+    isEditedFromExpenseList,
     policy,
     policyTagList,
     policyCategories,
@@ -1295,6 +1339,8 @@ function updateMoneyRequestCategory({
     parentReport: OnyxEntry<OnyxTypes.Report>;
     iouReportOwnerLogin: string | undefined;
     category: string;
+    /** Whether the edit came from a list of expenses, where the "Create a rule" callout has nowhere to appear */
+    isEditedFromExpenseList?: boolean;
     policy: OnyxEntry<OnyxTypes.Policy>;
     policyTagList: OnyxEntry<OnyxTypes.PolicyTagLists>;
     policyCategories: OnyxEntry<OnyxTypes.PolicyCategories>;
@@ -1340,7 +1386,16 @@ function updateMoneyRequestCategory({
     });
     addMerchantRuleSuggestionRollback(onyxData, transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.CATEGORY);
     API.write(WRITE_COMMANDS.UPDATE_MONEY_REQUEST_CATEGORY, params, onyxData);
-    trackMerchantRuleSuggestion(transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.CATEGORY, transactionThreadReport?.reportID, policy, policyCategories);
+    trackMerchantRuleSuggestion({
+        transactionID,
+        field: CONST.MERCHANT_RULE_SUGGESTION_FIELDS.CATEGORY,
+        reportID: transactionThreadReport?.reportID,
+        policy,
+        policyCategories,
+        transaction,
+        parentReport,
+        isEditedFromExpenseList,
+    });
 }
 
 /** Updates the description of an expense */
@@ -1351,6 +1406,7 @@ function updateMoneyRequestDescription({
     parentReport,
     iouReportOwnerLogin,
     comment,
+    isEditedFromExpenseList,
     policy,
     policyTagList,
     policyCategories,
@@ -1372,6 +1428,8 @@ function updateMoneyRequestDescription({
     parentReport: OnyxEntry<OnyxTypes.Report>;
     iouReportOwnerLogin: string | undefined;
     comment: string;
+    /** Whether the edit came from a list of expenses, where the "Create a rule" callout has nowhere to appear */
+    isEditedFromExpenseList?: boolean;
     policy: OnyxEntry<OnyxTypes.Policy>;
     policyTagList: OnyxEntry<OnyxTypes.PolicyTagLists>;
     policyCategories: OnyxEntry<OnyxTypes.PolicyCategories>;
@@ -1432,7 +1490,16 @@ function updateMoneyRequestDescription({
     params.description = parsedComment;
     addMerchantRuleSuggestionRollback(onyxData, transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.DESCRIPTION);
     API.write(WRITE_COMMANDS.UPDATE_MONEY_REQUEST_DESCRIPTION, params, onyxData);
-    trackMerchantRuleSuggestion(transactionID, CONST.MERCHANT_RULE_SUGGESTION_FIELDS.DESCRIPTION, transactionThreadReport?.reportID, policy, policyCategories);
+    trackMerchantRuleSuggestion({
+        transactionID,
+        field: CONST.MERCHANT_RULE_SUGGESTION_FIELDS.DESCRIPTION,
+        reportID: transactionThreadReport?.reportID,
+        policy,
+        policyCategories,
+        transaction,
+        parentReport,
+        isEditedFromExpenseList,
+    });
 }
 
 /** Updates the distance rate of an expense */

--- a/src/libs/actions/MerchantRuleSuggestion.ts
+++ b/src/libs/actions/MerchantRuleSuggestion.ts
@@ -1,12 +1,46 @@
 import {arePolicyRulesEnabled, isControlPolicy} from '@libs/PolicyUtils';
+import {isInvoiceReport} from '@libs/ReportUtils';
+import {isDistanceRequest, isMerchantMissing, isPerDiemRequest} from '@libs/TransactionUtils';
 
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {MerchantRuleSuggestion, Policy, PolicyCategories} from '@src/types/onyx';
+import type {MerchantRuleSuggestion, Policy, PolicyCategories, Report, Transaction} from '@src/types/onyx';
 import type {MerchantRuleSuggestionField} from '@src/types/onyx/MerchantRuleSuggestion';
 
 import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 
 import Onyx from 'react-native-onyx';
+
+type TrackMerchantRuleSuggestionParams = {
+    /** The edited expense */
+    transactionID: string | undefined;
+
+    /** The field that was edited */
+    field: MerchantRuleSuggestionField;
+
+    /** The edited expense's transaction thread, where the callout can show */
+    reportID: string | undefined;
+
+    /** The workspace that would own the rule */
+    policy: OnyxEntry<Policy>;
+
+    /** That workspace's categories, needed to tell whether Rules are reachable at all */
+    policyCategories: OnyxEntry<PolicyCategories>;
+
+    /** The edited expense itself, which decides whether a merchant rule could ever match it */
+    transaction: OnyxEntry<Transaction>;
+
+    /** The report holding the expense, which is what says the expense is really on this workspace */
+    parentReport: OnyxEntry<Report>;
+
+    /** Which levels of a multi-level tag were edited */
+    editedTagLevels?: number[];
+
+    /**
+     * Whether the edit was made straight from a list of expenses, rather than from the expense itself. Such an edit
+     * records no offer, because the callout has nowhere to appear at the moment it is made.
+     */
+    isEditedFromExpenseList?: boolean;
+};
 
 /**
  * Records an edit that could become a merchant rule, so the expense can offer to create one.
@@ -19,18 +53,40 @@ import Onyx from 'react-native-onyx';
  * the most recently edited expense offers. Recorded for anyone on the workspace; `useMerchantRuleSuggestion` decides
  * who actually sees the callout.
  */
-function trackMerchantRuleSuggestion(
-    transactionID: string | undefined,
-    field: MerchantRuleSuggestionField,
-    reportID: string | undefined,
-    policy: OnyxEntry<Policy>,
-    policyCategories: OnyxEntry<PolicyCategories>,
-    editedTagLevels?: number[],
-) {
+function trackMerchantRuleSuggestion({
+    transactionID,
+    field,
+    reportID,
+    policy,
+    policyCategories,
+    transaction,
+    parentReport,
+    editedTagLevels,
+    isEditedFromExpenseList = false,
+}: TrackMerchantRuleSuggestionParams) {
     // Skip workspaces that could not hold a merchant rule, otherwise an edit made with Rules off would surface the
     // moment somebody turned Rules on. Control only, matching the rule page the callout leads to, so an edit on a
     // Collect workspace does not pay for a write that could never be shown.
     if (!transactionID || !reportID || !isControlPolicy(policy) || !arePolicyRulesEnabled(policy, policyCategories)) {
+        return;
+    }
+
+    // An offer nothing can show is an offer nobody asked for. Editing from a list of expenses leaves no expense detail
+    // on screen, so the record would sit there unseen and fire on whatever expense the user opened next.
+    if (isEditedFromExpenseList) {
+        return;
+    }
+
+    // The policy handed in is the one whose fields the editor offered, which is not always the one that owns the
+    // expense. An expense held in a self DM borrows the workspace it would move to, so its edits must not be recorded
+    // against a workspace it has not reached. Invoices are excluded outright, since merchant rules govern expenses.
+    if (parentReport?.policyID !== policy?.id || isInvoiceReport(parentReport)) {
+        return;
+    }
+
+    // A rule matches on merchant, so an expense that has none, or whose merchant is not the user's to set, can never
+    // be matched by the rule this offer would create. Distance and per diem expenses derive their merchant.
+    if (isMerchantMissing(transaction) || isDistanceRequest(transaction) || isPerDiemRequest(transaction)) {
         return;
     }
 

--- a/src/libs/actions/TransactionInlineEdit.ts
+++ b/src/libs/actions/TransactionInlineEdit.ts
@@ -298,6 +298,7 @@ function editTransactionDescriptionInline(params: TransactionInlineEditParams, n
         ...iouParams,
         comment: newDescription,
         hash: params.hash,
+        isEditedFromExpenseList: true,
     });
 }
 
@@ -308,6 +309,7 @@ function editTransactionCategoryInline(params: TransactionInlineEditParams, newC
         ...iouParams,
         category: newCategory,
         hash: params.hash,
+        isEditedFromExpenseList: true,
     });
 }
 
@@ -357,6 +359,7 @@ function editTransactionTagInline(params: TransactionInlineEditParams, newTag: s
         policyRecentlyUsedTags: iouParams.policyRecentlyUsedTags,
         hash: params.hash,
         isOffline: params.isOffline,
+        isEditedFromExpenseList: true,
     });
 }
 

--- a/src/pages/iou/request/step/DynamicIOURequestStepCategory.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepCategory.tsx
@@ -190,6 +190,7 @@ function DynamicIOURequestStepCategory({
             if (isEditing && report) {
                 updateMoneyRequestCategory({
                     transactionID: transaction.transactionID,
+                    transaction,
                     transactionThreadReport: report,
                     parentReport,
                     iouReportOwnerLogin,

--- a/src/pages/iou/request/step/DynamicIOURequestStepCategoryCreate.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepCategoryCreate.tsx
@@ -163,6 +163,7 @@ function DynamicIOURequestStepCategoryCreate({
         } else if (isEditing && report) {
             updateMoneyRequestCategory({
                 transactionID: transaction?.transactionID ?? transactionID,
+                transaction,
                 transactionThreadReport: report,
                 parentReport,
                 iouReportOwnerLogin,

--- a/src/pages/iou/request/step/DynamicIOURequestStepDescription.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepDescription.tsx
@@ -154,6 +154,7 @@ function DynamicIOURequestStepDescription({
         if (action === CONST.IOU.ACTION.EDIT) {
             updateMoneyRequestDescription({
                 transactionID: transaction?.transactionID,
+                transaction,
                 transactionThreadReport: report,
                 parentReport,
                 iouReportOwnerLogin,

--- a/src/pages/iou/request/step/DynamicIOURequestStepTag.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepTag.tsx
@@ -172,6 +172,7 @@ function DynamicIOURequestStepTag({
         if (isEditing) {
             updateMoneyRequestTag({
                 transactionID,
+                transaction,
                 transactionThreadReport: report,
                 parentReport,
                 iouReportOwnerLogin,

--- a/src/pages/iou/request/step/DynamicIOURequestStepTaxRatePage.tsx
+++ b/src/pages/iou/request/step/DynamicIOURequestStepTaxRatePage.tsx
@@ -118,6 +118,7 @@ function DynamicIOURequestStepTaxRatePage({
             taxCode: '',
             taxValue: '',
             taxAmount: 0,
+            transaction: currentTransaction,
             policy,
             policyTagList: policyTags,
             policyCategories,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/100922
$ https://github.com/Expensify/App/issues/100925
$ https://github.com/Expensify/App/issues/100927
$ https://github.com/Expensify/App/issues/100928
$ https://github.com/Expensify/App/issues/100936
PROPOSAL:


### Tests
#### Precondition (all tests)
- Log in with an Expensifail account that has the `rulesRevamp` beta.
- Create a **Control** workspace and enable **Rules** on it.
- You are an admin (or editor) of that workspace.

---

#### 1. Regression check: the prompt still works (#96354)
1. Go to the workspace chat.
2. Create an expense **with a merchant**.
3. Open the expense.
4. Change the Category.
5. Verify the "Create a rule" prompt **appears** on the expense detail view.
6. Repeat steps 3-5 for Tag, Tax, Description, Billable and Reimbursable, and verify the prompt appears for each.
7. Tap **Create a rule** and verify the merchant rule flow opens pre-seeded with the merchant and every field edited so far.
8. Verify the prompt still does **not** appear after editing Merchant, Amount or Date.


#### 2. Self DM expense submitted to a workspace (#100922)
1. Go to your self DM.
2. Create an expense with a merchant and a category.
3. Open the expense and change the Category.
4. Verify no prompt appears.
5. Go back to the self DM and click **Submit** to a friend.
6. Select the workspace chat > **Create expense**.
7. Open the expense.
8. Verify the "Create a rule" prompt **does not** appear.

#### 3. Inline edit from a list of expenses (#100925)
1. Go to the workspace chat.
2. Create **two** expenses, each with a merchant and a category.
3. Open the report.
4. Inline edit the Category of one expense from the report list.
5. Open that edited expense.
6. Verify the "Create a rule" prompt **does not** appear.
7. Repeat with an inline Tag edit and an inline Description edit.
8. Repeat steps 4-6 from the **Search** results table.
9. Also verify the single-expense case still works: with a report holding exactly one expense, editing its Category **from the expense itself** still shows the prompt.

#### 4. Category added before a merchant exists (#100927)
1. Go to the workspace chat.
2. Create a scan expense with an invalid receipt.
3. Wait for the scan to fail, so the expense has no merchant.
4. Open the expense.
5. Click Category and add a category.
6. Verify no prompt appears (the expense has no merchant).
7. Click Merchant and add a merchant.
8. Verify the "Create a rule" prompt **does not** appear.

#### 5. Invoices (#100928)
1. Enable **Invoices** on the Control workspace.
2. Open FAB > **Send invoice**.
3. Send an invoice with a merchant and a category to any user.
4. Open the invoice.
5. Click Category and change it.
6. Verify the "Create a rule" prompt **does not** appear.

#### 6. Distance and per diem expenses (#100936)
1. Go to the workspace chat.
2. Create a **distance** expense.
3. Open it, click Category and change it.
4. Verify the "Create a rule" prompt **does not** appear.
5. Repeat with a **per diem** expense (Per diem must be enabled on the workspace).

- [x] Verify that no errors appear in the JS console

### Offline tests
- Same as tests

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>



https://github.com/user-attachments/assets/d1c774a9-b121-4c5d-aa26-9c6a725cd1d4

