### PR TITLE
Lower the Pusher activity and pong timeouts from the SDK defaults

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2799,6 +2799,8 @@ const CONST = {
     PUSHER: {
         PRIVATE_USER_CHANNEL_PREFIX: 'private-encrypted-user-accountID-',
         PRIVATE_REPORT_CHANNEL_PREFIX: 'private-report-reportID-',
+        ACTIVITY_TIMEOUT_MS: 30000,
+        PONG_TIMEOUT_MS: 20000,
         STATE: {
             CONNECTED: 'CONNECTED',
             DISCONNECTED: 'DISCONNECTED',

--- a/src/libs/Pusher/index.native.ts
+++ b/src/libs/Pusher/index.native.ts
@@ -71,6 +71,8 @@ function init(args: Args): Promise<void> {
         socket.init({
             apiKey: args.appKey,
             cluster: args.cluster,
+            activityTimeout: CONST.PUSHER.ACTIVITY_TIMEOUT_MS,
+            pongTimeout: CONST.PUSHER.PONG_TIMEOUT_MS,
             onConnectionStateChange: (currentState: string, previousState: string) => {
                 if (currentState === CONST.PUSHER.STATE.CONNECTED) {
                     socket?.getSocketId().then((id: string) => {

--- a/src/libs/Pusher/index.ts
+++ b/src/libs/Pusher/index.ts
@@ -1,6 +1,7 @@
 import Log from '@libs/Log';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
 
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 import type {Channel, ChannelAuthorizerGenerator, Options} from 'pusher-js/with-encryption';
@@ -86,6 +87,8 @@ function init(args: Args): Promise<void> {
 
         const options: Options = {
             cluster: args.cluster,
+            activityTimeout: CONST.PUSHER.ACTIVITY_TIMEOUT_MS,
+            pongTimeout: CONST.PUSHER.PONG_TIMEOUT_MS,
         };
 
         if (customAuthorizer) {


### PR DESCRIPTION
### Explanation of Change

Both Pusher liveness timeouts were left at the pusher-js defaults, so a socket that stopped delivering went unnoticed for up to 150 seconds; this sets them to 30s/20s on web and native, cutting that to about 50 seconds.

### Fixed Issues

$https://github.com/Expensify/App/issues/100986
PROPOSAL: N/A

### Tests

Detection time is not directly observable in the UI, so the check is that the SDK adopts the values and that a dead socket recovers inside the new window.

1. Sign in on web and open the console.
2. Run `window.pusher.connection.activityTimeout` and verify it is `30000`. Before this change it was `120000`.
3. Run `window.pusher.connection.options.pongTimeout` and verify it is `20000`. Before this change it was `30000`.
4. Kill the socket without closing it, so the SDK is not told: in DevTools, Network ? WS, select the Pusher connection, and throttle the network to Offline. The connection stays `connected` from the SDK's point of view.
5. Have another account send you a message. Verify it does not arrive.
6. Verify that within ~50 seconds the console logs `[PusherConnectionManager] state change` to `connecting`, then back to `connected`, and the missed message appears. Before this change this took up to ~150 seconds.
7. Send a message yourself and verify it posts normally, confirming the reconnect left a working socket.
8. Leave the tab open and idle for five minutes and verify there is no reconnect loop — `[PusherConnectionManager] state change` should not be firing repeatedly.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Turn off the network connection.
2. Verify the offline indicator appears as usual and the app does not attempt to reconnect Pusher in a tight loop.
3. Turn the network back on.
4. Verify Pusher reconnects, the offline indicator clears, and messages sent while offline are delivered.

Lowering these two values changes only how quickly a silent socket is detected. It does not change offline detection, which is driven by network reachability rather than by the socket.

### QA Steps

1. Sign in on each platform.
2. Have a second account send you a chat message and verify it arrives live, without a refresh.
3. Put the device on a network you can interrupt (for example a hotspot you can switch off). Switch the network off for about one minute, then back on, without backgrounding the app.
4. Verify that after the network returns, new messages from the second account arrive live and no refresh is needed.
5. Verify the app is not stuck showing stale data, and that the offline indicator behaved normally throughout.
6. Leave the app open and idle for five minutes and verify chats keep updating live.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

#### Still outstanding on the checklist above

The boxes left unchecked are not yet done, rather than not applicable:

- The platform runs, the screenshots, the console check and the high-traffic account test. The verification so far is at the SDK level: the values are adopted against the production Pusher app, confirmed with the repo's own app key (`activityTimeout` resolves to `30000` and `pongTimeout` to `20000`, versus `120000` and `30000` on the defaults). The `Tests` steps have not been walked on a device yet.
- Unit tests. A test here would assert that two constants are passed into a third-party `init` call, which tests the SDK rather than our behaviour. Happy to add one if a reviewer wants the regression guard.

The `Fixed Issues` link now points at Expensify/App#100986, the tracking issue for setting explicit, lower config values across Pusher's SDKs.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
