### PR TITLE
[No QA] Fix failing NavigateTests on main after the Insights tab landed

### DIFF
--- a/tests/navigation/NavigateTests.tsx
+++ b/tests/navigation/NavigateTests.tsx
@@ -151,11 +151,12 @@ describe('Navigate', () => {
                             {
                                 name: NAVIGATORS.TAB_NAVIGATOR,
                                 state: {
-                                    index: 4,
+                                    index: 5,
                                     routes: [
                                         {name: SCREENS.HOME},
                                         {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
                                         {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+                                        {name: SCREENS.INSIGHTS},
                                         {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR},
                                         {
                                             name: NAVIGATORS.WORKSPACE_NAVIGATOR,
@@ -176,7 +177,7 @@ describe('Navigate', () => {
                 Navigation.navigate(ROUTES.WORKSPACE_MEMBERS.getRoute('workspace-a'), {shouldSkipInitialSplitNavigatorSidebar: true});
             });
 
-            const workspaceStateAfterNavigate = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(4)?.state;
+            const workspaceStateAfterNavigate = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(5)?.state;
             expect(workspaceStateAfterNavigate?.routes.at(0)?.name).toBe(SCREENS.WORKSPACES_LIST);
             expect(workspaceStateAfterNavigate?.routes.at(-1)?.name).toBe(NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR);
             const workspaceSplitState = workspaceStateAfterNavigate?.routes.at(-1)?.state;
@@ -188,7 +189,7 @@ describe('Navigate', () => {
                 Navigation.goBack();
             });
 
-            const workspaceStateAfterGoBack = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(4)?.state;
+            const workspaceStateAfterGoBack = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(5)?.state;
             expect(workspaceStateAfterGoBack?.routes.at(-1)?.name).toBe(SCREENS.WORKSPACES_LIST);
         });
 
@@ -201,11 +202,12 @@ describe('Navigate', () => {
                             {
                                 name: NAVIGATORS.TAB_NAVIGATOR,
                                 state: {
-                                    index: 4,
+                                    index: 5,
                                     routes: [
                                         {name: SCREENS.HOME},
                                         {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
                                         {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+                                        {name: SCREENS.INSIGHTS},
                                         {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR},
                                         {
                                             name: NAVIGATORS.WORKSPACE_NAVIGATOR,
@@ -242,7 +244,7 @@ describe('Navigate', () => {
             if (!rootState) {
                 throw new Error('Expected the navigation state to be initialized');
             }
-            const workspaceState = rootState.routes.at(0)?.state?.routes.at(4)?.state;
+            const workspaceState = rootState.routes.at(0)?.state?.routes.at(5)?.state;
             const workspaceSplitState = workspaceState?.routes.at(-1)?.state;
             expect(workspaceSplitState?.routes.at(-1)?.name).toBe(SCREENS.WORKSPACE.MEMBERS);
             expect(workspaceSplitState?.routes.at(-1)?.params).toEqual({policyID: 'workspace-a'});
@@ -252,7 +254,7 @@ describe('Navigate', () => {
                 Navigation.goBack();
             });
 
-            const workspaceStateAfterGoBack = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(4)?.state;
+            const workspaceStateAfterGoBack = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(5)?.state;
             expect(workspaceStateAfterGoBack?.routes.at(-1)?.state?.routes.at(-1)?.name).toBe(SCREENS.WORKSPACE.PROFILE);
         });
 
@@ -703,11 +705,12 @@ describe('Navigate', () => {
                             {
                                 name: NAVIGATORS.TAB_NAVIGATOR,
                                 state: {
-                                    index: 4,
+                                    index: 5,
                                     routes: [
                                         {name: SCREENS.HOME},
                                         {name: NAVIGATORS.REPORTS_SPLIT_NAVIGATOR},
                                         {name: NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR},
+                                        {name: SCREENS.INSIGHTS},
                                         {name: NAVIGATORS.SETTINGS_SPLIT_NAVIGATOR},
                                         {
                                             name: NAVIGATORS.WORKSPACE_NAVIGATOR,
@@ -728,7 +731,7 @@ describe('Navigate', () => {
                 Navigation.navigate(ROUTES.WORKSPACE_MEMBERS.getRoute('workspace-a'), {shouldSkipInitialSplitNavigatorSidebar: true});
             });
 
-            const workspaceState = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(4)?.state;
+            const workspaceState = navigationRef.current?.getRootState().routes.at(0)?.state?.routes.at(5)?.state;
             const workspaceSplitState = workspaceState?.routes.at(-1)?.state;
             expect(workspaceSplitState?.routes.at(0)?.name).toBe(SCREENS.WORKSPACE.INITIAL);
             expect(workspaceSplitState?.routes.at(0)?.params).toEqual({policyID: 'workspace-a'});


### PR DESCRIPTION
### Explanation of Change

Three tests in `tests/navigation/NavigateTests.tsx` fail on `main` and break the Jest job.

This is a semantic merge conflict between two PRs that each passed CI on their own:

- [[No QA][Insights] Set up the Insights tab in the tab bar](https://github.com/Expensify/App/pull/100800) added an `Insights` screen to `TestTabNavigator` and shifted every seeded tab route index by one.
- [Fix back navigation from Workspace Search results](https://github.com/Expensify/App/pull/100387) added three new tests that seed the tab navigator with the old five-route layout.

`TestTabNavigator` declares `Insights` between `Search_Fullscreen_Navigator` and `Settings_Split_Navigator`. React Navigation rehydrates the seeded state against that declaration, so it inserts the missing `Insights` route at position 3. That pushes `Workspace_Navigator` from index 4 to index 5. The three tests then read `routes.at(4)`, get the `Settings_Split_Navigator` route, and every assertion on its nested state returns `undefined`.

The fix adds `{name: SCREENS.INSIGHTS}` to the seeded state of the three tests, bumps the focused `index` from 4 to 5, and reads `routes.at(5)` for the Workspace navigator. This matches what the other eleven tests in the file already do. No production code changes.

Failing run: https://github.com/Expensify/App/actions/runs/34632498401/job/103372459817

### Fixed Issues

$
PROPOSAL:

### Tests

1. Check out this branch.
2. Run `npx jest tests/navigation/NavigateTests.tsx`.
3. Verify that all 14 tests pass.
4. Run `npx jest tests/navigation`.
5. Verify that all 50 suites and 582 tests pass.
6. Check out `main` and run `npx jest tests/navigation/NavigateTests.tsx`.
7. Verify that 3 tests fail, which confirms this branch fixes them.

### Offline tests

Not applicable. This PR only changes Jest test fixtures.

### QA Steps

Not applicable. This PR only changes Jest test fixtures and does not touch production code.

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Not applicable. This PR only changes Jest test fixtures.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Not applicable. This PR only changes Jest test fixtures.

</details>

<details>
<summary>iOS: Native</summary>

Not applicable. This PR only changes Jest test fixtures.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not applicable. This PR only changes Jest test fixtures.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Not applicable. This PR only changes Jest test fixtures.

</details>
