### PR TITLE
Fix Chase VBBA setup navigation

### DIFF
--- a/src/libs/actions/BankAccounts.ts
+++ b/src/libs/actions/BankAccounts.ts
@@ -443,7 +443,7 @@ function getOnyxDataForConnectingVBBAAndLastPaymentMethod(policyID?: string, las
 /**
  * Submit Bank Account step with Plaid data so php can perform some checks.
  */
-function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAccount: PlaidBankAccount, policyID: string | undefined) {
+function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAccount: PlaidBankAccount, policyID: string | undefined): boolean {
     const isChaseBank = selectedPlaidBankAccount.bankName?.toLowerCase() === CONST.BANK_NAMES.CHASE;
     if (bankAccountID === CONST.DEFAULT_NUMBER_ID && isChaseBank) {
         Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
@@ -457,7 +457,7 @@ function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAcc
             accountNumber: '',
             routingNumber: '',
         });
-        return;
+        return false;
     }
 
     const parameters: ConnectBankAccountParams = {
@@ -473,6 +473,7 @@ function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAcc
     };
 
     API.write(WRITE_COMMANDS.CONNECT_BANK_ACCOUNT_WITH_PLAID, parameters, getVBBADataForOnyx());
+    return true;
 }
 
 /**

--- a/src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx
+++ b/src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx
@@ -59,6 +59,7 @@ function BankInfo({onBackButtonPress, onSubmit, policyID}: BankInfoProps) {
     const bankAccountID = getBankAccountIDAsNumber(reimbursementAccount?.achData);
     const submit = (submitData: unknown) => {
         const data = submitData as ReimbursementAccountForm;
+        let shouldMarkSubmitting = false;
         if (setupType === CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL) {
             connectBankAccountManually(
                 bankAccountID,
@@ -73,6 +74,7 @@ function BankInfo({onBackButtonPress, onSubmit, policyID}: BankInfoProps) {
                 },
                 policyID,
             );
+            shouldMarkSubmitting = true;
         } else if (setupType === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID) {
             const previousPlaidAccountID = reimbursementAccount?.achData?.plaidAccountID;
             const newPlaidAccountID = data[BANK_INFO_STEP_KEYS.PLAID_ACCOUNT_ID];
@@ -80,7 +82,7 @@ function BankInfo({onBackButtonPress, onSubmit, policyID}: BankInfoProps) {
             if (plaidAccountIDChanged) {
                 deletePaymentBankAccount(bankAccountID, undefined);
             }
-            connectBankAccountWithPlaid(
+            shouldMarkSubmitting = connectBankAccountWithPlaid(
                 plaidAccountIDChanged ? CONST.DEFAULT_NUMBER_ID : bankAccountID,
                 {
                     [BANK_INFO_STEP_KEYS.ROUTING_NUMBER]: data[BANK_INFO_STEP_KEYS.ROUTING_NUMBER] ?? '',
@@ -94,7 +96,9 @@ function BankInfo({onBackButtonPress, onSubmit, policyID}: BankInfoProps) {
                 policyID,
             );
         }
-        markSubmitting();
+        if (shouldMarkSubmitting) {
+            markSubmitting();
+        }
     };
 
     const renderBankInfo = () => {

--- a/tests/actions/BankAccountsTest.ts
+++ b/tests/actions/BankAccountsTest.ts
@@ -73,7 +73,7 @@ describe('actions/BankAccounts', () => {
             } as Partial<ReimbursementAccountForm>);
 
             // When we connect with Plaid for Chase on a new account
-            connectBankAccountWithPlaid(CONST.DEFAULT_NUMBER_ID, getPlaidBankAccount(CONST.BANK_NAMES_USER_FRIENDLY[CONST.BANK_NAMES.CHASE]), POLICY_ID);
+            const shouldMarkSubmitting = connectBankAccountWithPlaid(CONST.DEFAULT_NUMBER_ID, getPlaidBankAccount(CONST.BANK_NAMES_USER_FRIENDLY[CONST.BANK_NAMES.CHASE]), POLICY_ID);
             await waitForBatchedUpdates();
 
             // Then we should not call the backend, and should move user to manual with cleared account/routing draft fields
@@ -89,6 +89,7 @@ describe('actions/BankAccounts', () => {
             expect(reimbursementAccountDraft?.plaidAccountID).toBe('plaidAccountID123');
             expect(reimbursementAccountDraft?.plaidAccessToken).toBe('plaidAccessToken123');
             expect(reimbursementAccountDraft?.mask).toBe('3333');
+            expect(shouldMarkSubmitting).toBe(false);
         });
 
         test('does not short-circuit Chase flow when bankAccountID is non-zero', () => {
@@ -97,10 +98,11 @@ describe('actions/BankAccounts', () => {
             const selectedPlaidBankAccount = getPlaidBankAccount(CONST.BANK_NAMES_USER_FRIENDLY[CONST.BANK_NAMES.CHASE]);
 
             // When we connect with Plaid
-            connectBankAccountWithPlaid(bankAccountID, selectedPlaidBankAccount, POLICY_ID);
+            const shouldMarkSubmitting = connectBankAccountWithPlaid(bankAccountID, selectedPlaidBankAccount, POLICY_ID);
             return waitForBatchedUpdates().then(() => {
                 // Then we should call the existing API command
                 TestHelper.expectAPICommandToHaveBeenCalled(WRITE_COMMANDS.CONNECT_BANK_ACCOUNT_WITH_PLAID, 1);
+                expect(shouldMarkSubmitting).toBe(true);
                 const call = TestHelper.getFetchMockCalls(WRITE_COMMANDS.CONNECT_BANK_ACCOUNT_WITH_PLAID).at(0);
                 if (!call) {
                     throw new Error('Expected ConnectBankAccountWithPlaid fetch call');


### PR DESCRIPTION
### Explanation of Change

When a new Chase account is selected through Plaid, the App intentionally skips the Plaid API request and changes the flow to manual entry because Plaid returns substitute account numbers for Chase. This change makes that action report whether it started a backend request, and only arms deferred step navigation when a request was actually started. The manual Chase flow can now render and collect the real account numbers instead of advancing to personal information with `bankAccountID` set to `0`.

### Fixed Issues

For https://github.com/Expensify/Expensify/issues/678213
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — this change only affects the submit callback for the local Chase-to-manual transition; offline API behavior is unchanged.

### QA Steps

1. Start a new USD business bank account setup in staging.
2. Connect a Chase account through Plaid and select an account.
3. Verify the flow remains on the bank-information step and displays the manual account and routing number form.
4. Enter the real account and routing numbers for the Chase account and continue through the setup.
5. Verify the flow advances to personal information only after the manual bank-account request is submitted successfully.
6. Repeat the flow with a non-Chase new account and an existing Chase account to verify their behavior is unchanged.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified that any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that these changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review this change.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If `main` was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
