### PR TITLE
Keep newly created agents editable across browser tabs

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -818,7 +818,7 @@ const ONYXKEYS = {
     /** Persisted draft for the new-agent avatar selection flow */
     AGENT_NEW_AVATAR_DRAFT: 'agentNewAvatarDraft',
 
-    /** Maps an agent's optimistic accountID to the real one assigned by CreateAgent, consumed and cleared by replaceOptimisticAgentWithActualAgent */
+    /** Retains agent optimistic-to-real accountID mappings for queued actions, other tabs, and late-opened settings screens */
     OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING: 'optimisticAgentAccountIDMapping',
 
     /** Set when the rooms page has finished loading for the first time */

--- a/src/hooks/useAgentAccountID.ts
+++ b/src/hooks/useAgentAccountID.ts
@@ -1,0 +1,27 @@
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import {useEffect} from 'react';
+
+import useOnyx from './useOnyx';
+
+type AgentNavigation = {
+    setParams: (params: {accountID: number}) => void;
+};
+
+/** Follow the server-assigned ID even when this screen opens after the navigation redirect. */
+function useAgentAccountID(accountID: number, navigation: AgentNavigation) {
+    const [mappedAccountID, metadata] = useOnyx(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING, {selector: (mapping) => mapping?.[accountID]});
+    const resolvedAccountID = mappedAccountID && Number.isSafeInteger(mappedAccountID) && mappedAccountID > 0 ? mappedAccountID : accountID;
+
+    useEffect(() => {
+        if (resolvedAccountID === accountID) {
+            return;
+        }
+        // Keep this route aligned with child screens so their Back/Save fallback finds the existing parent.
+        navigation.setParams({accountID: resolvedAccountID});
+    }, [accountID, navigation, resolvedAccountID]);
+
+    return [resolvedAccountID, metadata] as const;
+}
+
+export default useAgentAccountID;

--- a/src/libs/AgentAccountIDMapping.ts
+++ b/src/libs/AgentAccountIDMapping.ts
@@ -1,7 +1,7 @@
 /**
- * In-memory record of the {optimisticAccountID: realAccountID} agent mappings consumed this session. The Onyx
- * mapping entry is cleared once consumed, so this is the only way a late caller (e.g. an agent settings screen
- * opened before the redirect) can still translate an optimistic accountID.
+ * In-memory record of the {optimisticAccountID: realAccountID} agent mappings received this session. Middleware
+ * registers mappings before the request queue drains so actions can resolve IDs before the Onyx update is flushed.
+ * Persisted mappings are also registered when the replacement listener starts.
  *
  * Own module because the middleware also registers mappings and cannot import the lazy-loaded
  * replaceOptimisticAgentWithActualAgent without pulling navigation into the startup path.

--- a/src/libs/actions/replaceOptimisticAgentWithActualAgent.ts
+++ b/src/libs/actions/replaceOptimisticAgentWithActualAgent.ts
@@ -18,8 +18,8 @@ import Onyx from 'react-native-onyx';
  *
  * Like replaceOptimisticReportWithActualReport, this module listens to that mapping. For each entry it redirects
  * any open agent settings screen to the real accountID, remaps the agent DM participants, clears the optimistic
- * data, and clears the consumed entry. The cleanup lives here instead of createAgent()'s successData so it always
- * runs after the redirect.
+ * data. The mapping stays in Onyx so other tabs and screens opened later can still resolve the optimistic ID.
+ * The cleanup lives here instead of createAgent()'s successData so it runs after this tab's redirect.
  *
  * Nothing is migrated onto the real keys: the mapping is only flushed to Onyx after the queue has drained, so any
  * pending state still on the optimistic keys is stale by then. The ReplaceOptimisticAgentAccountID middleware
@@ -27,6 +27,9 @@ import Onyx from 'react-native-onyx';
  */
 
 const AGENT_SETTINGS_SCREENS = new Set<string>([SCREENS.SETTINGS.AGENTS.EDIT, SCREENS.SETTINGS.AGENTS.EDIT_NAME, SCREENS.SETTINGS.AGENTS.EDIT_PROMPT, SCREENS.SETTINGS.AGENTS.EDIT_AVATAR]);
+
+// Retained mappings are delivered again when another agent is created. Schedule each replacement only once per tab.
+const processedAccountIDs = new Map<number, number>();
 
 // Reports are only read inside the mapping callback, so connectWithoutView() is used. On app start the mapping can
 // arrive before this collection is hydrated, so consumers wait for this promise. Onyx always fires the callback at
@@ -104,9 +107,14 @@ function replaceOptimisticAgentWithActualAgent(optimisticAccountID: number, real
     // pending. This is the only path that runs for a persisted mapping consumed on app start.
     registerAgentAccountIDMapping(optimisticAccountID, realAccountID);
 
+    if (processedAccountIDs.get(optimisticAccountID) === realAccountID) {
+        return;
+    }
+    processedAccountIDs.set(optimisticAccountID, realAccountID);
+
     // Neither navigation nor the report collection is guaranteed to be ready when a persisted mapping is consumed
-    // on app start. The optimistic data is cleared in the same callback so an open agent screen can never be left
-    // pointing at a deleted key.
+    // on app start. Edit screens also subscribe to the retained mapping because another tab can clear the
+    // optimistic data before this tab's navigation is ready.
     Promise.all([reportsHydrationPromise, Navigation.isNavigationReady()]).then(() => {
         TransitionTracker.runAfterTransitions({
             callback: () => {
@@ -119,14 +127,15 @@ function replaceOptimisticAgentWithActualAgent(optimisticAccountID: number, real
 
                 Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {[optimisticAccountID]: null});
                 Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`, null);
-                Onyx.merge(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING, {[optimisticAccountID]: null});
+                // Cross-tab Onyx notifications carry keys, not values. Deleting the mapping here lets another
+                // tab read only the final empty value and permanently lose the replacement ID.
             },
         });
     });
 }
 
-// No UI subscribes to the mapping, so connectWithoutView() is used. Firing with the persisted value on app start
-// also consumes any entry left over from a previous session.
+// This callback performs navigation and cleanup independently of UI subscribers. The persisted value also
+// restores action ID resolution and repairs any optimistic routes on app start.
 Onyx.connectWithoutView({
     key: ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING,
     callback: (mapping) => {
@@ -135,7 +144,7 @@ Onyx.connectWithoutView({
         }
 
         for (const [optimisticAccountID, mappedAccountID] of Object.entries(mapping)) {
-            // Already-consumed (nullish) entries are skipped. Clearing them again would just fire this callback once more.
+            // Removed invalid entries are skipped. Clearing them again would just fire this callback once more.
             const realAccountID: unknown = mappedAccountID;
             if (realAccountID === null || realAccountID === undefined) {
                 continue;

--- a/src/pages/settings/Agents/EditAgentPage.tsx
+++ b/src/pages/settings/Agents/EditAgentPage.tsx
@@ -9,6 +9,7 @@ import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 
+import useAgentAccountID from '@hooks/useAgentAccountID';
 import useChatWithAgent from '@hooks/useChatWithAgent';
 import useConfirmModal from '@hooks/useConfirmModal';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
@@ -37,11 +38,11 @@ import {View} from 'react-native';
 
 type EditAgentPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.AGENTS.EDIT>;
 
-function EditAgentPage({route}: EditAgentPageProps) {
+function EditAgentPage({route, navigation}: EditAgentPageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const icons = useMemoizedLazyExpensifyIcons(['Trashcan', 'ChatBubble', 'Users']);
-    const accountID = route.params.accountID;
+    const [accountID, accountIDMetadata] = useAgentAccountID(route.params.accountID, navigation);
     const [agent, agentMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${accountID}`);
     const [personalDetails, personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: (list) => list?.[accountID]});
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
@@ -49,7 +50,7 @@ function EditAgentPage({route}: EditAgentPageProps) {
     const showRuleBotGuardModal = useRuleBotGuardModal();
     const chatWithAgent = useChatWithAgent();
     const switchToDelegator = useSwitchToDelegator();
-    const isOnyxLoaded = agentMetadata.status === 'loaded' && personalDetailsMetadata.status === 'loaded';
+    const isOnyxLoaded = accountIDMetadata.status === 'loaded' && agentMetadata.status === 'loaded' && personalDetailsMetadata.status === 'loaded';
     const shouldShowNotFoundPage = isOnyxLoaded && !agent && !personalDetails;
 
     const agentLogin = personalDetails?.login ?? '';

--- a/src/pages/settings/Agents/Fields/EditAgentAvatarPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditAgentAvatarPage.tsx
@@ -9,6 +9,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 
+import useAgentAccountID from '@hooks/useAgentAccountID';
 import useAvatarCrop from '@hooks/useAvatarCrop';
 import useDiscardChangesConfirmation from '@hooks/useDiscardChangesConfirmation';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
@@ -232,8 +233,8 @@ function EditAgentAvatarContent({accountID, fallbackRoute, onSave, initialPreset
 
 EditAgentAvatarContent.displayName = 'EditAgentAvatarContent';
 
-function EditAgentAvatarPage({route}: EditAgentAvatarPageProps) {
-    const {accountID} = route.params;
+function EditAgentAvatarPage({route, navigation}: EditAgentAvatarPageProps) {
+    const [accountID] = useAgentAccountID(route.params.accountID, navigation);
     return (
         <EditAgentAvatarContent
             accountID={accountID}

--- a/src/pages/settings/Agents/Fields/EditNamePage.tsx
+++ b/src/pages/settings/Agents/Fields/EditNamePage.tsx
@@ -5,6 +5,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import TextInput from '@components/TextInput';
 
+import useAgentAccountID from '@hooks/useAgentAccountID';
 import useAutoFocusInput from '@hooks/useAutoFocusInput';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
@@ -25,10 +26,10 @@ import React from 'react';
 
 type EditNamePageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.AGENTS.EDIT_NAME>;
 
-function EditNamePage({route}: EditNamePageProps) {
+function EditNamePage({route, navigation}: EditNamePageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
-    const accountID = route.params.accountID;
+    const [accountID] = useAgentAccountID(route.params.accountID, navigation);
     const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {selector: (list) => list?.[accountID]});
 
     const {inputCallbackRef} = useAutoFocusInput();

--- a/src/pages/settings/Agents/Fields/EditPromptPage.tsx
+++ b/src/pages/settings/Agents/Fields/EditPromptPage.tsx
@@ -7,6 +7,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
 
+import useAgentAccountID from '@hooks/useAgentAccountID';
 import useIsInLandscapeMode from '@hooks/useIsInLandscapeMode';
 import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
 import useKeyboardState from '@hooks/useKeyboardState';
@@ -34,14 +35,14 @@ import {Platform, View} from 'react-native';
 
 type EditPromptPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.AGENTS.EDIT_PROMPT>;
 
-function EditPromptPage({route}: EditPromptPageProps) {
+function EditPromptPage({route, navigation}: EditPromptPageProps) {
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {isKeyboardActive} = useKeyboardState();
     const isInLandscapeMode = useIsInLandscapeMode();
     const shouldShrinkPromptInput = isInLandscapeMode && isKeyboardActive;
-    const accountID = route.params.accountID;
+    const [accountID] = useAgentAccountID(route.params.accountID, navigation);
     const [agentPrompt] = useOnyx(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${accountID}`);
     const formRef = useRef<FormRef>(null);
     const promptTopOffsetRef = useRef(0);

--- a/tests/actions/ReplaceOptimisticAgentWithActualAgentTest.ts
+++ b/tests/actions/ReplaceOptimisticAgentWithActualAgentTest.ts
@@ -210,14 +210,14 @@ describe('replaceOptimisticAgentWithActualAgent', () => {
         await Onyx.merge(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING, {[optimisticAccountID]: realAccountID});
         await waitForBatchedUpdates();
 
-        // Then the real agent keeps exactly the server's data, the optimistic copies are gone and the entry is cleared
+        // Then the real agent keeps exactly the server's data, the optimistic copies are gone and the mapping remains available to other tabs
         const personalDetails = await getOnyxValue(ONYXKEYS.PERSONAL_DETAILS_LIST);
         expect(personalDetails?.[realAccountID]).toStrictEqual(realPersonalDetail);
         expect(personalDetails?.[optimisticAccountID]).toBeUndefined();
         expect(await getOnyxValue(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${realAccountID}`)).toStrictEqual(realAgentPrompt);
         expect(await getOnyxValue(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`)).toBeUndefined();
         const mapping = await getOnyxValue(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING);
-        expect(mapping?.[optimisticAccountID]).toBeUndefined();
+        expect(mapping?.[optimisticAccountID]).toBe(realAccountID);
     });
 
     it('does not resurrect an agent that was deleted while its CreateAgent was in flight', async () => {
@@ -314,12 +314,12 @@ describe('replaceOptimisticAgentWithActualAgent', () => {
         navigationReady.resolve();
         await waitForBatchedUpdates();
 
-        // Then the screen is redirected and only then is the optimistic data and the mapping entry cleared
+        // Then the screen is redirected and only the optimistic data is cleared
         expect(mockSetParams).toHaveBeenCalledTimes(1);
         expect(mockSetParams).toHaveBeenCalledWith({accountID: realAccountID}, 'agents-edit-route-key', 'agent-settings-stack-key');
         expect((await getOnyxValue(ONYXKEYS.PERSONAL_DETAILS_LIST))?.[optimisticAccountID]).toBeUndefined();
         expect(await getOnyxValue(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`)).toBeUndefined();
-        expect((await getOnyxValue(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING))?.[optimisticAccountID]).toBeUndefined();
+        expect((await getOnyxValue(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING))?.[optimisticAccountID]).toBe(realAccountID);
     });
 
     it('resolveAgentAccountID returns the input unchanged for an accountID with no consumed mapping', () => {
@@ -338,15 +338,24 @@ describe('replaceOptimisticAgentWithActualAgent', () => {
         expect(resolveAgentAccountID(optimisticAccountID)).toBe(realAccountID);
     });
 
-    it('clears the mapping entry once it has been processed', async () => {
+    it('keeps the mapping available to a tab that reads storage after the optimistic data has been removed', async () => {
         const optimisticAccountID = 2837465910283746;
         const realAccountID = 6058172439605817;
 
+        await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+            [optimisticAccountID]: {accountID: optimisticAccountID, displayName: 'Pending agent', isOptimisticPersonalDetail: true},
+            [realAccountID]: {accountID: realAccountID, displayName: 'Created agent'},
+        });
+        await Onyx.set(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`, {prompt: 'Test instructions'});
         await Onyx.merge(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING, {[optimisticAccountID]: realAccountID});
         await waitForBatchedUpdates();
 
+        // Cross-tab Onyx notifications carry keys, then read their latest stored values. A receiving tab can
+        // therefore read only after the first tab has completed cleanup, without seeing the intermediate mapping.
+        expect((await getOnyxValue(ONYXKEYS.PERSONAL_DETAILS_LIST))?.[optimisticAccountID]).toBeUndefined();
+        expect(await getOnyxValue(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`)).toBeUndefined();
         const mapping = await getOnyxValue(ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING);
-        expect(mapping?.[optimisticAccountID]).toBeUndefined();
+        expect(mapping?.[optimisticAccountID]).toBe(realAccountID);
     });
 
     it('leaves the real agent untouched and only clears the entry when the mapping maps an accountID to itself', async () => {
@@ -445,7 +454,7 @@ describe('replaceOptimisticAgentWithActualAgent', () => {
             await waitForBatchedUpdates();
 
             // Then the screen is redirected, the DM participants are repaired against the hydrated report collection,
-            // and the optimistic data and the mapping entry are cleared
+            // and the optimistic data is cleared while the mapping remains available to other tabs
             expect(mockSetParams).toHaveBeenCalledWith({accountID: realAccountID}, 'agents-edit-route-key', 'agent-settings-stack-key');
             const report = await getColdStartOnyxValue(`${coldStartOnyxKeys.COLLECTION.REPORT}${reportID}`);
             expect(report?.participants).toStrictEqual({
@@ -454,7 +463,7 @@ describe('replaceOptimisticAgentWithActualAgent', () => {
             });
             expect((await getColdStartOnyxValue(coldStartOnyxKeys.PERSONAL_DETAILS_LIST))?.[optimisticAccountID]).toBeUndefined();
             expect(await getColdStartOnyxValue(`${coldStartOnyxKeys.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`)).toBeUndefined();
-            expect((await getColdStartOnyxValue(coldStartOnyxKeys.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING))?.[optimisticAccountID]).toBeUndefined();
+            expect((await getColdStartOnyxValue(coldStartOnyxKeys.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING))?.[optimisticAccountID]).toBe(realAccountID);
         });
     });
 });

--- a/tests/unit/pages/settings/EditAgentPageTest.tsx
+++ b/tests/unit/pages/settings/EditAgentPageTest.tsx
@@ -1,4 +1,4 @@
-import {render} from '@testing-library/react-native';
+import {act, render} from '@testing-library/react-native';
 
 import useOnyx from '@hooks/useOnyx';
 import type useStyleUtils from '@hooks/useStyleUtils';
@@ -12,8 +12,10 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
 
 import React from 'react';
+import Onyx from 'react-native-onyx';
 
 import createMock from '../../../utils/createMock';
+import waitForBatchedUpdates from '../../../utils/waitForBatchedUpdates';
 
 type ParsableStyle = Parameters<ReturnType<typeof useStyleUtils>['parseStyleFromFunction']>[0];
 
@@ -160,7 +162,7 @@ type EditAgentPageRoute = PlatformStackScreenProps<SettingsNavigatorParamList, t
 type EditAgentPageNavigation = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.AGENTS.EDIT>['navigation'];
 
 const mockRoute = createMock<EditAgentPageRoute>({params: {accountID: TEST_ACCOUNT_ID}});
-const mockNavigation = createMock<EditAgentPageNavigation>({});
+const mockNavigation = createMock<EditAgentPageNavigation>({setParams: jest.fn()});
 
 describe('EditAgentPage', () => {
     beforeEach(() => {
@@ -285,5 +287,83 @@ describe('EditAgentPage', () => {
         );
 
         expect(JSON.stringify(toJSON())).not.toContain('notFound.notHere');
+    });
+
+    describe('optimistic accountID replacement', () => {
+        beforeAll(() => {
+            Onyx.init({keys: ONYXKEYS});
+        });
+
+        beforeEach(async () => {
+            await Onyx.clear();
+            await waitForBatchedUpdates();
+            mockUseOnyx.mockImplementation(jest.requireActual<{default: typeof useOnyx}>('@hooks/useOnyx').default);
+        });
+
+        it('keeps an already-open Edit page usable when another tab replaces its optimistic agent', async () => {
+            const optimisticAccountID = 5728193046572819;
+            const realAccountID = 12346;
+            const route = createMock<EditAgentPageRoute>({params: {accountID: optimisticAccountID}});
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+                [optimisticAccountID]: {accountID: optimisticAccountID, displayName: 'Pending agent', isOptimisticPersonalDetail: true},
+            });
+            await Onyx.set(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`, {prompt: 'Pending instructions'});
+
+            const {toJSON} = render(
+                <EditAgentPage
+                    route={route}
+                    navigation={mockNavigation}
+                />,
+            );
+            await act(async () => waitForBatchedUpdates());
+            expect(JSON.stringify(toJSON())).toContain('Pending agent');
+
+            // This tab's route has not been redirected. It receives the latest shared state after the tab
+            // processing CreateAgent has written the real data and removed the optimistic copies.
+            await act(async () => {
+                await Onyx.multiSet({
+                    [ONYXKEYS.PERSONAL_DETAILS_LIST]: {[realAccountID]: {accountID: realAccountID, displayName: 'Created agent'}},
+                    [`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${realAccountID}`]: {prompt: 'Created instructions'},
+                    [`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${optimisticAccountID}`]: null,
+                    [ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING]: {[optimisticAccountID]: realAccountID},
+                });
+                await waitForBatchedUpdates();
+            });
+
+            expect(route.params.accountID).toBe(optimisticAccountID);
+            expect(mockNavigation.setParams).toHaveBeenCalledWith({accountID: realAccountID});
+            expect(JSON.stringify(toJSON())).toContain('Created agent');
+            expect(JSON.stringify(toJSON())).toContain('Created instructions');
+            expect(JSON.stringify(toJSON())).not.toContain('notFound.notHere');
+
+            // Retaining an ID mapping must not hide a genuinely deleted agent or resurrect its old data.
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {[realAccountID]: null});
+                await Onyx.set(`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${realAccountID}`, null);
+                await waitForBatchedUpdates();
+            });
+            expect(JSON.stringify(toJSON())).toContain('notFound.notHere');
+        });
+
+        it('opens an optimistic route after creation has already completed', async () => {
+            const optimisticAccountID = 6849302751684930;
+            const realAccountID = 12347;
+            await Onyx.multiSet({
+                [ONYXKEYS.PERSONAL_DETAILS_LIST]: {[realAccountID]: {accountID: realAccountID, displayName: 'Already created agent'}},
+                [`${ONYXKEYS.COLLECTION.SHARED_NVP_AGENT_PROMPT}${realAccountID}`]: {prompt: 'Already created instructions'},
+                [ONYXKEYS.OPTIMISTIC_AGENT_ACCOUNT_ID_MAPPING]: {[optimisticAccountID]: realAccountID},
+            });
+            const {toJSON} = render(
+                <EditAgentPage
+                    route={createMock<EditAgentPageRoute>({params: {accountID: optimisticAccountID}})}
+                    navigation={mockNavigation}
+                />,
+            );
+            await act(async () => waitForBatchedUpdates());
+            expect(mockNavigation.setParams).toHaveBeenCalledWith({accountID: realAccountID});
+            expect(JSON.stringify(toJSON())).toContain('Already created agent');
+            expect(JSON.stringify(toJSON())).toContain('Already created instructions');
+            expect(JSON.stringify(toJSON())).not.toContain('notFound.notHere');
+        });
     });
 });


### PR DESCRIPTION
### Explanation of Change

Keep a newly created agent's Edit page working when another browser tab completes creation. Retain the temporary-to-real ID mapping, use it in the agent editing screens, and update their routes so Save and Back return to the correct agent. Deleted agents still show the not-found page.

### Fixed Issues

$ https://github.com/Expensify/App/issues/100865
PROPOSAL: https://github.com/Expensify/App/issues/100865#issuecomment-5681975844

### Tests

Automated validation passed on `42e5fcaf7f5`: targeted formatting, ESLint, React Compiler, full TypeScript, and 4 Jest suites (110 tests). [Remote run](https://github.com/KJ21-ENG/App/actions/runs/35132311659).

Manual validation on this draft's final commit is pending. Planned steps:

- [ ] Verify that no errors appear in the JS console

1. Sign in and open Account > Agents in two browser tabs, opening the second tab last. In the first tab, create an agent, close its automatic chat, and immediately open the new agent from the list.
2. Verify Edit Agent remains visible while creation finishes, then shows the saved name, instructions, and avatar. Repeat with a second agent and in a single tab.
3. During creation, open Name, Instructions, or Avatar. Save an edit or use Back. Verify the values update and navigation returns to the same Edit Agent screen. Repeat for all three fields.
4. Save the temporary Edit Agent URL while creation is pending. After creation finishes, reopen that URL and reload it. Verify it opens the saved agent.
5. Delete the agent, then reopen its saved temporary URL. Verify the not-found page appears rather than showing old agent details.

### Offline tests

1. In the first tab, disconnect the network, create an agent, and open its Edit page. Edit its name or instructions while the creation is pending.
2. Reconnect with the second tab open. Verify the agent and queued edits finish saving, its Edit page remains usable, and reopening it shows the saved values.
3. With a previously created agent loaded, disconnect again. Verify Name, Instructions, and Avatar still open and Back returns correctly. Reconnect and verify any saved edit is retained.

### QA Steps

- [ ] Verify that no errors appear in the JS console

1. On staging, open Account > Agents in two browser tabs on the same account, opening the second tab last. Create an agent in the first tab, close its automatic chat, and immediately open the new agent.
2. Verify Edit Agent remains visible as creation finishes. Repeat with a second agent and with one tab.
3. Repeat while opening Name, Instructions, or Avatar before creation finishes. Verify Save and Back return to the same agent and saved changes appear.
4. Create an agent offline in the first tab, edit its name or instructions, and reconnect while the second tab is open. Verify the agent and edits save without a not-found page.
5. Reopen and reload a temporary Edit Agent URL saved during creation. Verify it opens the completed agent. Delete that agent and verify the old URL now shows not-found.
6. On native platforms, repeat the single-session create/edit, offline/reconnect, and Save/Back cases.

### PR Author Checklist

<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
