### PR TITLE
[NoQA] Fix typecheck on main

### DIFF
--- a/src/pages/workspace/accounting/netsuite/export/DynamicNetSuiteInvoiceItemPreferenceSelectPage.tsx
+++ b/src/pages/workspace/accounting/netsuite/export/DynamicNetSuiteInvoiceItemPreferenceSelectPage.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/ButtonComposed';
+import Button from '@components/Button';
 import ConnectionLayout from '@components/ConnectionLayout';
 import FixedFooter from '@components/FixedFooter';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
@@ -6,7 +6,6 @@ import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import SelectionList from '@components/SelectionList';
 import SingleSelectListItem from '@components/SelectionList/ListItem/SingleSelectListItem';
 import type {ListItem, SelectionListHandle} from '@components/SelectionList/types';
-import type {SelectorType} from '@components/SelectionScreen';
 
 import useDynamicBackPath from '@hooks/useDynamicBackPath';
 import useLocalize from '@hooks/useLocalize';
@@ -135,8 +134,8 @@ function DynamicNetSuiteInvoiceItemPreferenceSelectPage({policy}: WithPolicyConn
                 <SelectionList
                     ref={selectionListRef}
                     data={options}
-                    onSelectRow={(selection: SelectorType) => {
-                        setDraftPreference((selection as MenuListItem).value);
+                    onSelectRow={(selection: MenuListItem) => {
+                        setDraftPreference(selection.value);
                     }}
                     ListItem={SingleSelectListItem}
                     listFooterContent={invoiceItemFooterContent}


### PR DESCRIPTION
### Explanation of Change

[PR 99239](https://github.com/Expensify/App/pull/99239) was branched before `src/components/ButtonComposed` was renamed to `src/components/Button`, so it merged with an import of `@components/ButtonComposed`. That module no longer exists, and the `typecheck / typecheck` job on `main` fails with:

```
src/pages/workspace/accounting/netsuite/export/DynamicNetSuiteInvoiceItemPreferenceSelectPage.tsx(1,20): error TS2307: Cannot find module '@components/ButtonComposed' or its corresponding type declarations.
```

This PR points the import at `@components/Button`. The composed API is unchanged, so `Button.Text` and the `variant`, `size`, and `isDisabled` props work as before.

The same file also tripped the `@typescript-eslint/no-unsafe-type-assertion` lint rule, because `onSelectRow` annotated its argument as `SelectorType` and then cast it down to `MenuListItem`. `SelectionList` already infers the row type from `data`, so the callback now takes `MenuListItem` directly and the cast is gone.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100977

### Tests

1. Run `npx tsc --noEmit -p .` and verify it completes with no errors.
2. Run `npx eslint src/pages/workspace/accounting/netsuite/export/DynamicNetSuiteInvoiceItemPreferenceSelectPage.tsx` and verify it reports no problems.
3. Open the app and go to Workspace settings > Accounting > NetSuite > Export.
4. Open **Invoice item** and verify the page renders with the two options and a **Save** button in the footer.
5. Verify **Save** is disabled until you pick a different option.
6. Select **Create invoice items** and press **Save**. Verify the app returns to the previous screen.
7. Reopen **Invoice item**, select **Select existing invoice item**, and press **Save**. Verify the page stays open and the invoice item sub-menu appears.
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Turn off the network connection.
2. Go to Workspace settings > Accounting > NetSuite > Export > Invoice item.
3. Select a different option and press **Save**.
4. Verify the row shows the grey offline pending style.
5. Turn the network connection back on and verify the pending style clears.

### QA Steps

1. Log in as a workspace admin with a connected NetSuite workspace.
2. Go to Workspace settings > Accounting > NetSuite > Export.
3. Open **Invoice item** and verify the page renders with the two options and a **Save** button in the footer.
4. Verify **Save** is disabled until you pick a different option.
5. Select **Create invoice items** and press **Save**. Verify the app returns to the previous screen and the new value shows on the Export page.
6. Reopen **Invoice item**, select **Select existing invoice item**, and press **Save**. Verify the page stays open and the invoice item sub-menu appears.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: Native</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not yet tested — needs manual QA.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not yet tested — needs manual QA.

</details>
