### PR TITLE
Generalize convertToDisplayStringWithoutCurrency for any locale

### DIFF
--- a/src/components/CurrencyListContextProvider/index.tsx
+++ b/src/components/CurrencyListContextProvider/index.tsx
@@ -1,8 +1,8 @@
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 
-import {convertToFrontendAmountAsInteger, sanitizeCurrencyCode} from '@libs/CurrencyUtils';
-import {format, formatToParts} from '@libs/NumberFormatUtils';
+import {convertToDisplayStringWithoutCurrencyForLocale, convertToFrontendAmountAsInteger, sanitizeCurrencyCode} from '@libs/CurrencyUtils';
+import {format} from '@libs/NumberFormatUtils';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -57,25 +57,8 @@ function CurrencyListContextProvider({children}: React.PropsWithChildren) {
     );
 
     const convertToDisplayStringWithoutCurrency = useCallback(
-        (amountInCents: number, currencyCode: string = CONST.CURRENCY.USD): string => {
-            const sanitizedCurrency = sanitizeCurrencyCode(currencyCode);
-            const decimals = getCurrencyDecimals(sanitizedCurrency);
-            const convertedAmount = convertToFrontendAmountAsInteger(amountInCents, decimals);
-            return formatToParts(preferredLocale, convertedAmount, {
-                style: 'currency',
-                currency: sanitizedCurrency,
-
-                // We are forcing the number of decimals because we override the default number of decimals in the backend for some currencies
-                // See: https://github.com/Expensify/PHP-Libs/pull/834
-                minimumFractionDigits: decimals,
-                // For currencies that have decimal places > 2, floor to 2 instead as we don't support more than 2 decimal places.
-                maximumFractionDigits: 2,
-            })
-                .filter((x) => x.type !== 'currency')
-                .filter((x) => x.type !== 'literal' || x.value.trim().length !== 0)
-                .map((x) => x.value)
-                .join('');
-        },
+        (amountInCents: number, currencyCode: string = CONST.CURRENCY.USD): string =>
+            convertToDisplayStringWithoutCurrencyForLocale(preferredLocale, amountInCents, currencyCode, getCurrencyDecimals),
         [getCurrencyDecimals, preferredLocale],
     );
 

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -149,11 +149,11 @@ function convertToDisplayStringEnLocale(amountInCents: number, currency: string 
 }
 
 /**
- * Same as convertToDisplayStringWithoutCurrency but always formats with the `en` locale, with decimals
- * injected. Used alongside convertToDisplayStringEnLocale for stored values (e.g. formula-computed
- * report titles) that must not depend on the viewer's locale or this module's Onyx fallback.
+ * Given an amount in "cents", format it for the passed locale without the currency symbol. Decimals are
+ * injected so this function does not depend on this module's Onyx fallback.
  */
-function convertToDisplayStringWithoutCurrencyEnLocale(
+function convertToDisplayStringWithoutCurrencyForLocale(
+    locale: Locale | undefined,
     amountInCents: number,
     currency: string | undefined,
     getCurrencyDecimalsImpl: CurrencyListActionsContextType['getCurrencyDecimals'],
@@ -161,7 +161,7 @@ function convertToDisplayStringWithoutCurrencyEnLocale(
     const sanitizedCurrency = sanitizeCurrencyCode(currency);
     const decimals = getCurrencyDecimalsImpl(sanitizedCurrency);
     const convertedAmount = convertToFrontendAmountAsInteger(amountInCents, decimals);
-    return formatToParts(CONST.LOCALES.EN, convertedAmount, {
+    return formatToParts(locale, convertedAmount, {
         style: 'currency',
         currency: sanitizedCurrency,
 
@@ -175,6 +175,19 @@ function convertToDisplayStringWithoutCurrencyEnLocale(
         .filter((x) => x.type !== 'literal' || x.value.trim().length !== 0)
         .map((x) => x.value)
         .join('');
+}
+
+/**
+ * Same as convertToDisplayStringWithoutCurrency but always formats with the `en` locale, with decimals
+ * injected. Used alongside convertToDisplayStringEnLocale for stored values (e.g. formula-computed
+ * report titles) that must not depend on the viewer's locale or this module's Onyx fallback.
+ */
+function convertToDisplayStringWithoutCurrencyEnLocale(
+    amountInCents: number,
+    currency: string | undefined,
+    getCurrencyDecimalsImpl: CurrencyListActionsContextType['getCurrencyDecimals'],
+): string {
+    return convertToDisplayStringWithoutCurrencyForLocale(CONST.LOCALES.EN, amountInCents, currency, getCurrencyDecimalsImpl);
 }
 
 /**
@@ -226,5 +239,6 @@ export {
     convertToDisplayStringEnLocale,
     convertAmountToDisplayString,
     convertToDisplayStringWithoutCurrencyEnLocale,
+    convertToDisplayStringWithoutCurrencyForLocale,
     convertToShortDisplayString,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Prep slice 2 of 4 decomposing #99062 (Route Search previews through the shared LHN alternate text pipeline). This slice only generalizes the currency formatting helper, ahead of the actual pipeline change.

No behavior change: every existing caller goes through the unchanged `…EnLocale` wrapper and still formats with `en`.

### Fixed Issues

$ https://github.com/Expensify/App/issues/98958
PROPOSAL:

<!---
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Open a report with expenses and confirm amounts render with the same formatting as before (no currency symbol where that variant is used).
2. Switch the app locale (Settings > Preferences > Language) and confirm formula-computed report titles still format with `en`, unchanged.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — pure refactor of currency string formatting, no network interaction.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/b76f062c-fd22-4633-b713-ec463d89b96a


<!-- add screenshots or videos here -->

</details>