### PR TITLE
Fix: guard empty approvers on auto-injected default workflow (fixes #100266)

### DIFF
--- a/src/libs/WorkflowUtils.ts
+++ b/src/libs/WorkflowUtils.ts
@@ -284,9 +284,28 @@ function convertPolicyEmployeesToApprovalWorkflows({policy, personalDetails, fir
     // Add a default workflow if one doesn't exist (no employees submit to the default approver)
     const firstWorkflow = sortedApprovalWorkflows.at(0);
     if (firstWorkflow && !firstWorkflow.isDefault) {
+        let defaultApprovers = calculateApprovers({employees, firstEmail: defaultApprover, personalDetailsByEmail});
+        if (defaultApprovers.length === 0) {
+            // policy.approver / policy.owner are stored independently of employeeList and can
+            // reference an email that is no longer a current employee (e.g. removed through a
+            // different flow that didn't keep this field in sync). calculateApprovers then
+            // returns [], and an approvalWorkflows entry with an empty `approvers` array
+            // crashes convertApprovalWorkflowToPolicyEmployees the next time anything submits
+            // it, independent of any member removal. Mirror the fallback already used above
+            // for non-default workflows instead of leaving this one unguarded. See #100266.
+            defaultApprovers = [
+                {
+                    email: defaultApprover,
+                    forwardsTo: undefined,
+                    avatar: personalDetailsByEmail[defaultApprover]?.avatar,
+                    displayName: personalDetailsByEmail[defaultApprover]?.displayName ?? defaultApprover,
+                    isCircularReference: false,
+                },
+            ];
+        }
         sortedApprovalWorkflows.unshift({
             members: [],
-            approvers: calculateApprovers({employees, firstEmail: defaultApprover, personalDetailsByEmail}),
+            approvers: defaultApprovers,
             isDefault: true,
         });
     }

--- a/tests/unit/WorkflowUtilsTest.ts
+++ b/tests/unit/WorkflowUtilsTest.ts
@@ -843,6 +843,35 @@ describe('WorkflowUtils', () => {
             const unassignedMember = defaultWorkflow?.members.find((m) => m.email === 'unassigned@example.com');
             expect(unassignedMember).toBeDefined();
         });
+
+        it('Should fall back to a synthetic approver for the auto-injected default workflow when policy.approver is not a current employee (regression test for #100266)', () => {
+            // policy.approver/policy.owner are stored independently of employeeList and can go
+            // stale relative to it. When no employee submits directly to that stale approver,
+            // convertPolicyEmployeesToApprovalWorkflows auto-injects a default workflow via
+            // calculateApprovers({employees, firstEmail: defaultApprover, ...}) with no
+            // approvers.length === 0 fallback -- unlike the sibling branch above (used for
+            // non-default workflows) which already guards against exactly this case. The result
+            // was an approvalWorkflows entry with `approvers: []`, which crashes
+            // convertApprovalWorkflowToPolicyEmployees ("Approval workflow must have at least
+            // one approver") the next time anything submits it -- independent of whether any
+            // member removal ever happens. See #100266.
+            const employees: PolicyEmployeeList = {
+                '1@example.com': {
+                    email: '1@example.com',
+                    forwardsTo: undefined,
+                    submitsTo: '1@example.com',
+                },
+            };
+            // 'stale-approver@example.com' is not a key in `employees` -- e.g. a former
+            // approver removed through some other flow that didn't update policy.approver.
+            const policy = createMockPolicy(employees, 'stale-approver@example.com');
+
+            const {approvalWorkflows} = convertPolicyEmployeesToApprovalWorkflows({policy, personalDetails, localeCompare});
+
+            const defaultWorkflow = approvalWorkflows.find((workflow) => workflow.isDefault);
+            expect(defaultWorkflow).toBeDefined();
+            expect(defaultWorkflow?.approvers.length).toBeGreaterThan(0);
+        });
     });
 
     describe('mergeWorkflowMembersWithAvailableMembers', () => {


### PR DESCRIPTION
## Problem

#100266's own stated cause ("removing the last approver empties the approvers array") does not hold up against the current code — `updateWorkflowDataOnApproverRemoval` cannot produce an empty `approvers` array for the single-workflow/single-approver case the issue describes (traced by hand; this is also raised independently in the issue thread by @cretadn22).

The actual root cause is upstream, in `convertPolicyEmployeesToApprovalWorkflows`:

- `getDefaultApprover(policy)` (`PolicyUtils.ts`) returns `policy.approver || policy.owner`, a field stored independently of `policy.employeeList`. Nothing guarantees it still names a current employee.
- When it doesn't, `calculateApprovers({employees, firstEmail: defaultApprover, ...})` returns `[]` immediately (`employees[nextEmail]` is falsy, loop breaks on the first iteration).
- The auto-injected default workflow (`WorkflowUtils.ts`, "Add a default workflow if one doesn't exist") uses that result with **no empty-array fallback** — unlike the sibling branch ~70 lines above it, used for non-default workflows, which already guards against exactly this case (`if (approvers.length === 0) { approvers = [...] }`).
- The resulting `{approvers: [], isDefault: true}` workflow sits in `approvalWorkflows` from page load, independent of any removal. `updateWorkflowDataOnApproverRemoval` doesn't touch it (none of its branches match an empty-approvers default workflow), so it's submitted unchanged the next time anything triggers a workflow submission — removing an unrelated approver is simply the easiest way to trigger that submission, not the cause.

## Fix

Mirror the existing sibling fallback for the default-workflow branch: if `calculateApprovers` returns empty, fall back to a synthetic single approver using the (still-stale) default approver's email, exactly as already done for non-default workflows a few lines above.

## Verification

- ⚠️ **This was not run against this repo's own Jest suite.** `bun install` in my environment failed with a lockfile integrity error (`Integrity check failed for tarball: react-native-image-size`, `simply-deferred`) unrelated to this change, and I did not force past it. A maintainer with a working local environment should run `tests/unit/WorkflowUtilsTest.ts` before merging.
- The fix and regression test **were** verified by extracting the real logic (the exact `getDefaultApprover` → `calculateApprovers` → default-workflow-injection → `convertApprovalWorkflowToPolicyEmployees` chain) into an isolated Jest project outside this repo, where the crash reproduces with **zero approver removals** — a stale `policy.owner` alone is sufficient. Happy to share that isolated repro if useful for review.
- The added test in `tests/unit/WorkflowUtilsTest.ts` follows this file's existing `createMockPolicy`/`buildWorkflow` conventions.

This is a draft PR — opened to surface the traced root cause and a proposed fix for maintainer review, not asserting it's the only correct fix (an alternative would be guarding at the `convertApprovalWorkflowToPolicyEmployees` throw site itself, treating any empty-approvers workflow as one to remove rather than update — happy to go that direction instead if preferred).

$ #100266