### PR TITLE
Remove unsafe assertions across payments, cards, profiles, receipts, and video

### DIFF
--- a/src/components/SettlementButton/index.tsx
+++ b/src/components/SettlementButton/index.tsx
@@ -23,7 +23,7 @@ import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useVerifyAccountAndResume from '@hooks/useVerifyAccountAndResume';
 
-import {createWorkspace, generateDefaultWorkspaceName, isCurrencySupportedForDirectReimbursement, isCurrencySupportedForGlobalReimbursement} from '@libs/actions/Policy/Policy';
+import {createWorkspace, generateDefaultWorkspaceName, isCurrencySupportedForDirectReimbursement} from '@libs/actions/Policy/Policy';
 import {navigateToBankAccountRoute} from '@libs/actions/ReimbursementAccount';
 import {getLastPolicyBankAccountID, getLastPolicyPaymentMethod} from '@libs/actions/Search';
 import {isBankAccountPartiallySetup} from '@libs/BankAccountUtils';
@@ -49,11 +49,9 @@ import {navigateToConciergeChat} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {AccountData, BankAccount, LastPaymentMethodType, Policy} from '@src/types/onyx';
+import type {Policy} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
-
-import type {TupleToUnion} from 'type-fest';
 
 import {hasSeenTourSelector} from '@selectors/Onboarding';
 import truncate from 'lodash/truncate';
@@ -63,8 +61,6 @@ import {View} from 'react-native';
 import type SettlementButtonProps from './types';
 
 type TriggerKYCFlow = (params: ContinueActionParams) => void;
