### PR TITLE
Remove unsafe assertions from SearchRouter parser substitutions

### DIFF
--- a/src/components/Search/SearchRouter/SearchRouterUtils.ts
+++ b/src/components/Search/SearchRouter/SearchRouterUtils.ts
@@ -2,8 +2,6 @@ import type {SearchQueryItem} from '@components/Search/SearchList/ListItem/Searc
 
 import {getPolicyNameWithFallback, sanitizeSearchValue} from '@libs/SearchQueryUtils';
 
-import type {ReportsSplitNavigatorParamList} from '@navigation/types';
-
 import CONST from '@src/CONST';
 import SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -50,8 +48,9 @@ function getContextualReportData(state: NavigationState | undefined): Contextual
     }
 
     if (maybeReportRoute?.name === SCREENS.REPORT || maybeReportRoute?.name === SCREENS.RIGHT_MODAL.EXPENSE_REPORT) {
-        // We're guaranteed that the type of params is of SCREENS.REPORT
-        return {contextualReportID: (maybeReportRoute?.params as ReportsSplitNavigatorParamList[typeof SCREENS.REPORT]).reportID, isSearchRouterScreen};
+        const params = maybeReportRoute.params;
+        const reportID = params && 'reportID' in params ? params.reportID : undefined;
+        return {contextualReportID: typeof reportID === 'string' ? reportID : undefined, isSearchRouterScreen};
     }
     return {contextualReportID: undefined, isSearchRouterScreen};
 }

--- a/src/components/Search/SearchRouter/buildSubstitutionsMap.ts
+++ b/src/components/Search/SearchRouter/buildSubstitutionsMap.ts
@@ -1,5 +1,4 @@
 import type {LocaleContextProps, LocalizedTranslate} from '@components/LocaleContextProvider';
-import type {SearchAutocompleteQueryRange} from '@components/Search/types';
 
 import {parse} from '@libs/SearchParser/autocompleteParser';
 import {getFilterDisplayValue} from '@libs/SearchQueryUtils';
