### PR TITLE
perf: defer the split-save API.write behind the destination layout (re-land #98012)

### DIFF
--- a/src/libs/API/__mocks__/writeWhenReady.ts
+++ b/src/libs/API/__mocks__/writeWhenReady.ts
@@ -1,0 +1,28 @@
+import type {ApiRequestCommandParameters, WriteCommand} from '@libs/API/types';
+import type baseWrite from '@libs/API/write';
+import type {WriteReadyBarrier} from '@libs/API/writeWhenReady';
+
+import type {OnyxData} from '@src/types/onyx/Request';
+
+import type {OnyxKey} from 'react-native-onyx';
+
+const write = jest.requireActual<{default: typeof baseWrite}>('@libs/API/write').default;
+
+/**
+ * Runs the write inline instead of holding it until its barrier resolves, so a suite sees the Onyx state the flow
+ * settles on. In a test that barrier usually never resolves - a transition barrier has no transition to wait on, and
+ * the `SAFETY_TIMEOUT_MS` fallback does not fire under the globally enabled fake timers - so deferred optimistic data
+ * would otherwise read back as `undefined`. Stays a `jest.fn`, so suites can still assert the command and barrier.
+ */
+const writeWhenReady = jest.fn(
+    <TCommand extends WriteCommand, TKey extends OnyxKey>(command: TCommand, apiCommandParameters: ApiRequestCommandParameters[TCommand], onyxData?: OnyxData<TKey>) =>
+        write(command, apiCommandParameters, onyxData),
+);
+
+/** Never settles - the `writeWhenReady` above writes inline and ignores it. A `jest.fn` so suites can assert the barrier kind. */
+const createTransitionBarrier = jest.fn((): WriteReadyBarrier => () => new Promise(() => {}));
+
+/** Re-exported from the real module so suites that feed it into timer control still read a number. */
+const {SAFETY_TIMEOUT_MS} = jest.requireActual<{SAFETY_TIMEOUT_MS: number}>('@libs/API/writeWhenReady');
+
+export {writeWhenReady, createTransitionBarrier, SAFETY_TIMEOUT_MS};

--- a/src/libs/actions/IOU/SplitTransactionUpdate.ts
+++ b/src/libs/actions/IOU/SplitTransactionUpdate.ts
@@ -3,8 +3,9 @@ import type {SearchActionsContextValue, SearchStateContextValue} from '@componen
 
 import type {CurrencyListActionsContextType} from '@hooks/useCurrencyList';
 
-import {write as apiWrite} from '@libs/API';
+import {createTransitionBarrier, write as apiWrite, writeWhenReady} from '@libs/API';
 import type {RevertSplitTransactionParams, SplitTransactionParams, SplitTransactionSplitsParam} from '@libs/API/parameters';
+import type {ApiRequestCommandParameters, WriteCommand} from '@libs/API/types';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
@@ -1996,6 +1997,16 @@ function updateSplitTransactions({
         }
     }
 
+    // optimisticData is applied synchronously, re-rendering the destination screen mid-transition.
+    // Defer the write until the transition ends, unless there is none to wait on.
+    const writeSplit = <TCommand extends WriteCommand>(command: TCommand, parameters: ApiRequestCommandParameters[TCommand]) => {
+        if (!isFromSplitExpensesFlow) {
+            apiWrite(command, parameters, onyxData);
+            return;
+        }
+        writeWhenReady(command, parameters, onyxData, createTransitionBarrier('navigation'));
+    };
+
     if (isReverseSplitOperation) {
         const parameters = {
             ...splits.at(0),
@@ -2003,7 +2014,7 @@ function updateSplitTransactions({
             waypoints: splits.at(0)?.waypoints ? JSON.stringify(splits.at(0)?.waypoints) : undefined,
             copiedComments: splits.at(0)?.copiedComments ? JSON.stringify(splits.at(0)?.copiedComments) : undefined,
         } as RevertSplitTransactionParams;
-        apiWrite(WRITE_COMMANDS.REVERT_SPLIT_TRANSACTION, parameters, onyxData);
+        writeSplit(WRITE_COMMANDS.REVERT_SPLIT_TRANSACTION, parameters);
     } else {
         // Prepare splitApiParams for the Transaction_Split API call which requires a specific format for the splits
         // The format is: splits[0][amount], splits[0][category], splits[0][tag] etc.
@@ -2019,11 +2030,7 @@ function updateSplitTransactions({
             transactionID: originalTransactionID,
         };
 
-        if (isCreationOfSplits) {
-            apiWrite(WRITE_COMMANDS.SPLIT_TRANSACTION, splitParameters, onyxData);
-        } else {
-            apiWrite(WRITE_COMMANDS.UPDATE_SPLIT_TRANSACTION, splitParameters, onyxData);
-        }
+        writeSplit(isCreationOfSplits ? WRITE_COMMANDS.SPLIT_TRANSACTION : WRITE_COMMANDS.UPDATE_SPLIT_TRANSACTION, splitParameters);
     }
     TransitionTracker.runAfterTransitions({callback: () => removeDraftSplitTransaction(originalTransactionID), waitForUpcomingTransition: true});
 }
@@ -2062,11 +2069,7 @@ function updateSplitTransactionsFromSplitExpensesFlow(params: UpdateSplitTransac
     const reverseSplitKeepsOriginalInExpenseReport = isReverseSplitOperation && splitExpenses.at(0)?.reportID === expenseReportID;
     const willExpenseReportBecomeEmpty =
         !!expenseReportID && areAllExpenseReportTransactionsSplitChildren && !anyRemainingSplitStaysInExpenseReport && !reverseSplitKeepsOriginalInExpenseReport;
-    const isLastTransactionInReport =
-        willExpenseReportBecomeEmpty ||
-        (isReverseSplitOperation &&
-            !reverseSplitKeepsOriginalInExpenseReport &&
-            Object.values(params.allTransactionsList ?? {}).filter((itemTransaction) => itemTransaction?.reportID === expenseReportID).length === 1);
+    const isLastTransactionInReport = willExpenseReportBecomeEmpty || (isReverseSplitOperation && !reverseSplitKeepsOriginalInExpenseReport && expenseReportTransactions.length === 1);
     const fallbackReportID = params.expenseReport?.chatReportID ?? params.expenseReport?.parentReportID;
 
     if (isLastTransactionInReport && fallbackReportID) {
@@ -2196,3 +2199,4 @@ function updateSplitTransactionsFromSplitExpensesFlow(params: UpdateSplitTransac
 }
 
 export {updateSplitTransactions, updateSplitTransactionsFromSplitExpensesFlow};
+export type {UpdateSplitTransactionsParams};

--- a/tests/actions/IOU/SplitReportTotalsTest.ts
+++ b/tests/actions/IOU/SplitReportTotalsTest.ts
@@ -69,6 +69,7 @@ jest.mock('@libs/actions/IOU/PendingNewTransactions', () => ({
     deletePendingNewTransactionIDs: jest.fn(),
     isOneToTwoTransactionTransition: jest.fn(() => false),
 }));
+jest.mock('@libs/API/writeWhenReady');
 // In production, requestMoney defers its API.write() call until the target screen's
 // content lays out (or a safety timeout fires). In tests there is no target component
 // to flush the deferred write, so we bypass the deferral by executing the callback immediately.

--- a/tests/actions/IOUTest/SplitSelfDMTest.ts
+++ b/tests/actions/IOUTest/SplitSelfDMTest.ts
@@ -56,6 +56,7 @@ jest.mock('@src/libs/actions/Report', () => {
 
 jest.mock('@libs/Navigation/helpers/isSearchTopmostFullScreenRoute', () => jest.fn());
 
+jest.mock('@libs/API/writeWhenReady');
 jest.mock('@src/libs/SearchQueryUtils', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const actual = jest.requireActual('@src/libs/SearchQueryUtils');

--- a/tests/actions/IOUTest/SplitTest.ts
+++ b/tests/actions/IOUTest/SplitTest.ts
@@ -10512,6 +10512,7 @@ const buildSplitFlowParams = async ({withExistingSplitChildren = false, asSelfDM
         getCurrencyDecimals: getCurrencyDecimalsLocal,
         formatPhoneNumber,
         getCurrencySymbol: getCurrencySymbolLocal,
+        rules: undefined,
     };
 
     return {expenseReport, iouAction, params};

--- a/tests/actions/IOUTest/SplitTest.ts
+++ b/tests/actions/IOUTest/SplitTest.ts
@@ -10,7 +10,10 @@ import {createWorkspace, generatePolicyID, setWorkspaceApprovalMode} from '@libs
 import {addComment, notifyNewAction} from '@libs/actions/Report';
 import initSplitExpense from '@libs/actions/SplitExpenses';
 import type * as API from '@libs/API';
+import type {WriteCommand} from '@libs/API/types';
 import {WRITE_COMMANDS} from '@libs/API/types';
+import {createTransitionBarrier, writeWhenReady} from '@libs/API/writeWhenReady';
+import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import {rand64} from '@libs/NumberUtils';
 import {getIOUActionForReportID, getIOUActionForTransactionID, getOriginalMessage, isActionOfType, isAddCommentAction, isDeletedAction, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {buildOptimisticIOUReportAction, getAncestors, getReportOrDraftReport} from '@libs/ReportUtils';
@@ -34,6 +37,7 @@ import {
     updateSplitExpenseAmountField,
     updateSplitExpenseField,
 } from '@userActions/IOU/SplitExpenseItems';
+import type {UpdateSplitTransactionsParams} from '@userActions/IOU/SplitTransactionUpdate';
 import {updateSplitTransactions, updateSplitTransactionsFromSplitExpensesFlow} from '@userActions/IOU/SplitTransactionUpdate';
 
 import CONST from '@src/CONST';
@@ -120,6 +124,7 @@ jest.mock('@src/libs/actions/Report', () => {
 
 jest.mock('@libs/Navigation/helpers/isSearchTopmostFullScreenRoute', () => jest.fn());
 jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => jest.fn());
+jest.mock('@libs/API/writeWhenReady');
 jest.mock('@libs/deferredLayoutWrite', () => ({
     registerDeferredWrite: (_key: string, callback: () => void) => callback(),
     flushDeferredWrite: jest.fn(),
@@ -10394,6 +10399,221 @@ describe('startSplitBill delegateAccountID forwarding', () => {
 
         expect(splitTransactionID).toBeTruthy();
         expect(splitIOUAction?.delegateAccountID).toBe(DELEGATE_ACCOUNT_ID);
+    });
+});
+
+/**
+ * Fixture for the save tests below: an expense report with a single transaction, plus a draft that splits that
+ * transaction into two.
+ *
+ * `withExistingSplitChildren` also seeds those two split transactions in Onyx. That is what makes a one-item
+ * `splitExpenses` mean "collapse an existing split back into one expense" (a reverse split) rather than "split
+ * this expense into one".
+ */
+const buildSplitFlowParams = async ({withExistingSplitChildren = false, asSelfDMThread = false} = {}) => {
+    const expenseReport: Report = {
+        ...createRandomReport(9001, undefined),
+        type: CONST.REPORT.TYPE.EXPENSE,
+    };
+    const transaction: Transaction = {
+        amount: 100,
+        currency: 'USD',
+        transactionID: '9001',
+        reportID: expenseReport.reportID,
+        created: DateUtils.getDBTime(),
+        merchant: 'test',
+    };
+    // `asSelfDMThread` makes the thread a selfDM child of the expense report, which is the only shape that
+    // reaches the navigate-first branch in `updateSplitTransactionsFromSplitExpensesFlow`.
+    const transactionThread: Report = {
+        ...createRandomReport(9002, undefined),
+        type: CONST.REPORT.TYPE.CHAT,
+        ...(asSelfDMThread ? {chatType: CONST.REPORT.CHAT_TYPE.SELF_DM, parentReportID: expenseReport.reportID} : {}),
+    };
+    const iouAction: ReportAction = {
+        ...buildOptimisticIOUReportAction({
+            type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+            amount: transaction.amount,
+            currency: transaction.currency,
+            comment: '',
+            participants: [],
+            transactionID: transaction.transactionID,
+            iouReportID: expenseReport.reportID,
+            getCurrencyDecimals: getCurrencyDecimalsLocal,
+        }),
+        childReportID: transactionThread.reportID,
+    };
+
+    await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${expenseReport.reportID}`, expenseReport);
+    await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${transactionThread.reportID}`, transactionThread);
+    await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${expenseReport.reportID}`, {[iouAction.reportActionID]: iouAction});
+    await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction);
+    if (withExistingSplitChildren) {
+        for (const childTransactionID of ['9003', '9004']) {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${childTransactionID}`, {
+                ...transaction,
+                transactionID: childTransactionID,
+                amount: 50,
+                comment: {originalTransactionID: transaction.transactionID, source: CONST.IOU.TYPE.SPLIT},
+            });
+        }
+    }
+    await waitForBatchedUpdates();
+
+    let allTransactions: OnyxCollection<Transaction>;
+    let allReports: OnyxCollection<Report>;
+    await getOnyxData({
+        key: ONYXKEYS.COLLECTION.TRANSACTION,
+        callback: (value) => {
+            allTransactions = value;
+        },
+    });
+    await getOnyxData({
+        key: ONYXKEYS.COLLECTION.REPORT,
+        callback: (value) => {
+            allReports = value;
+        },
+    });
+
+    const reports = getTransactionAndExpenseReports(asSelfDMThread ? transactionThread.reportID : expenseReport.reportID);
+    const params: UpdateSplitTransactionsParams = {
+        allTransactionsList: allTransactions,
+        allReportsList: allReports,
+        allReportActionsList: undefined,
+        allReportNameValuePairsList: undefined,
+        transactionData: {
+            reportID: expenseReport.reportID,
+            originalTransactionID: transaction.transactionID,
+            splitExpenses: [
+                {transactionID: '9003', amount: 50, description: '', category: '', tags: [''], created: transaction.created, reportID: expenseReport.reportID},
+                {transactionID: '9004', amount: 50, description: '', category: '', tags: [''], created: transaction.created, reportID: expenseReport.reportID},
+            ],
+            splitExpensesTotal: 100,
+        },
+        searchContext: {currentSearchHash: -2},
+        policyCategories: undefined,
+        policy: undefined,
+        policyRecentlyUsedCategories: [],
+        iouReport: expenseReport,
+        firstIOU: iouAction,
+        isASAPSubmitBetaEnabled: false,
+        currentUserPersonalDetails,
+        transactionViolations: {},
+        policyRecentlyUsedCurrencies: [],
+        quickAction: undefined,
+        betas: [CONST.BETAS.ALL],
+        allPolicyTags: undefined,
+        personalDetails: {[RORY_ACCOUNT_ID]: {accountID: RORY_ACCOUNT_ID, login: RORY_EMAIL}},
+        transactionReport: reports.transactionReport,
+        expenseReport: reports.expenseReport,
+        isOffline: false,
+        delegateAccountID: undefined,
+        isTrackIntentUser: false,
+        getCurrencyDecimals: getCurrencyDecimalsLocal,
+        formatPhoneNumber,
+        getCurrencySymbol: getCurrencySymbolLocal,
+    };
+
+    return {expenseReport, iouAction, params};
+};
+
+/**
+ * `@libs/API` re-declares `writeWhenReady` rather than re-exporting it, and its wrapper always forwards the
+ * optional 5th argument. So the arity the mock records is the wrapper's, not the call site's, and asserting
+ * with `toHaveBeenCalledWith` breaks whenever that wrapper's signature grows. Assert the arguments this flow
+ * actually chooses - the command and the barrier - and ignore the rest.
+ */
+function expectDeferredWriteFor(command: WriteCommand) {
+    const deferredCall = jest.mocked(writeWhenReady).mock.calls.find(([calledCommand]) => calledCommand === command);
+    expect(deferredCall).toBeDefined();
+    expect(deferredCall?.at(3)).toEqual(expect.any(Function));
+}
+
+describe('split save deferred write', () => {
+    beforeEach(() => {
+        jest.mocked(isSearchTopmostFullScreenRoute).mockReturnValue(false);
+    });
+
+    it('defers the write behind a navigation barrier when saving from the split-expenses flow', async () => {
+        // Given a split saved through the split-expenses flow
+        const {params} = await buildSplitFlowParams();
+
+        // When the split is saved
+        updateSplitTransactionsFromSplitExpensesFlow(params);
+        await waitForBatchedUpdates();
+
+        // Then the write goes through writeWhenReady gated on a screen transition specifically, so its
+        // optimistic data does not land while the press is still trying to paint, and a stray modal or
+        // keyboard blip cannot release it early
+        expect(createTransitionBarrier).toHaveBeenCalledWith('navigation');
+        expectDeferredWriteFor(WRITE_COMMANDS.SPLIT_TRANSACTION);
+    });
+
+    it('navigates back to the selfDM before deferring the write when Search is not topmost', async () => {
+        const Navigation = jest.requireMock('@src/libs/Navigation/Navigation');
+
+        // Given a split whose transaction thread is a selfDM, the one shape that reaches the navigate-first branch
+        const {params} = await buildSplitFlowParams({asSelfDMThread: true});
+
+        // When it is saved while Search is not the topmost full screen route
+        updateSplitTransactionsFromSplitExpensesFlow(params);
+        await waitForBatchedUpdates();
+
+        // Then the flow navigates back to the selfDM first, so the transaction thread is off screen before the
+        // data changes under it. The write is still deferred, it just happens after that navigation.
+        expect(Navigation.dismissModal).toHaveBeenCalled();
+        expectDeferredWriteFor(WRITE_COMMANDS.SPLIT_TRANSACTION);
+    });
+
+    it('defers the write for the same selfDM split when the Search page is topmost', async () => {
+        const Navigation = jest.requireMock('@src/libs/Navigation/Navigation');
+
+        // Given the identical selfDM fixture, changed only by Search being the topmost full screen route
+        jest.mocked(isSearchTopmostFullScreenRoute).mockReturnValue(true);
+        const {params} = await buildSplitFlowParams({asSelfDMThread: true});
+
+        // When the split is saved
+        updateSplitTransactionsFromSplitExpensesFlow(params);
+        await waitForBatchedUpdates();
+
+        // Then the navigate-first branch is skipped and the write goes through the barrier instead
+        expect(Navigation.dismissModal).not.toHaveBeenCalled();
+        expect(createTransitionBarrier).toHaveBeenCalledWith('navigation');
+        expectDeferredWriteFor(WRITE_COMMANDS.SPLIT_TRANSACTION);
+    });
+
+    it('defers the reverse-split write behind the same barrier', async () => {
+        // Given an existing two-way split being collapsed back to a single expense
+        const {params} = await buildSplitFlowParams({withExistingSplitChildren: true});
+        const remainingSplit = params.transactionData.splitExpenses.at(0);
+
+        // When the reverse split is saved from the split-expenses flow
+        updateSplitTransactions({
+            ...params,
+            transactionData: {...params.transactionData, splitExpenses: remainingSplit ? [remainingSplit] : []},
+            isFromSplitExpensesFlow: true,
+        });
+        await waitForBatchedUpdates();
+
+        // Then REVERT_SPLIT_TRANSACTION goes through the same fork as the creation path
+        expect(createTransitionBarrier).toHaveBeenCalledWith('navigation');
+        expectDeferredWriteFor(WRITE_COMMANDS.REVERT_SPLIT_TRANSACTION);
+    });
+
+    it('writes immediately when the caller is not the split-expenses flow', async () => {
+        // Given a direct updateSplitTransactions call, as useDeleteTransactions makes
+        const {params} = await buildSplitFlowParams();
+        const writeSpy = jest.spyOn(APIlib, 'write');
+
+        // When it runs outside the split-expenses flow
+        updateSplitTransactions({...params, isFromSplitExpensesFlow: false});
+        await waitForBatchedUpdates();
+
+        // Then the write still happens, it is just not deferred behind a barrier
+        expect(writeSpy).toHaveBeenCalledWith(WRITE_COMMANDS.SPLIT_TRANSACTION, expect.anything(), expect.anything());
+        expect(writeWhenReady).not.toHaveBeenCalled();
+        expect(createTransitionBarrier).not.toHaveBeenCalled();
+        writeSpy.mockRestore();
     });
 });
 

--- a/tests/actions/TransactionTest.ts
+++ b/tests/actions/TransactionTest.ts
@@ -103,6 +103,7 @@ jest.mock('@src/libs/actions/Report', () => {
 });
 jest.mock('@libs/Navigation/helpers/isSearchTopmostFullScreenRoute', () => jest.fn());
 jest.mock('@libs/Navigation/helpers/isReportTopmostSplitNavigator', () => jest.fn());
+jest.mock('@libs/API/writeWhenReady');
 // In production, requestMoney defers its API.write() call until the target screen's
 // content lays out (or a safety timeout fires). In tests there is no target component
 // to flush the deferred write, so we bypass the deferral by executing the callback immediately.


### PR DESCRIPTION
### Explanation of Change

Re-lands #98012 on top of #99815, per @ikevin127's [plan](https://github.com/Expensify/App/issues/97802#issuecomment-5624979939).

#98012 deferred the split-save `API.write` behind a navigation barrier so the destination screen stops re-rendering mid-transition. It was full-reverted (#99814) after deploy blocker #99805. The product change was not the bug: `writeWhenReady()` did not close the sequential queue's read gate during its deferral window, so a READ could overtake the pending write and read back pre-write server state. #99815 fixed that hole in `SequentialQueue`/`writeWhenReady`, so this lands unchanged on a working primitive.

**Diff is byte-for-byte identical to #98012's net change**, with one exception, isolated in its own commit: `UpdateSplitTransactionsParams` gained a required `rules` field while this was reverted, so the restored test object no longer typechecked. Added `rules: undefined`, matching the 20+ existing constructions in that file.

### Fixed Issues

$ https://github.com/Expensify/App/issues/97802
PROPOSAL: https://github.com/Expensify/App/issues/97802#issuecomment-5183413475

### Tests

**1. The #99805 regression this was reverted for — verify it is gone:**
   1. Go to a workspace chat and create an expense
   2. Go to Spend > Expenses
   3. Open the search router, type `group-by:from`, search
   4. Expand the group, select the expense via checkbox
   5. Click dropdown > Split > Save
   6. Verify the split expenses **are** shown in the table, and the original expense does **not** change to Unreported

**2. Original #98012 steps:**
   1. Open the Search (Spend) page and click an expense that is not already split
   2. Click **More -> Split**
   3. Adjust the split amounts (or leave the even split) and press **Save**
   4. Verify you land back on the Search page and the expense now shows its split children
   5. Repeat starting from a report: open a report -> open an expense -> **More -> Split** -> **Save**, and verify you land on the report with the split applied
   6. Repeat for a self-DM tracked expense and verify you land on the self-DM report, with no "Not Found" flash
   7. Reduce an existing split back to a single item and press **Save** (reverse split); verify the original expense is restored and you are not stranded on a "Not Found" page

**Failure scenarios**
   8. With the network throttled to fail, perform a Save; verify the optimistic split is rolled back and the error is surfaced on the transaction rather than left applied
   9. Press **Save** twice in quick succession; verify only one split is created and no duplicate rows appear on the destination
   10. Start a Save and immediately navigate away before the destination finishes laying out; verify the write still executes and the split is not lost

**Automated coverage** (`tests/actions/IOUTest/SplitTest.ts`, `split save deferred write`) — all 5 restored tests pass:
* saving through the split-expenses flow routes the write through `writeWhenReady` with a barrier
* the same barrier-gated path is used when saving from the Search page, confirming the barrier is route agnostic
* the reverse-split write is deferred behind the same barrier
* a direct `updateSplitTransactions` call outside the split-expenses flow is not deferred

Verified locally at this head: `SplitTest.ts` 138/138, `SplitReportTotalsTest.ts` + `SplitSelfDMTest.ts` + `TransactionTest.ts` 48/48, and the primitive's own suites `APIWriteWhenReadyTest.ts` + `SequentialQueueReadGateTest.ts` + `resolveWriteBarrierTest.ts` 64/64. ESLint: zero new violations vs `main` on all changed files (verified by linting the same files at `main` and diffing). cspell clean. `typecheck` passes clean across all tsconfigs.

### Offline tests

1. Turn off your network connection
2. Perform the Save from Search, from a report, and from a self-DM tracked expense as in the Tests section
3. Verify the split still appears optimistically in each case and you land on the expected destination
4. Verify the Search page still highlights the newly created split rows while offline
5. Restore the connection and verify the queued writes are sent and no rows are duplicated

### QA Steps

Same as tests — the #99805 `group-by:from` repro in particular.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


 

https://github.com/user-attachments/assets/fa94d2b2-1d06-415d-a02f-c29755c553fa




</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/c89f70a9-031d-4831-9a15-36b782afb5fb


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/b2f91907-d966-45dd-8bc5-85ed9d5f9f83



</details>

<details>
<summary>iOS: mWeb Safari</summary>
 

https://github.com/user-attachments/assets/740841a1-4e7a-4c9d-9bf3-2cc80861ee11


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1200" height="755" alt="1-split-overview" src="https://github.com/user-attachments/assets/7d0f6e03-11d0-470c-a900-413ff2fa3aea" />
<img width="1200" height="755" alt="2-after-save-splits-shown" src="https://github.com/user-attachments/assets/4a210670-c3b3-4137-a944-16420c2200e6" />
<img width="1200" height="755" alt="3-after-reload-still-split" src="https://github.com/user-attachments/assets/d6f1f132-fced-423d-bd6a-967ed5e9e85e" />
<img width="1440" height="900" alt="4-reverse-split-restored" src="https://github.com/user-attachments/assets/26fd64ae-5a56-42ee-8976-d8a3d7c9c47b" />

https://github.com/user-attachments/assets/526256b4-0612-449e-8dfb-da38b6fe51cc



</details>