-
-type CurrencyType = TupleToUnion<typeof CONST.DIRECT_REIMBURSEMENT_CURRENCIES>;
 
 function SettlementButton({
     addDebitCardRoute = ROUTES.IOU_SEND_ADD_DEBIT_CARD,
@@ -119,7 +115,7 @@ function SettlementButton({
     const reportBelongsToWorkspace = policyID ? doesReportBelongToWorkspace(chatReport, policyID, conciergeReportID) : false;
     const policyIDKey = reportBelongsToWorkspace ? policyID : (iouReport?.policyID ?? CONST.POLICY.ID_FAKE);
     const [userWallet] = useOnyx(ONYXKEYS.USER_WALLET);
-    const hasActivatedWallet = ([CONST.WALLET.TIER_NAME.GOLD, CONST.WALLET.TIER_NAME.PLATINUM] as string[]).includes(userWallet?.tierName ?? '');
+    const hasActivatedWallet = userWallet?.tierName === CONST.WALLET.TIER_NAME.GOLD || userWallet?.tierName === CONST.WALLET.TIER_NAME.PLATINUM;
     const paymentMethods = useSettlementButtonPaymentMethods(hasActivatedWallet, translate);
     const [lastPaymentMethods] = useOnyx(ONYXKEYS.NVP_LAST_PAYMENT_METHOD);
     const [personalPolicyID] = useOnyx(ONYXKEYS.PERSONAL_POLICY_ID);
@@ -127,11 +123,11 @@ function SettlementButton({
     const [userBillingGracePeriodEnds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_USER_BILLING_GRACE_PERIOD_END);
     const [ownerBillingGracePeriodEnd] = useOnyx(ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END);
 
-    const lastPaymentMethod = iouReport?.type
-        ? getLastPolicyPaymentMethod(policyIDKey, personalPolicyID, lastPaymentMethods, iouReport?.type as keyof LastPaymentMethodType, isIOUReport(iouReport))
-        : undefined;
+    const reportType = iouReport?.type;
+    const paymentReportType = reportType === CONST.REPORT.TYPE.IOU || reportType === CONST.REPORT.TYPE.EXPENSE || reportType === CONST.REPORT.TYPE.INVOICE ? reportType : undefined;
+    const lastPaymentMethod = paymentReportType ? getLastPolicyPaymentMethod(policyIDKey, personalPolicyID, lastPaymentMethods, paymentReportType, isIOUReport(iouReport)) : undefined;
 
-    const lastBankAccountID = getLastPolicyBankAccountID(policyIDKey, lastPaymentMethods, iouReport?.type as keyof LastPaymentMethodType);
+    const lastBankAccountID = !reportType || paymentReportType ? getLastPolicyBankAccountID(policyIDKey, lastPaymentMethods, paymentReportType) : undefined;
     const [fundList] = useOnyx(ONYXKEYS.FUND_LIST);
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     const invoiceReceiverPolicyID = chatReport?.invoiceReceiver && 'policyID' in chatReport.invoiceReceiver ? chatReport.invoiceReceiver.policyID : undefined;
@@ -176,7 +172,7 @@ function SettlementButton({
     const isBankAccountLocked = policy?.achAccount?.state === CONST.BANK_ACCOUNT.STATE.LOCKED;
 
     function getLatestPersonalBankAccount() {
-        return formattedPaymentMethods.filter((ba) => (ba.accountData as AccountData)?.type === CONST.BANK_ACCOUNT.TYPE.PERSONAL);
+        return formattedPaymentMethods.filter((ba) => !!ba.accountData && 'type' in ba.accountData && ba.accountData.type === CONST.BANK_ACCOUNT.TYPE.PERSONAL);
     }
 
     // The guards checked after the account-validation gate. Also re-checked when a payment
@@ -262,7 +258,7 @@ function SettlementButton({
             ? businessBankAccountOptionList.map((account) => ({...account, value: CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT}))
             : undefined;
 
-    const canUseWallet = !isExpenseReport && !isInvoiceReport && isCurrencySupportedForGlobalReimbursement(currency as CurrencyType);
+    const canUseWallet = !isExpenseReport && !isInvoiceReport && CONST.DIRECT_REIMBURSEMENT_CURRENCIES.some((value) => value === currency);
     const canUseBusinessBankAccount = isExpenseReport || (isIOUReport(iouReport) && reportID && !hasRequestFromCurrentAccount(iouReport, accountID ?? CONST.DEFAULT_NUMBER_ID));
     const canUsePersonalBankAccount = shouldShowPersonalBankAccountOption || isIOUReport(iouReport);
     const isPersonalOnlyOption = canUsePersonalBankAccount && !canUseBusinessBankAccount;
@@ -342,7 +338,7 @@ function SettlementButton({
         }
 
         if (isInvoiceReport) {
-            const showPayViaExpensifyOptions = isPayInvoiceViaExpensifyBetaEnabled && isCurrencySupportedForGlobalReimbursement(currency as CurrencyType);
+            const showPayViaExpensifyOptions = isPayInvoiceViaExpensifyBetaEnabled && CONST.DIRECT_REIMBURSEMENT_CURRENCIES.some((value) => value === currency);
             const hasActivePolicyAsAdmin = !!activePolicy && isPolicyAdmin(activePolicy) && isPaidGroupPolicy(activePolicy);
 
             const isActivePolicyCurrencySupported = isCurrencySupportedForDirectReimbursement(activePolicy?.outputCurrency ?? '');
@@ -359,9 +355,11 @@ function SettlementButton({
 
                 return formattedPaymentMethods
                     .filter((method) => {
-                        const accountData = method?.accountData as AccountData;
-                        const isPartiallySetup = isBankAccountPartiallySetup(accountData?.state);
-                        return accountData?.type === requiredAccountType && !isPartiallySetup && matchesCurrency(method, currency);
+                        const accountData = method.accountData;
+                        const accountState = accountData && 'state' in accountData ? accountData.state : undefined;
+                        const accountType = accountData && 'type' in accountData ? accountData.type : undefined;
+                        const isPartiallySetup = isBankAccountPartiallySetup(accountState);
+                        return accountType === requiredAccountType && !isPartiallySetup && matchesCurrency(method, currency);
                     })
                     .map((formattedPaymentMethod) => ({
                         text: formattedPaymentMethod?.title ?? '',
@@ -471,11 +469,12 @@ function SettlementButton({
     const selectPaymentType = (iouPaymentType: PaymentMethodType) => {
         if (isInvoiceReport) {
             // if user has intent to pay, we should get the only bank account information to pay the invoice.
-            if (hasIntentToPay && isPayInvoiceViaExpensifyBetaEnabled) {
-                const currentBankInformation = formattedPaymentMethods.at(0) as BankAccount;
+            const currentBankInformation = formattedPaymentMethods.at(0);
+            if (hasIntentToPay && isPayInvoiceViaExpensifyBetaEnabled && currentBankInformation) {
                 onPress({
                     paymentType: CONST.IOU.PAYMENT_TYPE.EXPENSIFY,
-                    payAsBusiness: currentBankInformation.accountData?.type === CONST.BANK_ACCOUNT.TYPE.BUSINESS,
+                    payAsBusiness:
+                        !!currentBankInformation.accountData && 'type' in currentBankInformation.accountData && currentBankInformation.accountData.type === CONST.BANK_ACCOUNT.TYPE.BUSINESS,
                     methodID: currentBankInformation.methodID,
                     paymentMethod: currentBankInformation.accountType,
                 });
@@ -499,11 +498,11 @@ function SettlementButton({
         }
     };
 
-    const selectPaymentMethod = (paymentType: string, triggerKYCFlow: TriggerKYCFlow, paymentMethod?: PaymentMethod, selectedPolicy?: Policy) => {
+    const selectPaymentMethod = (paymentType: PaymentMethodType, triggerKYCFlow: TriggerKYCFlow, paymentMethod?: PaymentMethod, selectedPolicy?: Policy) => {
         const shouldContinueKYCAfterAddingBankAccount = paymentType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY || paymentType === CONST.IOU.PAYMENT_TYPE.VBBA;
 
         triggerKYCFlow({
-            iouPaymentType: paymentType as PaymentMethodType,
+            iouPaymentType: paymentType,
             paymentMethod,
             policy: selectedPolicy,
             personalBankAccountOnSuccessFallbackRoute: shouldContinueKYCAfterAddingBankAccount ? ROUTES.ENABLE_PAYMENTS : undefined,
@@ -515,11 +514,15 @@ function SettlementButton({
         const isPayingWithMethod = paymentType !== CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
 
         if (!!policyFromPaymentMethod || (shouldSelectPaymentMethod && isPayingWithMethod)) {
-            selectPaymentMethod(paymentType, triggerKYCFlow, selectedOption as PaymentMethod, policyFromPaymentMethod ?? policyFromContext);
+            const paymentMethod = Object.values(CONST.PAYMENT_METHODS).find((method) => method === selectedOption);
+            selectPaymentMethod(paymentType, triggerKYCFlow, paymentMethod, policyFromPaymentMethod ?? policyFromContext);
             return;
         }
 
-        selectPaymentType(selectedOption as PaymentMethodType);
+        const selectedPaymentType = Object.values(CONST.IOU.PAYMENT_TYPE).find((type) => type === selectedOption);
+        if (selectedPaymentType) {
+            selectPaymentType(selectedPaymentType);
+        }
     };
 
     const handlePaymentSelection = (selectedOption: string, triggerKYCFlow: TriggerKYCFlow) => {

--- a/src/components/StateSelector.tsx
+++ b/src/components/StateSelector.tsx
@@ -7,6 +7,7 @@ import Navigation from '@libs/Navigation/Navigation';
 
 import CONST from '@src/CONST';
 import {DYNAMIC_ROUTES} from '@src/ROUTES';
+import ObjectUtils from '@src/types/utils/ObjectUtils';
 
 import type {ForwardedRef} from 'react';
 import type {View} from 'react-native';
@@ -25,7 +26,7 @@ type StateSelectorProps = {
     /** Form error text. e.g when no state is selected */
     errorText?: string;
 
-    value?: State | '';
+    value?: string;
 
     /** Callback to call when the input changes */
     onInputChange?: (value: string) => void;
@@ -73,7 +74,8 @@ function StateSelector({errorText, onBlur, value: stateCode, label, onInputChang
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [stateFromUrl, onBlur, isFocused]);
 
-    const title = stateCode && stateCode in COMMON_CONST.STATES ? translate(`allStates.${stateCode}.stateName`) : '';
+    const translationStateCode = ObjectUtils.typedKeys(COMMON_CONST.STATES).find((code) => code === stateCode);
+    const title = translationStateCode ? translate(`allStates.${translationStateCode}.stateName`) : '';
     const descStyle = title.length === 0 ? styles.textNormal : null;
 
     return (

--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -18,8 +18,8 @@ import {canUseTouchScreen as canUseTouchScreenLib} from '@libs/DeviceCapabilitie
 
 import CONST from '@src/CONST';
 
-import type {MutedChangeEventPayload, PlayingChangeEventPayload, StatusChangeEventPayload, TimeUpdateEventPayload, VideoPlayer} from 'expo-video';
-import type {RefObject} from 'react';
+import type {} from '@fullstory/react-native';
+import type {MutedChangeEventPayload, PlayingChangeEventPayload, StatusChangeEventPayload, VideoPlayer} from 'expo-video';
 
 import {useEvent, useEventListener} from 'expo';
 import {useVideoPlayer, VideoView} from 'expo-video';
@@ -99,10 +99,10 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
     /* eslint-enable no-param-reassign */
 
     // `useEvent` — direct `.playing` read wouldn't re-render when play state changes.
-    const {isPlaying} = useEvent(videoPlayerRef.current, 'playingChange', {isPlaying: videoPlayerRef.current.playing, oldIsPlaying: false} as PlayingChangeEventPayload);
+    const {isPlaying} = useEvent(videoPlayerRef.current, 'playingChange', {isPlaying: videoPlayerRef.current.playing, oldIsPlaying: false});
 
-    const {currentTime} = useEvent(videoPlayerRef.current, 'timeUpdate', {currentTime: 0, bufferedPosition: 0} as TimeUpdateEventPayload);
-    const {status} = useEvent(videoPlayerRef.current, 'statusChange', {status: shouldUseSharedVideoElement ? playerStatus.current : 'loading'} as StatusChangeEventPayload);
+    const {currentTime} = useEvent(videoPlayerRef.current, 'timeUpdate', {currentTime: 0, bufferedPosition: 0, currentLiveTimestamp: null, currentOffsetFromLive: null});
+    const {status} = useEvent(videoPlayerRef.current, 'statusChange', {status: shouldUseSharedVideoElement ? playerStatus.current : 'loading'});
 
     const isLoading = useMemo(() => {
         return status === 'loading';
@@ -145,7 +145,7 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
 
     const videoViewRef = useRef<VideoView | null>(null);
     const videoPlayerElementParentRef = useRef<View | HTMLDivElement | null>(null);
-    const videoPlayerElementRef = useRef<View | HTMLDivElement | null>(null);
+    const videoPlayerElementRef = useRef<View | HTMLVideoElement | null>(null);
     const sharedVideoPlayerParentRef = useRef<View | HTMLDivElement | null>(null);
     const isReadyForDisplayRef = useRef(false);
     const savedCurrentTimeRef = useRef(0);
@@ -350,7 +350,7 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
             return true;
         }
 
-        if (videoViewRef.current?.nativeRef?.current instanceof HTMLVideoElement) {
+        if (typeof HTMLVideoElement !== 'undefined' && videoViewRef.current?.nativeRef?.current instanceof HTMLVideoElement) {
             return Reflect.get(videoViewRef.current.nativeRef.current, 'webkitDisplayingFullscreen') === true;
         }
         return false;
@@ -369,11 +369,11 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
         };
 
         document.addEventListener('fullscreenchange', syncFullScreenState);
-        document.addEventListener('webkitfullscreenchange', syncFullScreenState as EventListener);
+        document.addEventListener('webkitfullscreenchange', syncFullScreenState);
 
         return () => {
             document.removeEventListener('fullscreenchange', syncFullScreenState);
-            document.removeEventListener('webkitfullscreenchange', syncFullScreenState as EventListener);
+            document.removeEventListener('webkitfullscreenchange', syncFullScreenState);
         };
     }, [isActuallyFullScreen, setIsFullScreen]);
 
@@ -504,11 +504,11 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
             videoPlayerRef.current = currentVideoPlayerRef.current;
             videoViewRef.current = currentVideoViewRef.current;
         }
-        if (currentlyPlayingURL === url && newParentRef && 'appendChild' in newParentRef) {
+        if (currentlyPlayingURL === url && newParentRef && 'appendChild' in newParentRef && typeof HTMLVideoElement !== 'undefined' && sharedElement instanceof HTMLVideoElement) {
             if (newParentRef.hasChildNodes()) {
-                newParentRef.firstElementChild?.replaceWith(sharedElement as HTMLDivElement);
+                newParentRef.firstElementChild?.replaceWith(sharedElement);
             } else {
-                newParentRef.appendChild(sharedElement as HTMLDivElement);
+                newParentRef.appendChild(sharedElement);
             }
         }
         // Restore the playback position after moving the video element in the DOM.
@@ -517,10 +517,10 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
             videoPlayerRef.current.currentTime = savedCurrentTimeRef.current;
         }
         return () => {
-            if (!originalParent || !('appendChild' in originalParent)) {
+            if (!originalParent || !('appendChild' in originalParent) || typeof HTMLVideoElement === 'undefined' || !(sharedElement instanceof HTMLVideoElement)) {
                 return;
             }
-            originalParent.appendChild(sharedElement as HTMLDivElement);
+            originalParent.appendChild(sharedElement);
 
             if (!newParentRef || !('childNodes' in newParentRef)) {
                 return;
@@ -545,8 +545,8 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
 
     // ensure that video loads after page refresh on iOS Safari
     useEffect(() => {
-        const videoElement = videoViewRef.current?.nativeRef?.current as HTMLVideoElement;
-        if (!videoElement || hasError || !isSafari() || sharedElement) {
+        const videoElement: unknown = videoViewRef.current?.nativeRef?.current;
+        if (typeof HTMLVideoElement === 'undefined' || !(videoElement instanceof HTMLVideoElement) || hasError || !isSafari() || sharedElement) {
             return;
         }
         videoElement.load();
@@ -588,7 +588,9 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
                                 {shouldUseSharedVideoElement ? (
                                     <>
                                         <View
-                                            ref={sharedVideoPlayerParentRef as RefObject<View | null>}
+                                            ref={(element) => {
+                                                sharedVideoPlayerParentRef.current = element;
+                                            }}
                                             style={[styles.flex1]}
                                         />
                                         {/* We are adding transparent absolute View between appended video component and control buttons to enable
@@ -604,9 +606,11 @@ function BaseVideoPlayer(props: BaseVideoPlayerProps) {
                                             if (!el) {
                                                 return;
                                             }
-                                            const elHTML = el as View | HTMLDivElement;
-                                            if ('childNodes' in elHTML && elHTML.childNodes[0]) {
-                                                videoPlayerElementRef.current = elHTML.childNodes[0] as HTMLDivElement;
+                                            if (typeof HTMLDivElement !== 'undefined' && el instanceof HTMLDivElement) {
+                                                const child = el.childNodes[0];
+                                                if (typeof HTMLVideoElement !== 'undefined' && child instanceof HTMLVideoElement) {
+                                                    videoPlayerElementRef.current = child;
+                                                }
                                             }
                                             videoPlayerElementParentRef.current = el;
                                         }}

--- a/src/components/VideoPlayerContexts/PlaybackContext/index.tsx
+++ b/src/components/VideoPlayerContexts/PlaybackContext/index.tsx
@@ -91,7 +91,7 @@ function PlaybackContextProvider({children}: ChildrenProps) {
             videoPlayerRef: VideoPlayer | null,
             videoViewRef: VideoView | null,
             parent: View | HTMLDivElement | null,
-            child: View | HTMLDivElement | null,
+            child: PlaybackStateContextValues['sharedElement'],
             shouldNotAutoPlay: boolean,
             {shouldUseSharedVideoElement, url, reportID},
         ) => {

--- a/src/components/VideoPlayerContexts/PlaybackContext/types.ts
+++ b/src/components/VideoPlayerContexts/PlaybackContext/types.ts
@@ -56,9 +56,9 @@ type PlaybackStateContextValues = {
     originalParent: View | HTMLDivElement | null;
 
     /**
-     * The shared video element container, if one exists.
+     * Expo renders the web video directly, so this is the element moved between parent containers.
      */
-    sharedElement: View | HTMLDivElement | null;
+    sharedElement: View | HTMLVideoElement | null;
 
     /**
      * Array of currently mounted Video Player instances
@@ -94,7 +94,7 @@ type PlaybackActionsContextValues = {
      * @param playerRef Reference to the VideoPlayer instance.
      * @param viewRef Reference to the VideoView instance.
      * @param parent Parent container for the shared video element.
-     * @param child Child container for the shared video element.
+     * @param child Video element moved between parent containers on web, or a native View.
      * @param isUploading Whether the video is currently uploading.
      * @param videoElementData Metadata describing the video element.
      */
@@ -102,7 +102,7 @@ type PlaybackActionsContextValues = {
         playerRef: VideoPlayer | null,
         viewRef: VideoView | null,
         parent: View | HTMLDivElement | null,
-        child: View | HTMLDivElement | null,
+        child: PlaybackStateContextValues['sharedElement'],
         isUploading: boolean,
         videoElementData: VideoElementData,
     ) => void;

--- a/src/libs/API/parameters/ReplaceReceiptParams.ts
+++ b/src/libs/API/parameters/ReplaceReceiptParams.ts
@@ -1,10 +1,12 @@
+import type {CustomRNImageManipulatorResult} from '@libs/cropOrRotateImage/types';
+
 import type CONST from '@src/CONST';
 
 import type {ValueOf} from 'type-fest';
 
 type ReplaceReceiptParams = {
     transactionID: string;
-    receipt: File;
+    receipt: File | CustomRNImageManipulatorResult;
     receiptState?: ValueOf<typeof CONST.IOU.RECEIPT_STATE>;
     isSameReceipt?: boolean;
 };

--- a/src/libs/CardFeedUtils.ts
+++ b/src/libs/CardFeedUtils.ts
@@ -9,9 +9,10 @@ import CONST from '@src/CONST';
 import type {CombinedCardFeeds} from '@src/hooks/useCardFeeds';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Card, CardFeeds, CardList, Domain, ExpensifyCardSettings, PersonalDetailsList, Policy, WorkspaceCardsList} from '@src/types/onyx';
-import type {CardFeedData, CardFeedsStatus, CardFeedsStatusByDomainID, CardFeedWithDomainID, CardFeedWithNumber, CombinedCardFeed} from '@src/types/onyx/CardFeeds';
+import type {CardFeedData, CardFeedsStatus, CardFeedsStatusByDomainID, CardFeedWithNumber, CombinedCardFeed} from '@src/types/onyx/CardFeeds';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import ObjectUtils from '@src/types/utils/ObjectUtils';
 
 import type {OnyxCollection} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
@@ -127,8 +128,9 @@ function buildCardsData(
     const allWorkspaceCards: CardFilterItem[] = Object.values(workspaceCardFeeds)
         .filter((cardFeed) => !isEmptyObject(cardFeed))
         .flatMap((cardFeed) => {
-            return Object.values(cardFeed as CardList)
-                .filter((card) => card && isCard(card) && !userCardList?.[card.cardID] && filterCondition(card))
+            return Object.values(cardFeed ?? {})
+                .filter(isCard)
+                .filter((card) => !userCardList?.[card.cardID] && filterCondition(card))
                 .map((card) => createCardFilterItem(card, personalDetailsList, selectedCards, illustrations, companyCardIcons, customCardNames));
         });
 
@@ -156,7 +158,7 @@ function getExpensifyCardFeedsForDisplay(
     domains?: OnyxCollection<Domain>,
     expensifyCardSettings?: OnyxCollection<ExpensifyCardSettings>,
 ): CardFeedsForDisplay {
-    const result = {} as CardFeedsForDisplay;
+    const result: CardFeedsForDisplay = {};
 
     for (const card of Object.values(allCards ?? {})) {
         if (card.bank !== CONST.EXPENSIFY_CARD.BANK || !card.fundID) {
@@ -235,7 +237,7 @@ function getCardFeedsForDisplay(
     domains?: OnyxCollection<Domain>,
     expensifyCardSettings?: OnyxCollection<ExpensifyCardSettings>,
 ): CardFeedsForDisplay {
-    const cardFeedsForDisplay = {} as CardFeedsForDisplay;
+    const cardFeedsForDisplay: CardFeedsForDisplay = {};
 
     for (const [domainKey, cardFeeds] of Object.entries(allCardFeeds ?? {})) {
         // sharedNVP_private_domain_member_123456 -> 123456
@@ -244,8 +246,8 @@ function getCardFeedsForDisplay(
             continue;
         }
 
-        for (const [key, feedData] of Object.entries(getOriginalCompanyFeeds(cardFeeds, feedKeysWithCards, Number(fundID)))) {
-            const feed = key as CardFeedWithNumber;
+        for (const [key, feedData] of ObjectUtils.typedEntries(getOriginalCompanyFeeds(cardFeeds, feedKeysWithCards, Number(fundID)))) {
+            const feed = key;
             const id = `${fundID}_${feed}`;
 
             if (cardFeedsForDisplay[id]) {
@@ -285,7 +287,7 @@ function getCardFeedsForDisplayPerPolicy(
     feedKeysWithCards: FeedKeysWithAssignedCards | undefined,
     policies: OnyxCollection<Policy>,
 ): Record<string, CardFeedForDisplay[]> {
-    const cardFeedsForDisplayPerPolicy = {} as Record<string, CardFeedForDisplay[]>;
+    const cardFeedsForDisplayPerPolicy: Record<string, CardFeedForDisplay[]> = {};
 
     for (const [domainKey, cardFeeds] of Object.entries(allCardFeeds ?? {})) {
         // sharedNVP_private_domain_member_123456 -> 123456
@@ -294,11 +296,11 @@ function getCardFeedsForDisplayPerPolicy(
             continue;
         }
 
-        for (const [key, feedData] of Object.entries(getOriginalCompanyFeeds(cardFeeds, feedKeysWithCards, Number(fundID)))) {
+        for (const [key, feedData] of ObjectUtils.typedEntries(getOriginalCompanyFeeds(cardFeeds, feedKeysWithCards, Number(fundID)))) {
             const preferredPolicy = feedData && 'preferredPolicy' in feedData ? (feedData.preferredPolicy ?? '') : '';
             const country = feedData && 'country' in feedData ? (feedData.country ?? '') : '';
             const linkedPolicyIDs = feedData && 'linkedPolicyIDs' in feedData ? feedData.linkedPolicyIDs : undefined;
-            const feed = key as CardFeedWithNumber;
+            const feed = key;
             const id = `${fundID}_${feed}`;
             const feedEntry: CardFeedForDisplay = {
                 id,
@@ -338,16 +340,6 @@ function getCardFeedsForDisplayPerPolicy(
     }
 
     return cardFeedsForDisplayPerPolicy;
-}
-
-/**
- * Narrows a raw company-feed object key (widened to `string` by `Object.entries`) to `CardFeedWithNumber`.
- * This is not a full type guard that validates the key against the union — it only asserts that a non-empty
- * key belongs to `CardFeedWithNumber` (the map is keyed by that union at runtime), and rejects empty keys.
- * Used to avoid an unsafe `as` assertion when iterating the feed map.
- */
-function isCardFeedWithNumber(feedKey: string): feedKey is CardFeedWithNumber {
-    return !!feedKey;
 }
 
 /**
@@ -401,10 +393,8 @@ function getVisibleCompanyCardFeedsForSelector(
             continue;
         }
 
-        for (const [key, feedData] of Object.entries(getOriginalCompanyFeeds(cardFeeds, feedKeysWithCards, numericFundID))) {
-            // `getOriginalCompanyFeeds` is keyed by `CardFeedWithNumber`, but `Object.entries` widens the key to
-            // `string`. Narrow it back with a type guard instead of an unsafe `as` assertion.
-            if (!isCardFeedWithNumber(key)) {
+        for (const [key, feedData] of ObjectUtils.typedEntries(getOriginalCompanyFeeds(cardFeeds, feedKeysWithCards, numericFundID))) {
+            if (!key) {
                 continue;
             }
             const country = feedData && 'country' in feedData ? (feedData.country ?? '') : '';
@@ -461,7 +451,7 @@ function getWorkspaceCardFeedsStatus(allFeeds: OnyxCollection<CardFeeds> | undef
         const domainID = Number(onyxKey.split('_').at(-1));
         acc[domainID] = getCardFeedStatus(feeds);
         return acc;
-    }, {} as CardFeedsStatusByDomainID);
+    }, {});
 }
 
 function getCombinedCardFeedsFromAllFeeds(
@@ -479,8 +469,7 @@ function getCombinedCardFeedsFromAllFeeds(
             return acc;
         }
 
-        for (const feedName of Object.keys(companyCards) as CardFeedWithNumber[]) {
-            const feedSettings = companyCards?.[feedName];
+        for (const [feedName, feedSettings] of ObjectUtils.typedEntries(companyCards)) {
             const oAuthAccountDetails = workspaceFeedsSettings?.oAuthAccountDetails?.[feedName];
             const customFeedName = workspaceFeedsSettings?.companyCardNicknames?.[feedName];
             const status = workspaceFeedsSettings?.cardFeedsStatus?.[feedName];
@@ -526,14 +515,13 @@ function getCombinedCardFeedsFromAllFeeds(
 }
 
 function findMatchingCards(cardFeeds: CombinedCardFeeds, cardLists: OnyxCollection<WorkspaceCardsList>, cardFeed?: CardFeedWithNumber, cardID?: number) {
-    const feedsWithDomainIDs = Object.keys(cardFeeds) as CardFeedWithDomainID[];
+    const feedsWithDomainIDs = ObjectUtils.typedKeys(cardFeeds);
     return Object.values(cardLists ?? {})
         .flatMap((cardList) => Object.values(cardList ?? {}))
         .filter((card) => {
-            const feedKey = card.bank as CardFeedWithNumber;
-            const feedDomainID = card.fundID ?? CONST.DEFAULT_MISSING_ID;
-            const feedWithDomainID = getCardFeedWithDomainID(feedKey, feedDomainID);
-            if (!feedsWithDomainIDs.includes(feedWithDomainID)) {
+            const feedKey = card.bank;
+            const feedWithDomainID = `${card.bank}${CONST.COMPANY_CARD.FEED_KEY_SEPARATOR}${card.fundID ?? CONST.DEFAULT_MISSING_ID}`;
+            if (!feedsWithDomainIDs.some((key) => key === feedWithDomainID)) {
                 return false;
             }
             if (cardFeed && cardFeed !== feedKey) {
@@ -556,8 +544,8 @@ function getCardsUsingCustomExportCount(
 } {
     const perFeedCount: Partial<Record<CardFeedWithNumber, number>> = {};
     let totalCount = 0;
-    for (const card of findMatchingCards(cardFeeds, cardLists)) {
-        const feedKey = card.bank as CardFeedWithNumber;
+    for (const card of findMatchingCards(cardFeeds, cardLists).filter((matchingCard): matchingCard is Card => typeof matchingCard.nameValuePairs === 'object')) {
+        const feedKey = card.bank;
         if (typeof card.nameValuePairs !== 'object') {
             continue;
         }

--- a/src/libs/actions/IOU/Receipt.ts
+++ b/src/libs/actions/IOU/Receipt.ts
@@ -1,6 +1,7 @@
 import * as API from '@libs/API';
 import type {DetachReceiptParams, ReplaceReceiptParams} from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
+import type {CustomRNImageManipulatorResult} from '@libs/cropOrRotateImage/types';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
 import {readFileAsync} from '@libs/fileDownload/FileUtils';
 import {navigateToStartMoneyRequestStep} from '@libs/IOUUtils';
@@ -33,7 +34,7 @@ import {getReceiptError} from './MoneyRequestBuilder';
 
 type ReplaceReceipt = {
     transaction: OnyxEntry<OnyxTypes.Transaction>;
-    file?: File;
+    file?: File | CustomRNImageManipulatorResult;
     source: string;
     state?: ValueOf<typeof CONST.IOU.RECEIPT_STATE>;
     transactionPolicyCategories?: OnyxEntry<OnyxTypes.PolicyCategories>;

--- a/src/pages/media/AttachmentModalScreen/routes/TransactionReceiptModalContent.tsx
+++ b/src/pages/media/AttachmentModalScreen/routes/TransactionReceiptModalContent.tsx
@@ -17,6 +17,7 @@ import {detachReceipt, navigateToStartStepIfScanFileCannotBeRead, replaceReceipt
 import {removeMoneyRequestOdometerImage, setMoneyRequestOdometerImage} from '@libs/actions/OdometerTransactionUtils';
 import {openReport} from '@libs/actions/Report';
 import cropOrRotateImage from '@libs/cropOrRotateImage';
+import type {CustomRNImageManipulatorResult} from '@libs/cropOrRotateImage/types';
 import fetchImage from '@libs/fetchImage';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import getPlatform from '@libs/getPlatform';
@@ -125,7 +126,7 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
     const odometerFile = typeof odometerImage !== 'string' ? odometerImage : undefined;
     const odometerFilename = odometerFile?.name ?? (typeof odometerImage === 'string' ? odometerImage.split('/').pop() : undefined);
     const odometerUriExtension = odometerFilename?.split('.').pop()?.toLowerCase();
-    const odometerFileType = (odometerFile as Partial<File>)?.type ?? (odometerUriExtension ? `image/${odometerUriExtension}` : CONST.IMAGE_FILE_FORMAT.JPEG);
+    const odometerFileType = odometerFile?.type ?? (odometerUriExtension ? `image/${odometerUriExtension}` : CONST.IMAGE_FILE_FORMAT.JPEG);
     const [odometerImageSource, setOdometerImageSource] = useState<string | undefined>(undefined);
 
     useEffect(() => {
@@ -309,7 +310,7 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
     const allowDownload = !isEReceipt;
 
     const applyDurableReceipt = useCallback(
-        (imageUri: string, filename: string, file: File, isSameReceipt?: boolean) => {
+        (imageUri: string, filename: string, file: File | CustomRNImageManipulatorResult, isSameReceipt?: boolean) => {
             if (!transaction?.transactionID) {
                 return Promise.resolve();
             }
@@ -320,7 +321,10 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
                     return imageUri;
                 })
                 .then((durableUri) => {
-                    const durableFile = Object.assign(new File([file], file.name || filename, {type: file.type}), {uri: durableUri, source: durableUri});
+                    const durableFile =
+                        typeof File !== 'undefined' && file instanceof File
+                            ? Object.assign(new File([file], file.name || filename, {type: file.type}), {uri: durableUri, source: durableUri})
+                            : {...file, uri: durableUri, source: durableUri};
                     if (isOdometerImage) {
                         setMoneyRequestOdometerImage(transaction, imageType, durableFile, isDraftTransaction, !isEditingConfirmation);
                     } else if (isDraftTransaction) {
@@ -344,12 +348,12 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
     );
 
     const rotateReceipt = useCallback(() => {
-        if (!transaction?.transactionID || !sourceUri || !isImage) {
+        if (!transaction?.transactionID || typeof sourceUri !== 'string' || !sourceUri || !isImage) {
             return;
         }
 
         setIsRotating(true);
-        cropOrRotateImage(sourceUri as string, [{rotate: -90}], {
+        cropOrRotateImage(sourceUri, [{rotate: -90}], {
             compress: 1,
             name: fileName,
             type: fileType,
@@ -366,7 +370,7 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
                     return Promise.resolve();
                 }
 
-                const file = rotatedImage as File;
+                const file = rotatedImage;
                 const rotatedFilename = file.name ?? receiptFilename;
 
                 return applyDurableReceipt(imageUriResult, rotatedFilename, file, true).then(() => {
@@ -404,14 +408,14 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
     }, []);
 
     const saveCrop = useCallback(() => {
-        if (!transaction?.transactionID || !sourceUri || !isImage || !cropRect || cropRect.width < 1 || cropRect.height < 1) {
+        if (!transaction?.transactionID || typeof sourceUri !== 'string' || !sourceUri || !isImage || !cropRect || cropRect.width < 1 || cropRect.height < 1) {
             exitCropMode();
             return;
         }
 
         setIsCropSaving(true);
         cropOrRotateImage(
-            sourceUri as string,
+            sourceUri,
             [
                 {
                     crop: {
@@ -440,7 +444,7 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
                     return Promise.resolve();
                 }
 
-                const file = croppedImage as File;
+                const file = croppedImage;
                 const croppedFilename = file.name ?? receiptFilename;
 
                 return applyDurableReceipt(imageUriResult, croppedFilename, file).then(() => {
@@ -573,7 +577,22 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
                 )}
                 {isPDF && !isNative && (
                     <Button
-                        onPress={() => setPdfRotation((prev) => ((prev + 270) % 360) as RotationDegrees)}
+                        onPress={() =>
+                            setPdfRotation((prev) => {
+                                switch (prev) {
+                                    case 0:
+                                        return 270;
+                                    case 270:
+                                        return 180;
+                                    case 180:
+                                        return 90;
+                                    case 90:
+                                        return 0;
+                                    default:
+                                        return prev;
+                                }
+                            })
+                        }
                         style={styles.transactionReceiptButton}
                     >
                         <Button.Icon src={expensifyIcons.Rotate} />
@@ -648,13 +667,14 @@ function TransactionReceiptModalContent({navigation, route}: AttachmentModalScre
     ]);
 
     const customAttachmentContent = useMemo(() => {
-        if (!isCropping || (!sourceUri && !source)) {
+        const imageUri = sourceUri || source;
+        if (!isCropping || typeof imageUri !== 'string' || !imageUri) {
             return null;
         }
 
         return (
             <ReceiptCropView
-                imageUri={(sourceUri || source) as string}
+                imageUri={imageUri}
                 onCropChange={handleCropChange}
                 isAuthTokenRequired={sourceUri ? false : isAuthTokenRequired}
             />

--- a/src/pages/settings/Profile/PersonalDetails/PrivatePersonalDetailsPage.tsx
+++ b/src/pages/settings/Profile/PersonalDetails/PrivatePersonalDetailsPage.tsx
@@ -8,7 +8,6 @@ import type {FormInputErrors, FormOnyxValues} from '@components/Form/types';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
-import type {State} from '@components/StateSelector';
 import StateSelector from '@components/StateSelector';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
@@ -32,7 +31,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import INPUT_IDS from '@src/types/form/PersonalDetailsForm';
-import type {Address} from '@src/types/onyx/PrivatePersonalDetails';
+import ObjectUtils from '@src/types/utils/ObjectUtils';
 
 import {useRoute} from '@react-navigation/native';
 import {subYears} from 'date-fns';
@@ -64,14 +63,14 @@ function PrivatePersonalDetailsPage() {
     const legalLastName = privatePersonalDetails?.legalLastName ?? '';
     const phoneNumber = privatePersonalDetails?.phoneNumber ?? '';
     const dob = privatePersonalDetails?.dob ?? '';
-    const address = normalizeCountryCode(getCurrentAddress(privatePersonalDetails)) as Address | undefined;
+    const address = getCurrentAddress(privatePersonalDetails);
     const [street1, street2Fallback] = getStreetLines(address?.street);
     const initialStreet1 = street1 ?? '';
     const initialStreet2 = address?.street2 ?? street2Fallback ?? '';
     const city = address?.city ?? '';
     const state = address?.state ?? '';
     const zip = address?.zip ?? '';
-    const country = address?.country ?? '';
+    const country = normalizeCountryCode(address)?.country ?? '';
 
     const normalizedState = resolveStateCode(state);
 
@@ -79,7 +78,8 @@ function PrivatePersonalDetailsPage() {
     // suggestion's country/state choices survive a back-navigation instead of reverting to geolocation defaults.
     const draftCountry = draftValues?.[INPUT_IDS.COUNTRY] ?? '';
     const draftState = draftValues?.[INPUT_IDS.STATE] ?? '';
-    const [selectedCountry, setSelectedCountry] = useState<Country | ''>(draftCountry || country || ((defaultCountry as Country | undefined) ?? ''));
+    const initialCountry = draftCountry || country || (defaultCountry ?? '');
+    const [selectedCountry, setSelectedCountry] = useState<Country | ''>(ObjectUtils.typedKeys(CONST.ALL_COUNTRIES).find((code) => code === initialCountry) ?? '');
     const [selectedState, setSelectedState] = useState(draftState || normalizedState);
 
     // The draft is what feeds the confirm-validate-code page; clearing it on every unmount wipes the submission
@@ -158,12 +158,16 @@ function PrivatePersonalDetailsPage() {
         }
 
         const zipValue = values[INPUT_IDS.ZIP_POST_CODE] ?? '';
-        const countryRegexDetails = effectiveCountry ? (COMMON_CONST.COUNTRY_ZIP_REGEX_DATA?.[effectiveCountry] as {regex?: RegExp; samples?: string}) : undefined;
-        const countrySpecificZipRegex = countryRegexDetails?.regex;
+        const countryRegexKey = ObjectUtils.typedKeys(COMMON_CONST.COUNTRY_ZIP_REGEX_DATA).find((code) => code === effectiveCountry);
+        const countryRegexDetails = countryRegexKey ? COMMON_CONST.COUNTRY_ZIP_REGEX_DATA[countryRegexKey] : undefined;
+        const countrySpecificZipRegex = countryRegexDetails && 'regex' in countryRegexDetails && countryRegexDetails.regex instanceof RegExp ? countryRegexDetails.regex : undefined;
         if (countrySpecificZipRegex) {
             if (!countrySpecificZipRegex.test(zipValue.trim().toUpperCase())) {
                 if (isRequiredFulfilled(zipValue.trim())) {
-                    errors[INPUT_IDS.ZIP_POST_CODE] = translate('privatePersonalDetails.error.incorrectZipFormat', countryRegexDetails?.samples ?? '');
+                    errors[INPUT_IDS.ZIP_POST_CODE] = translate(
+                        'privatePersonalDetails.error.incorrectZipFormat',
+                        countryRegexDetails && 'samples' in countryRegexDetails && typeof countryRegexDetails.samples === 'string' ? countryRegexDetails.samples : '',
+                    );
                 } else {
                     errors[INPUT_IDS.ZIP_POST_CODE] = translate('common.error.fieldRequired');
                 }
@@ -324,11 +328,18 @@ function PrivatePersonalDetailsPage() {
                                 zipCode: INPUT_IDS.ZIP_POST_CODE,
                                 country: INPUT_IDS.COUNTRY,
                             }}
-                            onValueChange={(value: unknown, key: unknown) => {
+                            onValueChange={(value, key) => {
+                                if (value != null && typeof value !== 'string') {
+                                    return;
+                                }
                                 if (key === INPUT_IDS.COUNTRY) {
-                                    setSelectedCountry((value ?? '') as Country | '');
+                                    const countryValue = value ?? '';
+                                    const countryCodeValue = ObjectUtils.typedKeys(CONST.ALL_COUNTRIES).find((code) => code === countryValue);
+                                    if (countryValue === '' || countryCodeValue) {
+                                        setSelectedCountry(countryCodeValue ?? '');
+                                    }
                                 } else if (key === INPUT_IDS.STATE) {
-                                    setSelectedState((value ?? '') as string);
+                                    setSelectedState(value ?? '');
                                 }
                             }}
                         />
@@ -364,8 +375,13 @@ function PrivatePersonalDetailsPage() {
                             <InputWrapper
                                 InputComponent={StateSelector}
                                 inputID={INPUT_IDS.STATE}
-                                value={selectedState as State}
-                                onValueChange={(value: unknown) => setSelectedState((value ?? '') as string)}
+                                value={selectedState}
+                                onValueChange={(value) => {
+                                    if (value != null && typeof value !== 'string') {
+                                        return;
+                                    }
+                                    setSelectedState(value ?? '');
+                                }}
                                 shouldSaveDraft
                             />
                         </View>
@@ -378,7 +394,12 @@ function PrivatePersonalDetailsPage() {
                                 aria-label={translate('common.stateOrProvince')}
                                 role={CONST.ROLE.PRESENTATION}
                                 value={selectedState}
-                                onValueChange={(value: unknown) => setSelectedState((value ?? '') as string)}
+                                onValueChange={(value) => {
+                                    if (value != null && typeof value !== 'string') {
+                                        return;
+                                    }
+                                    setSelectedState(value ?? '');
+                                }}
                                 shouldSaveDraft
                                 spellCheck={false}
                             />
@@ -402,8 +423,16 @@ function PrivatePersonalDetailsPage() {
                             InputComponent={CountrySelector}
                             inputID={INPUT_IDS.COUNTRY}
                             value={selectedCountry}
-                            onValueChange={(value: unknown) => {
-                                const newCountry = (value ?? '') as Country | '';
+                            onValueChange={(value) => {
+                                if (value != null && typeof value !== 'string') {
+                                    return;
+                                }
+                                const countryValue = value ?? '';
+                                const countryCodeValue = ObjectUtils.typedKeys(CONST.ALL_COUNTRIES).find((code) => code === countryValue);
+                                if (countryValue !== '' && !countryCodeValue) {
+                                    return;
+                                }
+                                const newCountry = countryCodeValue ?? '';
                                 if (newCountry === selectedCountry) {
                                     return;
                                 }

--- a/tests/ui/TransactionReceiptModalContentTest.tsx
+++ b/tests/ui/TransactionReceiptModalContentTest.tsx
@@ -1,0 +1,384 @@
+/** Exercises receipt editing through the modal and the web and native image producers. */
+import {fireEvent, render, screen, waitFor} from '@testing-library/react-native';
+
+import type {ButtonProps} from '@components/ButtonComposed';
+import type ReceiptCropView from '@components/ReceiptCropView';
+
+import useAllTransactions from '@hooks/useAllTransactions';
+import type useOnyx from '@hooks/useOnyx';
+
+import {replaceReceipt, setMoneyRequestReceipt} from '@libs/actions/IOU/Receipt';
+import {setMoneyRequestOdometerImage} from '@libs/actions/OdometerTransactionUtils';
+import type * as CropOrRotateImageModule from '@libs/cropOrRotateImage';
+import type {CropOrRotateImage} from '@libs/cropOrRotateImage/types';
+import fetchImage from '@libs/fetchImage';
+import * as ReceiptPlatform from '@libs/getPlatform';
+import Log from '@libs/Log';
+import ReceiptStorage from '@libs/ReceiptStorage';
+import {logReceiptAdoptFailed} from '@libs/telemetry/ReceiptObservability';
+
+import type AttachmentModalContainerProps from '@pages/media/AttachmentModalScreen/AttachmentModalContainer/types';
+import TransactionReceiptModalContent from '@pages/media/AttachmentModalScreen/routes/TransactionReceiptModalContent';
+import type {AttachmentModalScreenProps} from '@pages/media/AttachmentModalScreen/types';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import type {Report, Transaction} from '@src/types/onyx';
+
+import type {ImageManipulatorContext, ImageRef} from 'expo-image-manipulator';
+import type {ComponentProps} from 'react';
+import type ReactNative from 'react-native';
+
+import {ImageManipulator, SaveFormat} from 'expo-image-manipulator';
+import React from 'react';
+import {Platform} from 'react-native';
+import RNFetchBlob from 'react-native-blob-util';
+import ImageSize from 'react-native-image-size';
+import Onyx from 'react-native-onyx';
+
+import createMock from '../utils/createMock';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+let mockNativeProducer = false;
+
+// Dispatch to the real implementation so neither producer's result is manufactured by the test.
+jest.mock('@libs/cropOrRotateImage', () => {
+    const web = jest.requireActual<typeof CropOrRotateImageModule>('../../src/libs/cropOrRotateImage/index.ts');
+    const native = jest.requireActual<typeof CropOrRotateImageModule>('../../src/libs/cropOrRotateImage/index.native.ts');
+    return {
+        __esModule: true,
+        default: (...args: Parameters<CropOrRotateImage>) => (mockNativeProducer ? native.default : web.default)(...args),
+    };
+});
+
+jest.mock('expo-image-manipulator', () => ({ImageManipulator: {manipulate: jest.fn()}, SaveFormat: {JPEG: 'jpeg', PNG: 'png', WEBP: 'webp'}}));
+jest.mock('react-native-image-size', () => ({__esModule: true, default: {getSize: jest.fn()}}));
+jest.mock('react-native-blob-util', () => ({__esModule: true, default: {fs: {stat: jest.fn()}}}));
+jest.mock('@libs/Log', () => ({__esModule: true, default: {warn: jest.fn(), info: jest.fn(), alert: jest.fn()}}));
+jest.mock('@libs/actions/IOU/Receipt', () => ({
+    detachReceipt: jest.fn(),
+    navigateToStartStepIfScanFileCannotBeRead: jest.fn(),
+    replaceReceipt: jest.fn(),
+    setMoneyRequestReceipt: jest.fn(),
+}));
+jest.mock('@libs/actions/OdometerTransactionUtils', () => ({removeMoneyRequestOdometerImage: jest.fn(), setMoneyRequestOdometerImage: jest.fn()}));
+jest.mock('@libs/actions/Report', () => ({openReport: jest.fn()}));
+jest.mock('@libs/telemetry/ReceiptObservability', () => ({logReceiptAdoptFailed: jest.fn()}));
+jest.mock('@libs/ReceiptStorage', () => ({__esModule: true, default: {adopt: jest.fn(), toLocalUri: jest.fn(), resolve: jest.fn()}}));
+jest.mock('@libs/fetchImage', () => ({__esModule: true, default: jest.fn()}));
+jest.mock('@libs/Navigation/Navigation', () => ({__esModule: true, default: {goBack: jest.fn(), navigate: jest.fn(), dismissModal: jest.fn()}}));
+jest.mock('@libs/ReportActionsUtils', () => ({getReportAction: jest.fn(), isTrackExpenseAction: () => false}));
+// Permissions are fixed here so each case reaches the modal's editing handlers.
+jest.mock('@libs/ReportUtils', () => ({canEditFieldOfMoneyRequest: () => true, isMoneyRequestReport: () => true, isTrackExpenseReport: () => false}));
+jest.mock('@hooks/useAllTransactions', () => ({__esModule: true, default: jest.fn()}));
+jest.mock('@hooks/useOnyx', () => ({__esModule: true, default: jest.requireActual<{useOnyx: typeof useOnyx}>('react-native-onyx').useOnyx}));
+jest.mock('@hooks/usePolicy', () => ({__esModule: true, default: () => undefined}));
+jest.mock('@hooks/useRestartOnOdometerImagesFailure', () => ({__esModule: true, default: jest.fn()}));
+jest.mock('@hooks/useConfirmModal', () => ({__esModule: true, default: () => ({showConfirmModal: jest.fn()})}));
+jest.mock('@hooks/useNetwork', () => ({__esModule: true, default: () => ({isOffline: false})}));
+jest.mock('@hooks/useLocalize', () => ({__esModule: true, default: () => ({translate: (key: string) => key})}));
+jest.mock('@hooks/useLazyAsset', () => ({useMemoizedLazyExpensifyIcons: () => ({})}));
+jest.mock('@hooks/useThemeStyles', () => ({__esModule: true, default: () => ({})}));
+jest.mock('@pages/media/AttachmentModalScreen/routes/hooks/useDownloadAttachment', () => ({__esModule: true, default: () => jest.fn()}));
+
+jest.mock('@components/ButtonComposed', () => {
+    const {Pressable, Text} = jest.requireActual<typeof ReactNative>('react-native');
+    function ReceiptButton({onPress, children, isDisabled, isLoading}: ButtonProps) {
+        return (
+            <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={typeof children === 'string' ? children : undefined}
+                onPress={(event) => {
+                    onPress?.(event);
+                }}
+                disabled={isDisabled}
+                accessibilityState={{disabled: isDisabled, busy: isLoading}}
+            >
+                {children}
+            </Pressable>
+        );
+    }
+    return {__esModule: true, default: Object.assign(ReceiptButton, {Icon: () => null, Text})};
+});
+
+// The container exposes the modal's actual controls without mounting unrelated carousel/navigation UI.
+jest.mock('@pages/media/AttachmentModalScreen/AttachmentModalContainer', () => {
+    const {View, Text} = jest.requireActual<typeof ReactNative>('react-native');
+    function ReceiptContainer({contentProps}: AttachmentModalContainerProps<typeof SCREENS.TRANSACTION_RECEIPT>) {
+        return (
+            <View>
+                {contentProps.footerActionButtons}
+                {contentProps.customAttachmentContent}
+                <Text testID="pdf-rotation">{contentProps.pdfRotation}</Text>
+            </View>
+        );
+    }
+    return {__esModule: true, default: ReceiptContainer};
+});
+
+// Geometry enters at the crop-view callback. The modal and image manipulator still perform the crop.
+jest.mock('@components/ReceiptCropView', () => {
+    const {View, Text, Pressable} = jest.requireActual<typeof ReactNative>('react-native');
+    function CropSelection({imageUri, onCropChange}: ComponentProps<typeof ReceiptCropView>) {
+        return (
+            <View>
+                <Text testID="crop-uri">{imageUri}</Text>
+                <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Select crop"
+                    onPress={() => onCropChange?.({x: -2.7, y: 8.9, width: 15.8, height: 1.2})}
+                />
+            </View>
+        );
+    }
+    return {__esModule: true, default: CropSelection};
+});
+
+type ReceiptScreenProps = AttachmentModalScreenProps<typeof SCREENS.TRANSACTION_RECEIPT>;
+const transactionID = '123';
+const reportID = '456';
+const receiptName = 'receipt.jpeg';
+const originalUri = 'file:///receipts/original.jpeg';
+const manipulatedUri = 'file:///cache/manipulated.jpeg';
+const durableUri = 'file:///receipts/durable.jpeg';
+const webObjectUri = 'blob:manipulated-receipt';
+const receiptObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+const mockCreateReceiptObjectURL = jest.fn<ReturnType<typeof URL.createObjectURL>, Parameters<typeof URL.createObjectURL>>();
+
+const receiptTransaction = createMock<Transaction>({
+    transactionID,
+    reportID,
+    receipt: {source: originalUri, filename: receiptName, type: CONST.IMAGE_FILE_FORMAT.JPEG, state: CONST.IOU.RECEIPT_STATE.SCAN_READY},
+});
+const receiptReport = createMock<Report>({reportID, type: CONST.REPORT.TYPE.EXPENSE});
+const imageRef = createMock<ImageRef>({saveAsync: jest.fn<ReturnType<ImageRef['saveAsync']>, Parameters<ImageRef['saveAsync']>>()});
+const imageContext = createMock<ImageManipulatorContext>({
+    crop: jest.fn<ReturnType<ImageManipulatorContext['crop']>, Parameters<ImageManipulatorContext['crop']>>().mockReturnThis(),
+    rotate: jest.fn<ReturnType<ImageManipulatorContext['rotate']>, Parameters<ImageManipulatorContext['rotate']>>().mockReturnThis(),
+    renderAsync: jest.fn<ReturnType<ImageManipulatorContext['renderAsync']>, Parameters<ImageManipulatorContext['renderAsync']>>(),
+});
+
+async function renderReceipt(transaction = receiptTransaction, params: Partial<ReceiptScreenProps['route']['params']> = {}) {
+    jest.mocked(useAllTransactions).mockReturnValue({[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`]: transaction});
+    await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, receiptReport);
+    await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${transactionID}`, transaction);
+    await Onyx.set(ONYXKEYS.SESSION, {accountID: 1, encryptedAuthToken: 'receipt-test-token'});
+    render(
+        <TransactionReceiptModalContent
+            navigation={createMock<ReceiptScreenProps['navigation']>({goBack: jest.fn()})}
+            route={{key: 'receipt', name: SCREENS.TRANSACTION_RECEIPT, params: {reportID, transactionID, ...params}}}
+        />,
+    );
+    await waitForBatchedUpdatesWithAct();
+}
+
+beforeAll(() => {
+    Object.defineProperty(URL, 'createObjectURL', {configurable: true, writable: true, value: mockCreateReceiptObjectURL});
+});
+
+afterAll(() => {
+    if (receiptObjectURLDescriptor) {
+        Object.defineProperty(URL, 'createObjectURL', receiptObjectURLDescriptor);
+    } else {
+        Reflect.deleteProperty(URL, 'createObjectURL');
+    }
+});
+
+beforeEach(async () => {
+    jest.clearAllMocks();
+    await Onyx.clear();
+    mockNativeProducer = false;
+    jest.replaceProperty(Platform, 'OS', 'web');
+    jest.spyOn(ImageManipulator, 'manipulate').mockReturnValue(imageContext);
+    jest.spyOn(imageContext, 'renderAsync').mockResolvedValue(imageRef);
+    jest.spyOn(imageRef, 'saveAsync').mockResolvedValue({uri: manipulatedUri, width: 640, height: 480, base64: 'discard-this-native-field'});
+    jest.spyOn(RNFetchBlob.fs, 'stat').mockResolvedValue(createMock<Awaited<ReturnType<typeof RNFetchBlob.fs.stat>>>({size: 12}));
+    jest.spyOn(ImageSize, 'getSize').mockResolvedValue({width: 640, height: 480, rotation: 0});
+    jest.mocked(ReceiptStorage.adopt).mockResolvedValue('durable.jpeg');
+    jest.mocked(ReceiptStorage.toLocalUri).mockReturnValue(durableUri);
+    jest.mocked(ReceiptStorage.resolve).mockImplementation((source) => (typeof source === 'string' ? source : undefined));
+    jest.mocked(fetchImage).mockResolvedValue(originalUri);
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(createMock<Response>({blob: () => Promise.resolve(new Blob(['image-bytes'], {type: CONST.IMAGE_FILE_FORMAT.JPEG}))}));
+    mockCreateReceiptObjectURL.mockReturnValue(webObjectUri);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('TransactionReceiptModalContent image editing', () => {
+    it.each(['web', 'android', 'ios'] as const)('rotates a %s receipt and uploads the durable producer representation', async (platform) => {
+        mockNativeProducer = platform !== 'web';
+        jest.replaceProperty(Platform, 'OS', platform);
+        await renderReceipt();
+        fireEvent.press(screen.getByText('common.rotate'));
+        await waitFor(() => expect(replaceReceipt).toHaveBeenCalledTimes(1));
+        const replacement = jest.mocked(replaceReceipt).mock.calls.at(0)?.[0];
+        expect(replacement).toBeDefined();
+        expect(replacement?.transaction).toEqual(receiptTransaction);
+        expect(replacement?.source).toBe(durableUri);
+        expect(replacement?.isSameReceipt).toBe(true);
+        expect(replacement?.state).toBe(CONST.IOU.RECEIPT_STATE.SCAN_READY);
+        expect(replacement?.file).toMatchObject({uri: durableUri, source: durableUri, name: receiptName, type: CONST.IMAGE_FILE_FORMAT.JPEG});
+        expect(jest.spyOn(imageContext, 'rotate')).toHaveBeenCalledWith(-90);
+        expect(jest.spyOn(imageContext, 'crop')).not.toHaveBeenCalled();
+        expect(jest.spyOn(imageRef, 'saveAsync')).toHaveBeenCalledWith({compress: 1, format: SaveFormat.JPEG});
+        expect(ReceiptStorage.adopt).toHaveBeenCalledWith(platform === 'web' ? webObjectUri : manipulatedUri, receiptName);
+        expect(ReceiptStorage.toLocalUri).toHaveBeenCalledWith('durable.jpeg');
+        expect(setMoneyRequestReceipt).not.toHaveBeenCalled();
+        expect(setMoneyRequestOdometerImage).not.toHaveBeenCalled();
+        if (platform === 'web') {
+            expect(replacement?.file).toBeInstanceOf(File);
+            expect(replacement?.file?.size).toBe(new Blob(['image-bytes']).size);
+        } else {
+            expect(replacement?.file).not.toBeInstanceOf(File);
+            expect(replacement?.file).toMatchObject({width: 640, height: 480, size: 12});
+            expect(replacement?.file).not.toHaveProperty('base64');
+            expect(globalThis.fetch).not.toHaveBeenCalled();
+            expect(jest.spyOn(URL, 'createObjectURL')).not.toHaveBeenCalled();
+        }
+    });
+
+    it.each([true, false])('retains the iOS fallback when dimension lookup succeeds: %s', async (hasDimensions) => {
+        mockNativeProducer = true;
+        jest.replaceProperty(Platform, 'OS', 'ios');
+        jest.spyOn(imageContext, 'renderAsync').mockRejectedValueOnce(new Error('image allocation failed'));
+        if (!hasDimensions) {
+            jest.spyOn(ImageSize, 'getSize').mockRejectedValueOnce(new Error('dimensions unavailable'));
+        }
+        await renderReceipt();
+        fireEvent.press(screen.getByText('common.rotate'));
+        await waitFor(() => expect(replaceReceipt).toHaveBeenCalledTimes(1));
+        const replacement = jest.mocked(replaceReceipt).mock.calls.at(0)?.[0];
+        expect(replacement).toBeDefined();
+        expect(replacement?.file).not.toBeInstanceOf(File);
+        expect(replacement?.file).toMatchObject({uri: durableUri, source: durableUri, width: hasDimensions ? 640 : 0, height: hasDimensions ? 480 : 0, size: 12, name: receiptName});
+        expect(ReceiptStorage.adopt).toHaveBeenCalledWith(originalUri, receiptName);
+        expect(jest.spyOn(ImageSize, 'getSize')).toHaveBeenCalledWith(originalUri);
+        expect(jest.spyOn(Log, 'warn')).toHaveBeenCalled();
+    });
+
+    it.each(['web', 'android'] as const)('logs adoption failure and keeps the original %s manipulation URI', async (platform) => {
+        mockNativeProducer = platform === 'android';
+        jest.replaceProperty(Platform, 'OS', platform);
+        const adoptionError = new Error('receipt folder unavailable');
+        jest.mocked(ReceiptStorage.adopt).mockRejectedValueOnce(adoptionError);
+        await renderReceipt();
+        fireEvent.press(screen.getByText('common.rotate'));
+        await waitFor(() => expect(replaceReceipt).toHaveBeenCalledTimes(1));
+        const replacement = jest.mocked(replaceReceipt).mock.calls.at(0)?.[0];
+        expect(replacement).toBeDefined();
+        const fallbackUri = platform === 'web' ? webObjectUri : manipulatedUri;
+        expect(replacement?.source).toBe(fallbackUri);
+        expect(replacement?.file).toMatchObject({uri: fallbackUri, source: fallbackUri});
+        expect(logReceiptAdoptFailed).toHaveBeenCalledWith({error: adoptionError, captureSource: 'replace'});
+        expect(ReceiptStorage.toLocalUri).not.toHaveBeenCalled();
+    });
+
+    it.each(['web', 'android'] as const)('floors and clamps crop geometry for %s without the rotation-only flags', async (platform) => {
+        mockNativeProducer = platform === 'android';
+        jest.replaceProperty(Platform, 'OS', platform);
+        await renderReceipt();
+        fireEvent.press(screen.getByText('receipt.crop'));
+        expect(screen.getByTestId('crop-uri')).toHaveTextContent(originalUri);
+        fireEvent.press(screen.getByRole('button', {name: 'Select crop'}));
+        fireEvent.press(screen.getByText('common.save'));
+        await waitFor(() => expect(replaceReceipt).toHaveBeenCalledTimes(1));
+        const replacement = jest.mocked(replaceReceipt).mock.calls.at(0)?.[0];
+        expect(replacement).toBeDefined();
+        expect(replacement?.file).toMatchObject({uri: durableUri, source: durableUri});
+        expect(replacement).not.toHaveProperty('isSameReceipt');
+        expect(replacement).not.toHaveProperty('state');
+        expect(jest.spyOn(imageContext, 'crop')).toHaveBeenCalledWith({originX: 0, originY: 8, width: 15, height: 1});
+        expect(jest.spyOn(imageContext, 'rotate')).not.toHaveBeenCalled();
+        expect(screen.queryByRole('button', {name: 'Select crop'})).toBeNull();
+    });
+
+    it('writes the draft receipt using its transaction key', async () => {
+        mockNativeProducer = true;
+        jest.replaceProperty(Platform, 'OS', 'android');
+        await renderReceipt(receiptTransaction, {action: CONST.IOU.ACTION.CREATE});
+        fireEvent.press(screen.getByText('common.rotate'));
+        await waitFor(() => expect(setMoneyRequestReceipt).toHaveBeenCalledTimes(1));
+        expect(setMoneyRequestReceipt).toHaveBeenCalledWith(transactionID, durableUri, receiptName, true, CONST.IMAGE_FILE_FORMAT.JPEG);
+        expect(replaceReceipt).not.toHaveBeenCalled();
+        expect(setMoneyRequestOdometerImage).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {imageType: CONST.IOU.ODOMETER_IMAGE_TYPE.START, isDraft: true, isEditingConfirmation: true},
+        {imageType: CONST.IOU.ODOMETER_IMAGE_TYPE.END, isDraft: true, isEditingConfirmation: false},
+        {imageType: CONST.IOU.ODOMETER_IMAGE_TYPE.START, isDraft: false, isEditingConfirmation: false},
+        {imageType: CONST.IOU.ODOMETER_IMAGE_TYPE.END, isDraft: false, isEditingConfirmation: true},
+    ])('routes $imageType odometer edits with draft=$isDraft and confirmation=$isEditingConfirmation', async ({imageType, isDraft, isEditingConfirmation}) => {
+        mockNativeProducer = true;
+        jest.replaceProperty(Platform, 'OS', 'android');
+        const odometerTransaction = createMock<Transaction>({
+            transactionID,
+            reportID,
+            comment: {
+                odometerStartImage: {uri: 'file:///start.jpeg', name: 'start.jpeg', type: CONST.IMAGE_FILE_FORMAT.JPEG},
+                odometerEndImage: {uri: 'file:///end.jpeg', name: 'end.jpeg', type: CONST.IMAGE_FILE_FORMAT.JPEG},
+            },
+        });
+        await renderReceipt(odometerTransaction, {imageType, isEditingConfirmation, ...(isDraft ? {action: CONST.IOU.ACTION.CREATE} : {})});
+        fireEvent.press(screen.getByText('common.rotate'));
+        await waitFor(() => expect(setMoneyRequestOdometerImage).toHaveBeenCalledTimes(1));
+        const odometerUpdate = jest.mocked(setMoneyRequestOdometerImage).mock.calls.at(0);
+        expect(odometerUpdate).toBeDefined();
+        expect(odometerUpdate?.[0]).toEqual(odometerTransaction);
+        expect(odometerUpdate?.[1]).toBe(imageType);
+        expect(odometerUpdate?.[2]).toMatchObject({uri: durableUri, source: durableUri, name: imageType === CONST.IOU.ODOMETER_IMAGE_TYPE.START ? 'start.jpeg' : 'end.jpeg'});
+        expect(odometerUpdate?.[2]).not.toBeInstanceOf(File);
+        expect(odometerUpdate?.[3]).toBe(isDraft);
+        expect(odometerUpdate?.[4]).toBe(!isEditingConfirmation);
+        expect(setMoneyRequestReceipt).not.toHaveBeenCalled();
+        expect(replaceReceipt).not.toHaveBeenCalled();
+    });
+
+    it.each(['rotate', 'crop'] as const)('clears busy state after a rejected %s and permits retry', async (operation) => {
+        mockNativeProducer = true;
+        jest.replaceProperty(Platform, 'OS', 'android');
+        jest.spyOn(imageContext, 'renderAsync').mockRejectedValueOnce(new Error('manipulation failed'));
+        await renderReceipt();
+        if (operation === 'crop') {
+            fireEvent.press(screen.getByText('receipt.crop'));
+            fireEvent.press(screen.getByRole('button', {name: 'Select crop'}));
+        }
+        const buttonText = operation === 'crop' ? 'common.save' : 'common.rotate';
+        fireEvent.press(screen.getByText(buttonText));
+        await waitForBatchedUpdatesWithAct();
+        expect(replaceReceipt).not.toHaveBeenCalled();
+        expect(ReceiptStorage.adopt).not.toHaveBeenCalled();
+        fireEvent.press(screen.getByText(buttonText));
+        await waitFor(() => expect(replaceReceipt).toHaveBeenCalledTimes(1));
+        expect(jest.spyOn(imageContext, 'renderAsync')).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores rotation and exits cropping when authentication supplies no image URI', async () => {
+        jest.mocked(fetchImage).mockResolvedValue('');
+        const remoteReceipt = createMock<Transaction>({...receiptTransaction, receipt: {...receiptTransaction.receipt, source: 'https://example.com/receipt.jpeg'}});
+        await renderReceipt(remoteReceipt);
+        fireEvent.press(screen.getByText('common.rotate'));
+        fireEvent.press(screen.getByText('receipt.crop'));
+        fireEvent.press(screen.getByRole('button', {name: 'Select crop'}));
+        fireEvent.press(screen.getByText('common.save'));
+        await waitForBatchedUpdatesWithAct();
+        expect(jest.spyOn(ImageManipulator, 'manipulate')).not.toHaveBeenCalled();
+        expect(ReceiptStorage.adopt).not.toHaveBeenCalled();
+        expect(replaceReceipt).not.toHaveBeenCalled();
+        expect(screen.queryByRole('button', {name: 'Select crop'})).toBeNull();
+    });
+
+    it('cycles PDF rotation through the four quarter turns', async () => {
+        // Jest resolves getPlatform to its native module independently of Platform.OS.
+        jest.spyOn(ReceiptPlatform, 'default').mockReturnValue(CONST.PLATFORM.WEB);
+        const pdfTransaction = createMock<Transaction>({...receiptTransaction, receipt: {source: 'file:///receipts/original.pdf', filename: 'receipt.pdf', type: 'application/pdf'}});
+        await renderReceipt(pdfTransaction);
+        expect(screen.getByTestId('pdf-rotation')).toHaveTextContent('0');
+        for (const rotation of [270, 180, 90, 0]) {
+            fireEvent.press(screen.getByText('common.rotate'));
+            expect(screen.getByTestId('pdf-rotation')).toHaveTextContent(String(rotation));
+        }
+        expect(jest.spyOn(ImageManipulator, 'manipulate')).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### Explanation of Change

This cleanup removes unsafe type assertions across payment settlement, company card feeds, personal details, receipt editing, and shared video playback by replacing them with typed iteration, explicit discriminant and constructor checks, and accurate shared-element and upload unions. It preserves payment routing, card-feed ordering and filtering, country/state/ZIP behavior, receipt crop/rotate/upload behavior, and shared-video playback and reparenting while adding focused receipt regression coverage. The video contract now reflects Expo’s direct HTMLVideoElement web child while retaining native View support and distinct parent-container types.

Exact changed paths:

- src/components/SettlementButton/index.tsx
- src/components/StateSelector.tsx
- src/components/VideoPlayer/BaseVideoPlayer.tsx
- src/components/VideoPlayerContexts/PlaybackContext/index.tsx
- src/components/VideoPlayerContexts/PlaybackContext/types.ts
- src/libs/API/parameters/ReplaceReceiptParams.ts
- src/libs/CardFeedUtils.ts
- src/libs/actions/IOU/Receipt.ts
- src/pages/media/AttachmentModalScreen/routes/TransactionReceiptModalContent.tsx
- src/pages/settings/Profile/PersonalDetails/PrivatePersonalDetailsPage.tsx
- tests/ui/TransactionReceiptModalContentTest.tsx

### Fixed Issues

$ https://github.com/Expensify/App/issues/94739
PROPOSAL: https://github.com/Expensify/App/issues/94739#issuecomment-4882049995

### Tests

Focused verification established the following bounded automated coverage:

1. All five cleanup targets have zero `@typescript-eslint/no-unsafe-type-assertion` diagnostics.
2. Authoritative App lint passed for all eleven changed paths with no errors. Formatting, spelling, React Compiler comparison, changed-path identity, and whole-diff hygiene also passed.
3. Seven focused Jest suites passed 113 tests, including 18 receipt-modal cases. Four supplemental card-feed cases passed, and receipt, feed, and video mutations produced attributable failures.
4. The video harness exercised the installed Expo web VideoView producer, React Native Web, BaseVideoPlayer, and PlaybackContextProvider. Eleven control groups passed, including HTMLVideoElement registration, empty and occupied attachment insertion, restoration, saved-position handling, constructor absence, simulated fullscreen stability, and narrow-to-wide donor re-registration. Fullscreen and media behavior and the resize trigger were simulated, not actual browser or native execution.
5. Fork CI run 34614239479 passed typecheck, lint, format, React Compiler, and Jest for signed head `9fdcae73c2eccc28cb70125efba3019a673f40e5` against base `4541881ce86bcac1185c2b8088e9fd4beb23be3c`.
6. The separate local focused TypeScript check did not pass. It found zero diagnostics in the eleven candidate paths but 26 imported ambient diagnostics: 24 missing `NodeJS.Timeout` declarations, one missing `buffer.WithImplicitCoercion`, and one missing `global`. The exact blocked check was approved as waived; the waiver skips the guarantee that the focused imported TypeScript graph typechecks without diagnostics under Node 26.5.0 and TypeScript 7.0.2.

For repeatable local manual validation in a development environment, follow the applicable platform-attributed steps in the `QA Steps` section below. No interactive platform session or console-error check was performed.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Offline behavior has not been manually tested. Before review, repeat the payment settlement and native receipt replacement flows below while offline and after reconnecting, verifying that no payment action silently proceeds with a missing account, receipt edits are not lost, pending upload state remains coherent, and the durable receipt reopens from the expected filesystem-backed URI after synchronization.

### QA Steps

Manual QA required. QA before review.

This mixed production/test diff changes runtime payment selection and missing-account fallback, feed iteration and filtering, country/state callbacks and ZIP lookup, receipt transformation and upload representation, plus shared video DOM capture, reparenting, restoration, fullscreen protection, and responsive donor re-registration across PlaybackContext consumers. The repaired web harness proves the actual installed Expo producer and four falsifying mutations, but it simulates fullscreen/media and the resize trigger; it does not establish actual browser/Safari/native playback, fullscreen, attachment handoff/restoration, or narrow/wide behavior. Seven passing suites and receipt/feed/video mutation evidence are bounded automated coverage and do not replace these consumer-visible manual checks.

1. On Desktop Chrome, open an expense report with an eligible business bank account and settle it through the payment dropdown. Verify the selected account, currency, payment method, and pay-as-business value reach the existing payment flow. Repeat with the previously selected account absent and verify the settlement button uses the existing setup/fallback path instead of submitting an undefined account.
2. On Desktop Chrome, open Settings > Profile > Personal details with a Canadian address using Ontario, then change the country to the United States. Verify the state control changes to the US selector and preserves a valid resolved US state only when applicable. Test a full state name, a same-country change, and a change away from the US, verifying that arbitrary non-US state/province text remains usable and stale US state data is cleared when the country changes.
3. In Personal details, validate ZIP/postal codes for the US, Canada, the UAE, an absent country, and an empty country. Verify lowercase or padded valid input is normalized for validation, invalid and blank values show the existing error, and country-specific examples appear only when supplied by the country data. Save valid changes and verify the draft survives navigation to the confirm-code screen; separately leave the page without entering that lifecycle and verify ordinary unmount cleanup still clears the draft.
4. On Desktop Chrome, open Settings > Workspaces > Company cards for workspaces with multiple feeds and assignments. Verify each visible feed remains associated with the correct domain and workspace, duplicate feeds are not introduced, empty feed keys remain excluded, stale cards remain filtered, assigned and unassigned cards remain correctly separated, and custom-export counts, pending/error selection, nicknames, and CSV visibility remain unchanged.
5. On Desktop Chrome and macOS Safari, open a report containing a video attachment, start playback, seek to a nonzero position, and open the attachment modal. Verify the same video element moves into both an empty and an already occupied attachment container, playback position is retained or restored if the move resets it to zero, closing the modal returns the same video to its original parent, and no duplicate player appears.
6. On Desktop Chrome and macOS Safari, enter and exit standard or WebKit fullscreen while the video is playing. Verify fullscreen does not unexpectedly move or restore the shared video. Resize from narrow to wide and back, reopen the attachment, and verify donor re-registration replaces stale references, playback controls remain connected to the current player, and the video restores to the correct parent.
7. On Android Native and iOS Native, repeat playback, seeking, attachment handoff, restoration, fullscreen entry/exit, and narrow/wide layout transitions where supported. Verify native View references remain accepted, playback and controls remain usable, saved position is preserved, and web-only DOM constructor checks do not block native behavior.
8. On Desktop Chrome, drag or drop a replacement receipt through the supported receipt-drop entry point and verify the modal displays the expected source and completes the existing replacement route. This flow was not executed by the focused tests and must be checked directly.
9. On Android Native and iOS Native, open an existing transaction receipt, rotate it counterclockwise, crop it, save it, leave the modal, and reopen it. Verify the durable edited image is displayed, rotation and crop geometry are correct, the upload uses the native image-manipulator representation without requiring a browser File, and filesystem adoption or its logged fallback preserves the usable URI. Repeat for draft, persisted, odometer start/end, and confirmation editing routes, and verify retry remains possible after a failed manipulation or upload.
10. Repeat the preceding native receipt flow once with filesystem adoption unavailable and once after temporarily removing network connectivity. Verify the logged fallback keeps the original manipulated URI usable, busy state clears after failure, retry succeeds after recovery, and no receipt is lost.

No screenshots, videos, all-platform run, High Traffic account run, console inspection, direct-deeplink run, affected-consumer manual run, or post-review retest has been performed.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

The issue and proposal are linked, the exact changed paths and automated evidence are documented, and clean scope, type-safety, and regression reviews support the code-pattern and review-guideline acknowledgements. Exact diff and review evidence support the comment acknowledgements, and the added receipt-modal test supports the unit-test acknowledgement. Conditional items that are inapplicable or not manually exercised remain unchecked because inapplicability does not prove testing; no Design label, cross-platform asset validation, or other unperformed action is claimed.

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

Not provided because the required platform-attributed manual QA has not yet been performed.

<!-- seatbelt-v2:create:e3be7ce0-8984-4f92-9d9a-f0b456a4f35c:s08-e3be7ce0-4541881-draft-create-1 -->