### PR TITLE
[CP Staging] Revert "Gate workspace picker selection behind a Save button (a11y On Input, PR 11)"

### DIFF
--- a/src/hooks/useWorkspaceList.ts
+++ b/src/hooks/useWorkspaceList.ts
@@ -25,7 +25,6 @@ type UseWorkspaceListParams = {
     localeCompare: LocaleContextProps['localeCompare'];
     additionalFilter?: (policy: OnyxEntry<Policy>) => boolean;
     shouldSortSelectedToTop?: boolean;
-    policyIDsToSortToTop?: string[];
     includeArchivedPolicy?: boolean;
 };
 
@@ -38,7 +37,6 @@ function useWorkspaceList({
     localeCompare,
     additionalFilter,
     shouldSortSelectedToTop = true,
-    policyIDsToSortToTop,
     includeArchivedPolicy = false,
 }: UseWorkspaceListParams) {
     const icons = useMemoizedLazyExpensifyIcons(['FallbackWorkspaceAvatar']);
@@ -83,16 +81,11 @@ function useWorkspaceList({
         () =>
             tokenizedSearch(usersWorkspaces, searchTerm, (policy) => [policy.text]).sort((policy1, policy2) => {
                 if (shouldSortSelectedToTop) {
-                    return sortWorkspacesBySelected(
-                        {policyID: policy1.policyID, name: policy1.text},
-                        {policyID: policy2.policyID, name: policy2.text},
-                        policyIDsToSortToTop ?? selectedPolicyIDs,
-                        localeCompare,
-                    );
+                    return sortWorkspacesBySelected({policyID: policy1.policyID, name: policy1.text}, {policyID: policy2.policyID, name: policy2.text}, selectedPolicyIDs, localeCompare);
                 }
                 return localeCompare(policy1.text, policy2.text);
             }),
-        [searchTerm, usersWorkspaces, selectedPolicyIDs, policyIDsToSortToTop, localeCompare, shouldSortSelectedToTop],
+        [searchTerm, usersWorkspaces, selectedPolicyIDs, localeCompare, shouldSortSelectedToTop],
     );
 
     const sections = useMemo(() => {

--- a/src/pages/DynamicReportChangeWorkspacePage.tsx
+++ b/src/pages/DynamicReportChangeWorkspacePage.tsx
@@ -54,7 +54,7 @@ import type {DismissedProductTraining} from '@src/types/onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 
 import {isTrackIntentUserSelector} from '@selectors/Onboarding';
-import React, {useState} from 'react';
+import React from 'react';
 import {View} from 'react-native';
 
 import type {WithReportOrNotFoundProps} from './inbox/report/withReportOrNotFound';
@@ -119,9 +119,6 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
     const {currentSearchQueryJSON, currentSearchKey} = useSearchQueryContext();
     const {currentSearchResults} = useSearchResultsContext();
     const shouldCalculateTotals = useSearchShouldCalculateTotals(currentSearchKey, true);
-
-    const [draftPolicyID, setDraftPolicyID] = useState<string>();
-    const currentSelection = draftPolicyID ?? report.policyID;
 
     // The snapshot keeps the report row after a workspace change, and only the server can tell whether it still matches the query.
     const refreshSearch = () => {
@@ -224,8 +221,7 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
         policies,
         currentUserLogin: session?.email,
         shouldShowPendingDeletePolicy: false,
-        selectedPolicyIDs: currentSelection ? [currentSelection] : undefined,
-        policyIDsToSortToTop: report.policyID ? [report.policyID] : undefined,
+        selectedPolicyIDs: report.policyID ? [report.policyID] : undefined,
         searchTerm: debouncedSearchTerm,
         localeCompare,
         additionalFilter: (newPolicy) => {
@@ -245,13 +241,6 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
         headerMessage: shouldShowNoResultsFoundMessage ? translate('common.noResultsFound') : '',
     };
 
-    const confirmButtonOptions = {
-        showButton: true,
-        text: translate('common.save'),
-        onConfirm: () => selectPolicy(currentSelection),
-        isDisabled: !currentSelection || currentSelection === report.policyID,
-    };
-
     if (!isMoneyRequestReport(report) || isMoneyRequestReportPendingDeletion(report) || hasCommuterExclusionDistanceRequest) {
         return <NotFoundPage />;
     }
@@ -259,7 +248,7 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
     return (
         <ScreenWrapper
             testID="DynamicReportChangeWorkspacePage"
-            enableEdgeToEdgeBottomSafeAreaPadding
+            includeSafeAreaPaddingBottom
             shouldEnableMaxHeight
         >
             {({didScreenTransitionEnd}) => (
@@ -278,13 +267,11 @@ function DynamicReportChangeWorkspacePage({report}: DynamicReportChangeWorkspace
                         <SelectionList<WorkspaceListItemType>
                             ListItem={UserListItem}
                             data={data}
-                            onSelectRow={(option) => setDraftPolicyID(option.policyID)}
+                            onSelectRow={(option) => selectPolicy(option.policyID)}
                             textInputOptions={textInputOptions}
-                            confirmButtonOptions={confirmButtonOptions}
                             initiallyFocusedItemKey={report.policyID}
                             shouldShowLoadingPlaceholder={fetchStatus.status === 'loading' || !didScreenTransitionEnd}
                             disableMaintainingScrollPosition
-                            addBottomSafeAreaPadding
                         />
                     )}
                 </>

--- a/src/pages/SetDefaultWorkspacePage.tsx
+++ b/src/pages/SetDefaultWorkspacePage.tsx
@@ -27,7 +27,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
 
-import React, {useMemo, useState} from 'react';
+import React, {useMemo} from 'react';
 import {View} from 'react-native';
 
 type SetDefaultWorkspacePageProps = PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.SET_DEFAULT_WORKSPACE>;
@@ -45,8 +45,6 @@ function SetDefaultWorkspacePage({route}: SetDefaultWorkspacePageProps) {
 
     const shouldShowLoadingIndicator = isAppLoadPending && !isOffline;
     const session = useSession();
-
-    const [draftPolicyID, setDraftPolicyID] = useState<string>();
 
     const selectPolicy = (selectedPolicyID?: string) => {
         if (!selectedPolicyID) {
@@ -74,20 +72,11 @@ function SetDefaultWorkspacePage({route}: SetDefaultWorkspacePageProps) {
         policies,
         currentUserLogin: session?.email,
         shouldShowPendingDeletePolicy: false,
-        selectedPolicyIDs: draftPolicyID ? [draftPolicyID] : undefined,
-        // This page never pinned a workspace to the top, so don't start now that checking a row sets selectedPolicyIDs.
-        shouldSortSelectedToTop: false,
+        selectedPolicyIDs: undefined,
         searchTerm: debouncedSearchTerm,
         localeCompare,
         additionalFilter: (newPolicy) => isGroupPolicy(newPolicy),
     });
-
-    const confirmButtonOptions = {
-        showButton: true,
-        text: translate('common.save'),
-        onConfirm: () => selectPolicy(draftPolicyID),
-        isDisabled: !draftPolicyID,
-    };
 
     const textInputOptions = useMemo(
         () => ({
@@ -102,7 +91,7 @@ function SetDefaultWorkspacePage({route}: SetDefaultWorkspacePageProps) {
     return (
         <ScreenWrapper
             testID="SetDefaultWorkspacePage"
-            enableEdgeToEdgeBottomSafeAreaPadding
+            includeSafeAreaPaddingBottom
             shouldEnableMaxHeight
         >
             {({didScreenTransitionEnd}) => (
@@ -120,11 +109,9 @@ function SetDefaultWorkspacePage({route}: SetDefaultWorkspacePageProps) {
                             data={data}
                             ListItem={UserListItem}
                             textInputOptions={textInputOptions}
-                            onSelectRow={(option) => setDraftPolicyID(option.policyID)}
-                            confirmButtonOptions={confirmButtonOptions}
+                            onSelectRow={(option) => selectPolicy(option.policyID)}
                             shouldShowLoadingPlaceholder={fetchStatus.status === 'loading' || !didScreenTransitionEnd}
                             disableMaintainingScrollPosition
-                            addBottomSafeAreaPadding
                         />
                     )}
                 </>

--- a/src/pages/domain/Groups/BaseDomainGroupPreferredWorkspacePage.tsx
+++ b/src/pages/domain/Groups/BaseDomainGroupPreferredWorkspacePage.tsx
@@ -24,7 +24,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 import {createAdminPoliciesSelector} from '@selectors/Policy';
-import React, {useState} from 'react';
+import React from 'react';
 
 type WorkspaceListItem = {
     policyID: string;
@@ -37,14 +37,11 @@ type BaseDomainGroupPreferredWorkspacePageProps = {
     /** AccountID of the domain */
     domainAccountID: number;
 
-    /** The policy ID of the saved preferred workspace */
+    /** The policy ID of the currently selected preferred workspace */
     selectedPolicyID: string | undefined;
 
     /** Called with the policy ID of the workspace the user picked */
     onSelectWorkspace: (policyID: string) => void;
-
-    /** Whether a pick is staged behind a Save button, which WCAG 3.2.2 "On Input" requires when committing navigates away */
-    shouldConfirmSelection?: boolean;
 
     /** Called when the back button is pressed */
     onBackButtonPress: () => void;
@@ -63,7 +60,6 @@ function BaseDomainGroupPreferredWorkspacePage({
     domainAccountID,
     selectedPolicyID,
     onSelectWorkspace,
-    shouldConfirmSelection = false,
     onBackButtonPress,
     testID,
     shouldBeBlocked,
@@ -71,9 +67,6 @@ function BaseDomainGroupPreferredWorkspacePage({
 }: BaseDomainGroupPreferredWorkspacePageProps) {
     const styles = useThemeStyles();
     const {translate, localeCompare} = useLocalize();
-
-    const [draftPolicyID, setDraftPolicyID] = useState<string>();
-    const checkedPolicyID = draftPolicyID ?? selectedPolicyID;
 
     const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: createAdminPoliciesSelector(selectedPolicyID)});
 
@@ -88,7 +81,7 @@ function BaseDomainGroupPreferredWorkspacePage({
             policyID: policy.id,
             created: policy.created,
             keyForList: policy.id,
-            isSelected: checkedPolicyID === policy.id,
+            isSelected: selectedPolicyID === policy.id,
         });
     }
     workspaceOptions.sort((a, b) => localeCompare(a.created ?? '', b.created ?? ''));
@@ -101,20 +94,6 @@ function BaseDomainGroupPreferredWorkspacePage({
     // The search input is gated on the unfiltered list length so it doesn't disappear once a query narrows the results.
     const shouldShowSearchInput = workspaceOptions.length >= CONST.STANDARD_LIST_ITEM_LIMIT;
 
-    const confirmButtonOptions = shouldConfirmSelection
-        ? {
-              showButton: true,
-              text: translate('common.save'),
-              onConfirm: () => {
-                  if (!checkedPolicyID) {
-                      return;
-                  }
-                  onSelectWorkspace(checkedPolicyID);
-              },
-              isDisabled: checkedPolicyID === selectedPolicyID,
-          }
-        : undefined;
-
     return (
         <DomainNotFoundPageWrapper
             domainAccountID={domainAccountID}
@@ -124,7 +103,7 @@ function BaseDomainGroupPreferredWorkspacePage({
             <ScreenWrapper
                 shouldEnableMaxHeight
                 testID={testID}
-                enableEdgeToEdgeBottomSafeAreaPadding
+                includeSafeAreaPaddingBottom
             >
                 <HeaderWithBackButton
                     title={translate('domain.groups.preferredWorkspace')}
@@ -140,11 +119,9 @@ function BaseDomainGroupPreferredWorkspacePage({
                         onChangeText: setSearchTerm,
                         headerMessage: workspaceOptions.length > 0 && filteredWorkspaceOptions.length === 0 ? translate('common.noResultsFound') : '',
                     }}
-                    onSelectRow={(item: WorkspaceListItem) => (shouldConfirmSelection ? setDraftPolicyID(item.policyID) : onSelectWorkspace(item.policyID))}
-                    confirmButtonOptions={confirmButtonOptions}
+                    onSelectRow={(item: WorkspaceListItem) => onSelectWorkspace(item.policyID)}
                     initiallyFocusedItemKey={selectedPolicyID}
                     shouldUpdateFocusedIndex
-                    addBottomSafeAreaPadding
                 />
             </ScreenWrapper>
         </DomainNotFoundPageWrapper>

--- a/src/pages/domain/Groups/DomainGroupPreferredWorkspacePage.tsx
+++ b/src/pages/domain/Groups/DomainGroupPreferredWorkspacePage.tsx
@@ -38,7 +38,6 @@ function DomainGroupPreferredWorkspacePage({route}: DomainGroupPreferredWorkspac
                 onBackButtonPress: () => Navigation.goBack(ROUTES.DOMAIN_GROUPS.getRoute(domainAccountID)),
             }}
             onBackButtonPress={() => Navigation.goBack(ROUTES.DOMAIN_GROUP_DETAILS.getRoute(domainAccountID, groupID))}
-            shouldConfirmSelection
             onSelectWorkspace={(policyID: string) => {
                 if (!group) {
                     return;

--- a/tests/ui/DomainGroupPreferredWorkspacePageTest.tsx
+++ b/tests/ui/DomainGroupPreferredWorkspacePageTest.tsx
@@ -258,7 +258,7 @@ describe('Domain group preferred workspace pages', () => {
     });
 
     describe('DomainGroupPreferredWorkspacePage', () => {
-        it("preselects the group's current preferred workspace and stores the newly picked one via updateDomainSecurityGroup once Save is pressed", async () => {
+        it("preselects the group's current preferred workspace and stores the newly picked one via updateDomainSecurityGroup", async () => {
             // Given a domain admin with an existing security group whose preferred workspace is already set
             await setUpDomainAdminWithPolicies(3);
             await setUpSecurityGroup(GROUP_ID, {restrictedPrimaryPolicyID: 'policy01'});
@@ -273,16 +273,6 @@ describe('Domain group preferred workspace pages', () => {
 
             // When a different workspace row is pressed
             fireEvent.press(screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}policy02`));
-            await waitForBatchedUpdatesWithAct();
-
-            // Then the checkmark moves to the picked row, but nothing is written yet
-            expect(screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}policy02`).props.accessibilityState).toMatchObject({selected: true});
-            expect(screen.getByTestId(`${CONST.BASE_LIST_ITEM_TEST_ID}policy01`).props.accessibilityState).toMatchObject({selected: false});
-            const domainBeforeSave = await getOnyxValue(`${ONYXKEYS.COLLECTION.DOMAIN}${DOMAIN_ACCOUNT_ID}`);
-            expect(domainBeforeSave?.[`${CONST.DOMAIN.DOMAIN_SECURITY_GROUP_PREFIX}${GROUP_ID}`]).toMatchObject({restrictedPrimaryPolicyID: 'policy01'});
-
-            // When the Save button is pressed
-            fireEvent.press(screen.getByText('Save'));
             await waitForBatchedUpdatesWithAct();
 
             // Then the group's restrictedPrimaryPolicyID is updated in place, instead of a separate draft key


### PR DESCRIPTION
Reverts Expensify/App#99236

### Fixed issues

$ https://github.com/Expensify/App/issues/101013