### PR TITLE
Auto-download an export that is already ready when the app loads

### DIFF
--- a/src/components/ExportDownloadStatusModal.tsx
+++ b/src/components/ExportDownloadStatusModal.tsx
@@ -97,6 +97,7 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
             return;
         }
         downloadFile();
+        onClose();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isReady, fileName, shouldSendFromConcierge, isEmptyReceipts]);
 

--- a/src/components/ExportDownloadStatusModal.tsx
+++ b/src/components/ExportDownloadStatusModal.tsx
@@ -24,7 +24,7 @@ import type {Session} from '@src/types/onyx';
 
 import type {OnyxEntry} from 'react-native-onyx';
 
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import {View} from 'react-native';
 
 import ActivityIndicator from './ActivityIndicator';
@@ -77,15 +77,6 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
     const isFailed = state === CONST.EXPORT_DOWNLOAD.STATE.FAILED;
     const isEmptyReceipts = isReady && exportType === CONST.EXPORT_DOWNLOAD.TYPE.RECEIPTS && receiptCount === 0;
 
-    const wasPreparingRef = useRef(false);
-    useEffect(() => {
-        if (state !== CONST.EXPORT_DOWNLOAD.STATE.PREPARING) {
-            return;
-        }
-
-        wasPreparingRef.current = true;
-    }, [state]);
-
     // Build the secure download URL the same way downloadReportPDF does, so the host always follows
     // the app's current environment (instead of the env baked into a backend-built URL) and authenticates
     // via the encryptedAuthToken, so no separate OldDot sign-in is needed.
@@ -102,7 +93,7 @@ function ExportDownloadStatusModal({exportID, isVisible, onClose, failedBody}: E
 
     useEffect(() => {
         // Only the leader tab auto-downloads, so a ready export isn't downloaded once per open tab.
-        if (!isReady || !fileName || shouldSendFromConcierge || isEmptyReceipts || !isClientTheLeader() || !wasPreparingRef.current) {
+        if (!isReady || !fileName || shouldSendFromConcierge || isEmptyReceipts || !isClientTheLeader()) {
             return;
         }
         downloadFile();


### PR DESCRIPTION
### Explanation of Change

A finished export only stays on your account when the file was never actually delivered to you, so when the app loads and finds one, it can just download the file instead of showing a button and waiting for you to press it.

### Fixed Issues

$
PROPOSAL: N/A

### Tests

The behaviour only differs on a page load that finds an export already marked ready, which is why the reload is the important step.

1. Sign in on web, run a Search, and export it — "All Data - expense level" is a good choice because it takes long enough to work with.
2. While the modal still says "Preparing download...", reload the page.
3. Wait for the export to finish. Verify the modal shows "Your file is ready!" and the file downloads on its own, without pressing "Download file". Before this change the download had to be triggered by hand.
4. Verify the modal closes on its own once the file is downloaded, and that reloading again does not show it or download the file a second time. Reload twice more and verify no further downloads — before the second commit in this PR the file re-downloaded on every load.
5. Start another export, let it finish in the same page load without reloading, and verify it still auto-downloads exactly once.
6. Open the app in two tabs, start an export in the first, and verify only one tab downloads the file.
7. Start an export, press "Send me the file when it's ready" while it is still preparing, and verify the modal switches to the Concierge message and no file is downloaded.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go offline and verify an export cannot be started, matching current behaviour.
2. Start an export while online, go offline before it finishes, then come back online.
3. Verify the modal reaches "Your file is ready!" and the file downloads once connectivity returns.

### QA Steps

1. Sign in on each platform and run a Search with enough expenses that the export takes several seconds.
2. Export it and, while the modal says "Preparing download...", reload or relaunch the app.
3. Verify that once the export finishes, the file downloads without having to press "Download file".
4. Verify the modal does not reappear after another reload.
5. Repeat without reloading and verify the file still downloads exactly once.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

#### Two corrections to an earlier version of this description

**The premise was false when first written, and the second commit fixes it.** `clearExportDownload` has exactly one call site outside `Export.ts` — `handleClose` in `ExportDownloadStatusManager.tsx:81`, reached only when the modal is dismissed. The automatic download path called `downloadFile()` and never `onClose()`, so a delivered export stayed in Onyx as `ready`. With `wasPreparingRef` gone, that record would have been downloaded again on every later load until the user dismissed the modal. `wasPreparingRef` had been accidentally bounding that to one download per page load.

The fix is to do what the manual button already does — download, then close — since closing is what clears the record. That makes the premise true rather than aspirational: a `ready` record present at load now means the file never reached the user.

**The dependency on https://github.com/Expensify/Expensify/issues/680500 was overstated.** I previously said this change would download the `ready` records that carry `shouldSendFromConcierge`. It cannot: the auto-download guard returns early on that flag, and `ExportDownloadStatusManager.tsx:37` refuses to surface those records at all. They are invisible to this code. #680500 is still needed for the users holding those records, but it is not a merge-ordering constraint for this PR.

This stays a draft because it has not been run on any platform yet, not because of that dependency.

The boxes left unchecked are not yet done rather than not applicable: the platform runs, the screenshots, the console check and the high-traffic account test. No unit test either — the behaviour depends on a record surviving a page load, which is awkward to assert meaningfully in the existing test setup, so I would rather add one if a reviewer sees a good shape for it.

The `Fixed Issues` link points at the internal tracking issue because there is no `Expensify/App` issue for this.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

</details>
