### PR TITLE
Fix: Top bar buttons briefly disappear and educational tooltip re-animates on tab switch

### DIFF
--- a/src/components/Tooltip/EducationalTooltip/BaseEducationalTooltip.tsx
+++ b/src/components/Tooltip/EducationalTooltip/BaseEducationalTooltip.tsx
@@ -152,6 +152,9 @@ function BaseEducationalTooltip({
             return;
         }
         // When tooltip is used inside an animated view (e.g. popover), we need to wait for the animation to finish before measuring content.
+        if (hasDisplayedTooltipRef.current) {
+            return;
+        }
         const timerID = setTimeout(() => {
             show.current?.();
             // Mark the first display as done only once it has actually happened, so paths that re-measure

--- a/src/libs/Navigation/AppNavigator/FreezeWrapper/index.tsx
+++ b/src/libs/Navigation/AppNavigator/FreezeWrapper/index.tsx
@@ -3,8 +3,8 @@ import useOnyx from '@hooks/useOnyx';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 
-import {useNavigation, useRoute} from '@react-navigation/native';
-import React, {useEffect, useLayoutEffect, useState} from 'react';
+import {useNavigationState, useRoute} from '@react-navigation/native';
+import React, {useCallback, useLayoutEffect, useState} from 'react';
 import {Freeze} from 'react-freeze';
 
 import getIsScreenBlurred from './getIsScreenBlurred';
@@ -15,27 +15,27 @@ type FreezeWrapperProps = ChildrenProps & {
 };
 
 function FreezeWrapper({children, freezeWhenInTabBackground = true}: FreezeWrapperProps) {
-    const navigation = useNavigation();
     const currentRoute = useRoute();
     const [isAnyModalOpen] = useOnyx(ONYXKEYS.MODAL, {
         selector: (modal) => !!modal?.isVisible || !!modal?.willAlertModalBecomeVisible,
     });
 
-    const [isScreenBlurred, setIsScreenBlurred] = useState(false);
+    const isScreenBlurred = useNavigationState(
+        useCallback((state) => getIsScreenBlurred(state, currentRoute.key, {freezeWhenInTabBackground}), [currentRoute.key, freezeWhenInTabBackground]),
+    );
     const [freezed, setFreezed] = useState(false);
-
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('state', (e) => setIsScreenBlurred(getIsScreenBlurred(e.data.state, currentRoute.key, {freezeWhenInTabBackground})));
-        return () => unsubscribe();
-    }, [currentRoute.key, freezeWhenInTabBackground, navigation]);
 
     // Decouple the Suspense render task so it won't be interrupted by React's concurrent mode
     // and stuck in an infinite loop
     useLayoutEffect(() => {
-        if (isScreenBlurred && isAnyModalOpen) {
+        if (!isScreenBlurred) {
+            setFreezed(false);
             return;
         }
-        setFreezed(isScreenBlurred);
+        if (isAnyModalOpen) {
+            return;
+        }
+        setFreezed(true);
     }, [isAnyModalOpen, isScreenBlurred]);
 
     return <Freeze freeze={freezed}>{children}</Freeze>;


### PR DESCRIPTION
### Explanation of Change

1. **`FreezeWrapper` (`src/libs/Navigation/AppNavigator/FreezeWrapper/index.tsx`)**:
   - Replaces the passive `useEffect` event listener and `isScreenBlurred` React state with synchronous derivation via `useNavigationState`.
   - In `useLayoutEffect`, immediately unfreezes synchronously before paint (`setFreezed(false)`) when `!isScreenBlurred`. When blurred, preserves modal safety by freezing only when all modals are hidden.
   - This eliminates the 1-2 frame delay where newly active tabs mounted while suspended by `react-freeze`, preventing the top bar button from blinking out.

2. **`BaseEducationalTooltip` (`src/components/Tooltip/EducationalTooltip/BaseEducationalTooltip.tsx`)**:
   - Adds a guard in the initial layout `useEffect` (`if (hasDisplayedTooltipRef.current) return;`) so that once an educational tooltip has already been displayed once, refocusing on tab switch does not schedule a 500ms entrance timeout or re-run delayed animations.
   - The refocusing effect immediately invokes `renderTooltip()`, keeping tooltips smoothly visible across tab switches without delays or flickers.

### Fixed Issues
$ https://github.com/Expensify/App/issues/100814
PROPOSAL: https://github.com/Expensify/App/issues/100814#issuecomment-5638160667

### Tests

1. Sign in to New Expensify on web.
2. Navigate to a page displaying a top bar button with an educational tooltip (e.g., Concierge Anywhere / Account button).
3. Switch between bottom tabs (`Home`, `Inbox`, `Search/Spend`, `Workspaces`) repeatedly.
4. Verify that the top bar button stays continuously visible with 0 missing frames.
5. Verify that the educational tooltip remains anchored without blinking off and taking >1s to re-animate.
6. Open a modal (e.g., workspace settings or search filters) while on Inbox/Search and verify freeze behavior works as expected without infinite loops.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Disconnect network connectivity (offline mode).
2. Switch between cached bottom tabs.
3. Verify top bar buttons remain visible and responsive.

### QA Steps

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I included steps for local testing in the `Tests` section
- [x] I added steps for the expected offline behavior in the `Offline steps` section
- [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [x] I verified that no console errors appear
- [x] I followed proper code patterns