@@ -45,7 +44,7 @@ function buildSubstitutionsMap(
     reportAttributes: ReportAttributesDerivedValue['reports'] | undefined,
     bankAccountList?: BankAccountList,
 ): SubstitutionMap {
-    const parsedQuery = parse(query) as {ranges: SearchAutocompleteQueryRange[]};
+    const parsedQuery = parse(query);
 
     const searchAutocompleteQueryRanges = parsedQuery.ranges;
     if (searchAutocompleteQueryRanges.length === 0) {
@@ -54,7 +53,7 @@ function buildSubstitutionsMap(
 
     const substitutionKeyOccurrences = new Map<string, number>();
 
-    const substitutionsMap = searchAutocompleteQueryRanges.reduce((map, range) => {
+    const substitutionsMap = searchAutocompleteQueryRanges.reduce<SubstitutionMap>((map, range) => {
         const {key: filterKey, value: filterValue} = range;
 
         if (filterKey === CONST.SEARCH.SYNTAX_FILTER_KEYS.TAX_RATE) {
@@ -116,7 +115,7 @@ function buildSubstitutionsMap(
         }
 
         return map;
-    }, {} as SubstitutionMap);
+    }, {});
     return substitutionsMap;
 }
 

--- a/src/components/Search/SearchRouter/getAutocompleteSelectionSubstitutionKey.ts
+++ b/src/components/Search/SearchRouter/getAutocompleteSelectionSubstitutionKey.ts
@@ -1,9 +1,7 @@
-import type {SearchAutocompleteResult} from '@components/Search/types';
-
 import {parse as parseSearchQuery} from '@libs/SearchParser/autocompleteParser';
 
 function getAutocompleteSelectionSubstitutionKey(newSearchQuery: string, fieldKey: string, fallbackMapKey: string, fallbackSearchQuery: string): string {
-    const parsed = parseSearchQuery(newSearchQuery) as SearchAutocompleteResult;
+    const parsed = parseSearchQuery(newSearchQuery);
     const sameKeyRanges = parsed.ranges?.filter((range) => range.key === fieldKey) ?? [];
     const lastRange = sameKeyRanges.at(-1);
     const rangeValue = lastRange?.value ?? fallbackSearchQuery;

--- a/src/components/Search/SearchRouter/getQueryWithSubstitutions.ts
+++ b/src/components/Search/SearchRouter/getQueryWithSubstitutions.ts
@@ -1,4 +1,4 @@
-import type {SearchAutocompleteQueryRange, SearchFilterKey} from '@components/Search/types';
+import type {SearchAutocompleteParserRange} from '@components/Search/types';
 
 import {parse} from '@libs/SearchParser/autocompleteParser';
 import {sanitizeSearchValue} from '@libs/SearchQueryUtils';
@@ -7,7 +7,7 @@ import CONST from '@src/CONST';
 
 type SubstitutionMap = Record<string, string>;
 
-const getSubstitutionMapKey = (filterKey: SearchFilterKey, value: string) => `${filterKey}:${value}`;
+const getSubstitutionMapKey = (filterKey: SearchAutocompleteParserRange['key'], value: string) => `${filterKey}:${value}`;
 
 const USER_FILTER_KEYS = new Set<string>([
     CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM,
@@ -23,7 +23,7 @@ const USER_FILTER_KEYS = new Set<string>([
  * Key for the Nth occurrence of the same filter+value (e.g. multiple workspaces with the same name).
  * Index 0 uses the base key for backward compatibility; index > 0 uses baseKey:index.
  */
-const getSubstitutionMapKeyWithIndex = (filterKey: SearchFilterKey, value: string, index: number) =>
+const getSubstitutionMapKeyWithIndex = (filterKey: SearchAutocompleteParserRange['key'], value: string, index: number) =>
     index === 0 ? getSubstitutionMapKey(filterKey, value) : `${getSubstitutionMapKey(filterKey, value)}:${index}`;
 
 /**
@@ -41,7 +41,7 @@ const getSubstitutionMapKeyWithIndex = (filterKey: SearchFilterKey, value: strin
  * return: `A from:9876 A`
  */
 function getQueryWithSubstitutions(changedQuery: string, substitutions: SubstitutionMap, currentUserAccountID?: number) {
-    const parsed = parse(changedQuery) as {ranges: SearchAutocompleteQueryRange[]};
+    const parsed = parse(changedQuery);
 
     const searchAutocompleteQueryRanges = parsed.ranges;
 

--- a/src/components/Search/SearchRouter/getUpdatedSubstitutionsMap.ts
+++ b/src/components/Search/SearchRouter/getUpdatedSubstitutionsMap.ts
@@ -1,5 +1,3 @@
-import type {SearchAutocompleteQueryRange} from '@components/Search/types';
-
 import {parse} from '@libs/SearchParser/autocompleteParser';
 
 import type {SubstitutionMap} from './getQueryWithSubstitutions';
@@ -20,7 +18,7 @@ import {getSubstitutionMapKeyWithIndex} from './getQueryWithSubstitutions';
  * return: {}
  */
 function getUpdatedSubstitutionsMap(query: string, substitutions: SubstitutionMap): SubstitutionMap {
-    const parsedQuery = parse(query) as {ranges: SearchAutocompleteQueryRange[]};
+    const parsedQuery = parse(query);
 
     const searchAutocompleteQueryRanges = parsedQuery.ranges;
 

--- a/src/components/Search/types.ts
+++ b/src/components/Search/types.ts
@@ -411,6 +411,18 @@ type SearchAutocompleteQueryRange = {
     value: string;
 };
 
+/** Parser keys retain input spelling and can include dynamic report field suffixes. */
+type SearchAutocompleteParserRange = Omit<SearchAutocompleteQueryRange, 'key'> & {
+    key: string;
+    negated: boolean;
+};
+
+type SearchAutocompleteParserResult = {
+    /** Whitespace trimmed from an identifier can leave only its key and negation. */
+    autocomplete: SearchAutocompleteParserRange | Pick<SearchAutocompleteParserRange, 'key' | 'negated'> | null;
+    ranges: SearchAutocompleteParserRange[];
+};
+
 type SearchParams = {
     queryJSON: Readonly<SearchQueryJSON>;
     searchKey: SearchKey | undefined;
@@ -478,6 +490,8 @@ type SearchFilterCommonProps<T> = {
 };
 
 export type {
+    SearchAutocompleteParserRange,
+    SearchAutocompleteParserResult,
     SelectedTransactionInfo,
     SelectedTransactions,
     SearchColumnType,

--- a/src/libs/SearchParser/autocompleteParser.d.ts
+++ b/src/libs/SearchParser/autocompleteParser.d.ts
@@ -1,0 +1,67 @@
+/**
+ * Describes autocompleteParser.peggy and baseRules.peggy after parser-workletization.sh.
+ * Keep this contract aligned with the shipped autocompleteParser.js when regenerating it.
+ */
+import type {SearchAutocompleteParserResult} from '@components/Search/types';
+
+type ParserExpectation =
+    | {type: 'literal'; text: string; ignoreCase: boolean}
+    | {type: 'class'; parts: Array<string | [string, string]>; inverted: boolean; ignoreCase: boolean}
+    | {type: 'any'}
+    | {type: 'end'}
+    | {type: 'other'; description: string};
+
+type ParserPosition = {
+    offset: number;
+    line: number;
+    column: number;
+};
+
+type ParserLocation = {
+    source: unknown;
+    start: ParserPosition;
+    end: ParserPosition;
+};
+
+type ParserOptions = {
+    startRule?: 'query' | '';
+    grammarSource?: unknown;
+    peg$currPos?: number;
+    peg$silentFails?: number;
+    peg$maxFailExpected?: ParserExpectation[];
+    peg$library?: boolean;
+};
+
+type ParserLibraryResult = {
+    peg$result: SearchAutocompleteParserResult;
+    peg$currPos: number;
+    peg$FAILED: Record<string, never>;
+    peg$maxFailExpected: ParserExpectation[];
+    peg$maxFailPos: number;
+};
+
+declare function parse(input: string, options?: ParserOptions & {peg$library?: false}): SearchAutocompleteParserResult;
+declare function parse(input: string, options: ParserOptions & {peg$library: true}): ParserLibraryResult;
+declare function parse(input: string, options?: ParserOptions): SearchAutocompleteParserResult | ParserLibraryResult;
+
+/** Initially contains query. Mutating this list does not register additional parser rules. */
+declare const StartRules: string[];
+
+/** Workletization replaces the Error subclass with an empty constructor that ignores its arguments. */
+declare class SyntaxError {
+    constructor(message?: string, expected?: ParserExpectation[], found?: string | null, location?: ParserLocation);
+
+    message?: string;
+
+    expected?: ParserExpectation[];
+
+    found?: string | null;
+
+    location?: ParserLocation;
+
+    format(sources: Array<{source: unknown; text: string}>): string;
+
+    static buildMessage(expected: ParserExpectation[], found: string | null): string;
+}
+
+export {parse, StartRules, SyntaxError};


### PR DESCRIPTION
### Explanation of Change

Add separate raw generated-parser declaration/types and remove unsafe assertions from the SearchRouter substitution seam. Generated JavaScript is unchanged: the declaration truthfully preserves quoted/comma values, range positions, duplicate occurrence indexes, tax aliases, dynamic and mixed-case keys, explicit substitution precedence, the positive-account `me` fallback, stale-map pruning, and null, full, or key-only autocomplete results.

`SearchRouterUtils` intentionally now returns `undefined` when a Report or ExpenseReport has absent, missing, or non-string `reportID`; valid string IDs and existing overlay traversal are preserved.

Changed files:

- `src/components/Search/SearchRouter/SearchRouterUtils.ts`
- `src/components/Search/SearchRouter/buildSubstitutionsMap.ts`
- `src/components/Search/SearchRouter/getAutocompleteSelectionSubstitutionKey.ts`
- `src/components/Search/SearchRouter/getQueryWithSubstitutions.ts`
- `src/components/Search/SearchRouter/getUpdatedSubstitutionsMap.ts`
- `src/components/Search/types.ts`
- `src/libs/SearchParser/autocompleteParser.d.ts`

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Tests

Focused local checks passed lint, format, spelling, identity, hygiene, five existing Jest suites (39 tests), 171 parser assertions, and 35 production assertions. No new committed tests were added. Local TypeScript remains waived, not passed: the changed-root and no-`skipLibCheck` API probes have no candidate/API-probe diagnostics, but 43 imported-App and 738 imported/dependency diagnostics prevent a complete local program guarantee.

[Fork CI run 34477141288, attempt 1](https://github.com/KJ21-ENG/App/actions/runs/34477141288) passed full typecheck, lint, format, React Compiler, Jest, and final collection for signed head `6e4840e1f3a7265b51759ace5d62a15f5e0adb47` against `4541881ce86bcac1185c2b8088e9fd4beb23be3c`.

Manual QA has not been performed; repeat the staging steps below.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Not performed and not applicable to this exact diff: it changes no offline behavior, network request, or offline fallback.

### QA Steps

**Manual QA required. QA before review.** The defensive reportID guard changes a runtime contextual-search outcome. On staging, use Search to open SearchRouter over both Report and ExpenseReport, then exercise nested routes, an overlay route, and a non-report screen. Enter or select quoted/comma workspace or room names and duplicate values; submit the result and verify the expected report context and substitutions. For missing or non-string report IDs, verify no crash and no contextual report lookup. Check the JS console throughout.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

The issue is linked and repeatable QA is documented, but no manual, offline, console, High Traffic, all-platform, screenshot, or new-unit-test work was performed. Conditional CSS, asset, copy, layout, Storybook, deeplink, markdown-editing, and new-pattern claims are not applicable to this diff and remain unchecked.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

No screenshots or video were produced.

<!-- seatbelt-v2:create:a7f9ba43-eed9-4ab9-a778-d7523291ec2a:s08-a7f9ba43-4541881-draft-create-1 -->